### PR TITLE
cisco-nxos-provider: add `interface` implementation

### DIFF
--- a/internal/provider/cisco/nxos/iface/l2config.go
+++ b/internal/provider/cisco/nxos/iface/l2config.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"errors"
+)
+
+type L2Option func(*L2Config) error
+
+type SwitchPortMode uint
+
+const (
+	SwitchPortModeAccess SwitchPortMode = iota + 1
+	SwitchPortModeTrunk
+)
+
+type SpanningTreeMode uint
+
+const (
+	SpanningTreeModeUnset SpanningTreeMode = iota
+	SpanningTreeModeEdge
+	SpanningTreeModeNetwork
+	SpanningTreeModeTrunk
+)
+
+type L2Config struct {
+	spanningTree SpanningTreeMode
+	switchPort   SwitchPortMode
+	accessVlan   *uint16
+	nativeVlan   *uint16
+	allowedVlans []uint16
+}
+
+func NewL2Config(opts ...L2Option) (*L2Config, error) {
+	l2cfg := &L2Config{}
+	for _, opt := range opts {
+		if err := opt(l2cfg); err != nil {
+			return nil, err
+		}
+	}
+	return l2cfg, nil
+}
+
+func WithSpanningTree(mode SpanningTreeMode) L2Option {
+	return func(c *L2Config) error {
+		switch mode {
+		case SpanningTreeModeUnset, SpanningTreeModeEdge, SpanningTreeModeNetwork, SpanningTreeModeTrunk:
+			c.spanningTree = mode
+			return nil
+		default:
+			return errors.New("invalid spanning tree mode")
+		}
+	}
+}
+
+func WithSwithPortMode(mode SwitchPortMode) L2Option {
+	return func(c *L2Config) error {
+		switch mode {
+		case SwitchPortModeAccess, SwitchPortModeTrunk:
+			c.switchPort = mode
+			return nil
+		default:
+			return errors.New("invalid switch port mode")
+		}
+	}
+}
+
+func WithAccessVlan(vlan uint16) L2Option {
+	return func(c *L2Config) error {
+		if c.switchPort != SwitchPortModeAccess {
+			return errors.New("access VLAN can only be set for access switch port mode")
+		}
+		if vlan < 1 || vlan > 4094 {
+			return errors.New("access VLAN must be between 1 and 4094")
+		}
+		c.accessVlan = &vlan
+		return nil
+	}
+}
+
+func WithNativeVlan(vlan uint16) L2Option {
+	return func(c *L2Config) error {
+		if c.switchPort != SwitchPortModeTrunk {
+			return errors.New("native VLAN can only be set for trunk switch port mode")
+		}
+		if vlan < 1 || vlan > 4094 {
+			return errors.New("native VLAN must be between 1 and 4094")
+		}
+		c.nativeVlan = &vlan
+		return nil
+	}
+}
+
+func WithAllowedVlans(vlans []uint16) L2Option {
+	return func(c *L2Config) error {
+		if len(vlans) == 0 {
+			return errors.New("number of allowed VLAN should be greater than zero")
+		}
+		if c.switchPort != SwitchPortModeTrunk {
+			return errors.New("allowed VLANs can only be set for trunk switch port mode")
+		}
+		for _, vlan := range vlans {
+			if vlan < 1 || vlan > 4094 {
+				return errors.New("allowed VLANs must be between 1 and 4094")
+			}
+		}
+		c.allowedVlans = vlans
+		return nil
+	}
+}

--- a/internal/provider/cisco/nxos/iface/l2config_test.go
+++ b/internal/provider/cisco/nxos/iface/l2config_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package iface
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestL2Config_AccessModeOptions(t *testing.T) {
+	// valid vlan
+	l2, err := NewL2Config(
+		WithSwithPortMode(SwitchPortModeAccess),
+		WithAccessVlan(100),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error while creating L2 config: %v", err)
+	}
+	if l2.accessVlan == nil || *l2.accessVlan != 100 {
+		t.Errorf("expected accessVlan to be 100, got %v", l2.accessVlan)
+	}
+
+	// invalid VLAN
+	l2, err = NewL2Config(WithSwithPortMode(SwitchPortModeAccess))
+	if err != nil {
+		t.Fatalf("unexpected error while creating L2 config: %v", err)
+	}
+	err = WithAccessVlan(0)(l2)
+	if err == nil {
+		t.Error("expected error for VLAN < 1")
+	}
+	err = WithAccessVlan(4095)(l2)
+	if err == nil {
+		t.Error("expected error for VLAN > 4094")
+	}
+
+	// use of trunk mode options in access mode
+	_, err = NewL2Config(
+		WithSwithPortMode(SwitchPortModeAccess),
+		WithNativeVlan(200),
+		WithAllowedVlans([]uint16{10, 20, 30}),
+	)
+	if err == nil {
+		t.Fatalf("misconfig error not triggered wile using trunk options")
+	}
+}
+
+func TestL2Config_TrunkModeOptions(t *testing.T) {
+	// trunk mode with NativeVlan and AllowedVlans
+	t.Run("Valid trunk mode with configured native and allowed vlans", func(t *testing.T) {
+		l2, err := NewL2Config(
+			WithSwithPortMode(SwitchPortModeTrunk),
+			WithNativeVlan(200),
+			WithAllowedVlans([]uint16{10, 20, 30}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error while creating L2 config: %v", err)
+		}
+
+		if l2.nativeVlan == nil || *l2.nativeVlan != 200 {
+			t.Errorf("expected nativeVlan to be 200, got %v", l2.nativeVlan)
+		}
+		expected := []uint16{10, 20, 30}
+		if !reflect.DeepEqual(l2.allowedVlans, expected) {
+			t.Errorf("expected allowedVlans to be %v, got %v", expected, l2.allowedVlans)
+		}
+	})
+	t.Run("Valid trunk mode with invalid vlan configuration", func(t *testing.T) {
+		_, err := NewL2Config(
+			WithSwithPortMode(SwitchPortModeTrunk),
+			WithNativeVlan(0),
+			WithAllowedVlans([]uint16{0, 4095}),
+		)
+		if err == nil {
+			t.Fatal("error not triggered for invalid VLANs")
+		}
+	})
+	t.Run("Invalid config: use of access mode options in trunk mode", func(t *testing.T) {
+		_, err := NewL2Config(
+			WithSwithPortMode(SwitchPortModeTrunk),
+			WithAccessVlan(100),
+		)
+		if err == nil {
+			t.Fatalf("misconfig error not triggered wile using edge mode options in trunk mode")
+		}
+	})
+}
+
+func TestWithSpanningTree_InvalidMode(t *testing.T) {
+	_, err := NewL2Config(WithSpanningTree(SpanningTreeMode(99)))
+	if err == nil {
+		t.Error("expected error for invalid spanning tree mode, got nil")
+	}
+}
+
+func TestWithSwitchPortMode_InvalidMode(t *testing.T) {
+	_, err := NewL2Config(WithSwithPortMode(SwitchPortMode(99)))
+	if err == nil {
+		t.Error("expected error for invalid switch port mode, got nil")
+	}
+}

--- a/internal/provider/cisco/nxos/iface/l3config.go
+++ b/internal/provider/cisco/nxos/iface/l3config.go
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+type L3Option func(*L3Config) error
+
+type L3MediumType int
+
+const (
+	L3MediumTypeUnset L3MediumType = iota
+	L3MediumTypeBroadcast
+	L3MediumTypeP2P
+)
+
+type L3IPAddressingModeType int
+
+const (
+	AddressingModeNumbered L3IPAddressingModeType = iota + 1
+	AddressingModeUnnumbered
+)
+
+type ISISConfig struct {
+	Name     string // e.g., "UNDERLAY"
+	V4Enable bool
+	V6Enable bool
+}
+
+type L3Config struct {
+	medium             L3MediumType
+	addressingMode     L3IPAddressingModeType
+	unnumberedLoopback string // used with unnumbered addressing: name of the loopback interface name we borrow the IP from
+	prefixesIPv4       []netip.Prefix
+	prefixesIPv6       []netip.Prefix
+	isisCfg            *ISISConfig
+	pimSparseMode      bool
+}
+
+func NewL3Config(opts ...L3Option) (*L3Config, error) {
+	cfg := &L3Config{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
+
+func WithSparseModePIM() L3Option {
+	return func(c *L3Config) error {
+		c.pimSparseMode = true
+		return nil
+	}
+}
+
+// WithISIS configures the ISIS routing protocol for the interface.
+// This is a no-op if a process with such name does not exist.
+func WithISIS(name string, v4Enable, v6Enable bool) L3Option {
+	return func(c *L3Config) error {
+		c.isisCfg = &ISISConfig{
+			Name:     name,
+			V4Enable: v4Enable,
+			V6Enable: v6Enable,
+		}
+		return nil
+	}
+}
+
+// WithUnnumberedAddressing sets the interface to use unnumbered addressing, borrowing the IP from the specified loopback interface.
+// If the interface where this config is applied is not configured to be in the medium P2P, an error is returned.
+func WithUnnumberedAddressing(interfaceName string) L3Option {
+	return func(c *L3Config) error {
+		loName, err := getLoopbackShortName(interfaceName)
+		if err != nil {
+			return fmt.Errorf("not a valid loopback interface name %s", interfaceName)
+		}
+		if c.medium != L3MediumTypeP2P {
+			return errors.New("interface must use P2P medium type for unnumbered addressing")
+		}
+		c.addressingMode = AddressingModeUnnumbered
+		c.unnumberedLoopback = loName
+		c.prefixesIPv4 = nil
+		c.prefixesIPv6 = nil
+		return nil
+	}
+}
+
+// WithNumberedAddressingIPv4 sets the interface to use numbered addressing with the provided IPv4 addresses.
+// Returns an error if the addresses are empty, invalid or overlap.
+func WithNumberedAddressingIPv4(v4prefixes []string) L3Option {
+	return func(c *L3Config) error {
+		if len(v4prefixes) == 0 {
+			return errors.New("at least one IPv4 prefix must be provided for numbered addressing")
+		}
+		var parsed []netip.Prefix
+		for _, prefixStr := range v4prefixes {
+			prefix, err := netip.ParsePrefix(prefixStr)
+			if err != nil || !prefix.Addr().Is4() {
+				return fmt.Errorf("invalid IPv4 prefix %s: %w", prefixStr, err)
+			}
+			parsed = append(parsed, prefix)
+		}
+		for i := range parsed {
+			for j := i + 1; j < len(parsed); j++ {
+				if parsed[i].Overlaps(parsed[j]) {
+					return fmt.Errorf("overlapping IPv4 prefixes: %s and %s", parsed[i], parsed[j])
+				}
+			}
+		}
+		c.addressingMode = AddressingModeNumbered
+		c.prefixesIPv4 = parsed
+		c.unnumberedLoopback = ""
+		return nil
+	}
+}
+
+// WithNumberedAddressingIPv6 sets the interface to use numbered addressing with the provided IPv6 addresses.
+// Returns an error if any of the prefixes are empty, invalid or overlap.
+func WithNumberedAddressingIPv6(v6prefixes []string) L3Option {
+	return func(c *L3Config) error {
+		if len(v6prefixes) == 0 {
+			return errors.New("at least one IPv4 prefix must be provided for numbered addressing")
+		}
+		var parsed []netip.Prefix
+		for _, prefixStr := range v6prefixes {
+			prefix, err := netip.ParsePrefix(prefixStr)
+			if err != nil || !prefix.Addr().Is6() {
+				return fmt.Errorf("invalid IPv6 prefix %s: %w", prefixStr, err)
+			}
+			parsed = append(parsed, prefix)
+		}
+		for i := range parsed {
+			for j := i + 1; j < len(parsed); j++ {
+				if parsed[i].Overlaps(parsed[j]) {
+					return fmt.Errorf("overlapping IPv6 prefixes: %s and %s", parsed[i], parsed[j])
+				}
+			}
+		}
+		c.addressingMode = AddressingModeNumbered
+		c.prefixesIPv6 = parsed
+		c.unnumberedLoopback = ""
+		return nil
+	}
+}
+
+// WithMedium sets the L3 medium type for the interface.
+func WithMedium(medium L3MediumType) L3Option {
+	return func(i *L3Config) error {
+		switch medium {
+		case L3MediumTypeUnset, L3MediumTypeBroadcast, L3MediumTypeP2P:
+			i.medium = medium
+			return nil
+		default:
+			return fmt.Errorf("invalid L3 medium type: %v", medium)
+		}
+	}
+}
+
+func (c *L3Config) ToYGOT(interfaceName, vrfName string) ([]gnmiext.Update, error) {
+	updates := []gnmiext.Update{}
+	if c.pimSparseMode {
+		updates = append(updates, c.createPIM(interfaceName, vrfName))
+	}
+	switch c.addressingMode {
+	case AddressingModeUnnumbered:
+		updates = append(updates, c.createAddressingUnnumbered(interfaceName, vrfName))
+	case AddressingModeNumbered:
+		if len(c.prefixesIPv4) > 0 {
+			updates = append(updates, c.createAddressingIP4(interfaceName, vrfName))
+		}
+		if len(c.prefixesIPv6) > 0 {
+			updates = append(updates, c.createAddressingIP6(interfaceName, vrfName))
+		}
+	}
+	if c.isisCfg != nil {
+		isisUpdate, err := c.createISIS(interfaceName, vrfName)
+		if err != nil {
+			return nil, fmt.Errorf("L3: fail to create ygot objects for ISIS config %w ", err)
+		}
+		if isisUpdate != nil {
+			updates = append(updates, isisUpdate)
+		}
+	}
+	return updates, nil
+}
+
+// createPIM configures PIM in sparse mode for the interface
+func (c *L3Config) createPIM(interfaceName, vrfName string) gnmiext.Update {
+	return gnmiext.ReplacingUpdate{
+		XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + vrfName + "]/if-items/If-list[id=" + interfaceName + "]",
+		Value: &nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList{
+			AdminSt:       nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+			PimSparseMode: ygot.Bool(true),
+		},
+	}
+}
+
+func (c *L3Config) createAddressingUnnumbered(interfaceName, vrfName string) gnmiext.Update {
+	iface := &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{}
+	iface.Unnumbered = ygot.String(c.unnumberedLoopback)
+	return gnmiext.ReplacingUpdate{
+		XPath: "System/ipv4-items/inst-items/dom-items/Dom-list[name=" + vrfName + "]/if-items/If-list[id=" + interfaceName + "]",
+		Value: iface,
+	}
+}
+
+// createAddressingIP4 returns updates to configure l3 addressing on the interface (IPv4).
+func (c *L3Config) createAddressingIP4(interfaceName, vrfName string) gnmiext.Update {
+	iface := &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{}
+	for _, addr := range c.prefixesIPv4 {
+		iface.GetOrCreateAddrItems().GetOrCreateAddrList(addr.String())
+	}
+	return gnmiext.ReplacingUpdate{
+		XPath: "System/ipv4-items/inst-items/dom-items/Dom-list[name=" + vrfName + "]/if-items/If-list[id=" + interfaceName + "]",
+		Value: iface,
+	}
+}
+
+// createAddressingIP6 returns updates to configure l3 addressing on the interface (IPv6).
+func (c *L3Config) createAddressingIP6(interfaceName, vrfName string) gnmiext.Update {
+	iface := &nxos.Cisco_NX_OSDevice_System_Ipv6Items_InstItems_DomItems_DomList_IfItems_IfList{}
+	for _, addr := range c.prefixesIPv6 {
+		iface.GetOrCreateAddrItems().GetOrCreateAddrList(addr.String())
+	}
+	return gnmiext.ReplacingUpdate{
+		XPath: "System/ipv6-items/inst-items/dom-items/Dom-list[name=" + vrfName + "]/if-items/If-list[id=" + interfaceName + "]",
+		Value: iface,
+	}
+}
+
+func (c *L3Config) createISIS(interfaceName, vrfName string) (gnmiext.Update, error) {
+	if c.isisCfg == nil {
+		return nil, nil
+	}
+	if c.isisCfg.Name == "" {
+		return nil, errors.New("isis config name is not set")
+	}
+	return gnmiext.ReplacingUpdate{
+		XPath: "System/isis-items/if-items/InternalIf-list[id=" + interfaceName + "]",
+		Value: &nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList{
+			Dom:            ygot.String(vrfName),
+			Instance:       ygot.String(c.isisCfg.Name),
+			NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on,
+			V4Enable:       ygot.Bool(c.isisCfg.V4Enable),
+			V6Enable:       ygot.Bool(c.isisCfg.V6Enable),
+		},
+	}, nil
+}

--- a/internal/provider/cisco/nxos/iface/l3config_test.go
+++ b/internal/provider/cisco/nxos/iface/l3config_test.go
@@ -1,0 +1,442 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"math"
+	"net/netip"
+	"reflect"
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+func mustParsePrefixes(t *testing.T, ss []string) []netip.Prefix {
+	t.Helper()
+	var out []netip.Prefix
+	for _, s := range ss {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			t.Fatalf("failed to parse prefix %q: %v", s, err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestL3Config_ConflictingAddressingModes(t *testing.T) {
+	t.Run("Unnumbered after Numbered", func(t *testing.T) {
+		c, err := NewL3Config(
+			WithMedium(L3MediumTypeP2P),
+			WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+			WithMedium(L3MediumTypeP2P),
+			WithUnnumberedAddressing("lo0"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.addressingMode != AddressingModeUnnumbered {
+			t.Errorf("expected AddressingModeUnnumbered, got %v", c.addressingMode)
+		}
+		if c.unnumberedLoopback != "lo0" {
+			t.Errorf("expected addressesInterface to be 'lo0', got %s", c.unnumberedLoopback)
+		}
+		if len(c.prefixesIPv4) != 0 {
+			t.Errorf("expected no IPv4 addresses, got %v", c.prefixesIPv4)
+		}
+		if len(c.prefixesIPv6) != 0 {
+			t.Errorf("expected no IPv6 addresses, got %v", c.prefixesIPv6)
+		}
+	})
+	t.Run("Numbered after Unnumbered", func(t *testing.T) {
+		c, err := NewL3Config(
+			WithMedium(L3MediumTypeP2P),
+			WithUnnumberedAddressing("lo0"),
+			WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.addressingMode != AddressingModeNumbered {
+			t.Errorf("expected AddressingModeNumbered, got %v", c.addressingMode)
+		}
+		if c.unnumberedLoopback != "" {
+			t.Errorf("expected no addressesInterface, got %s", c.unnumberedLoopback)
+		}
+		if len(c.prefixesIPv4) != 1 || c.prefixesIPv4[0].String() != "10.0.0.1/24" {
+			t.Errorf("expected IPv4 addresses to be 10.0.1/24, got %v", c.prefixesIPv4)
+		}
+		if len(c.prefixesIPv6) != 0 {
+			t.Errorf("expected no IPv6 addresses, got %v", c.prefixesIPv6)
+		}
+	})
+}
+
+func TestWithNumberedAddressing_IPv4(t *testing.T) {
+	cfg, err := NewL3Config(WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "10.0.1.1/24"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Run("TestWithNumberedAddressing_IPv4_config_valid", func(t *testing.T) {
+		if cfg.addressingMode != AddressingModeNumbered {
+			t.Errorf("expected AddressingModeNumbered, got %v", cfg.addressingMode)
+		}
+		expected := mustParsePrefixes(t, []string{"10.0.0.1/24", "10.0.1.1/24"})
+		if !reflect.DeepEqual(cfg.prefixesIPv4, expected) {
+			t.Errorf("expected addresses %v, got %v", expected, cfg.prefixesIPv4)
+		}
+	})
+	t.Run("TestWithNumberedAddressing_IPv4_config_invalid", func(t *testing.T) {
+		_, err = NewL3Config(WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "266.266.266.266/24"}))
+		if err == nil {
+			t.Error("expected error for invalid IPv4 address, got nil")
+		}
+	})
+}
+
+func TestL3Config_EmptyAddressList(t *testing.T) {
+	t.Run("WithNumberedAddressingIPv4_empty", func(t *testing.T) {
+		_, err := NewL3Config(WithNumberedAddressingIPv4([]string{}))
+		if err == nil {
+			t.Error("expected error for empty IPv4 address list, got nil")
+		}
+	})
+	t.Run("WithNumberedAddressingIPv6_empty", func(t *testing.T) {
+		_, err := NewL3Config(WithNumberedAddressingIPv6([]string{}))
+		if err == nil {
+			t.Error("expected error for empty IPv6 address list, got nil")
+		}
+	})
+}
+
+func TestL3Config_OverlapAddresses(t *testing.T) {
+	t.Run("WithNumberedAddressingIPv4_duplicates", func(t *testing.T) {
+		_, err := NewL3Config(WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "10.0.0.1/24"}))
+		if err == nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("WithNumberedAddressingIPv4_overlap", func(t *testing.T) {
+		_, err := NewL3Config(WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "10.0.0.1/8"}))
+		if err == nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("WithNumberedAddressingIPv6_duplicates", func(t *testing.T) {
+		_, err := NewL3Config(WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "2001:db8::1/64"}))
+		if err == nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("WithNumberedAddressingIPv6_overlap", func(t *testing.T) {
+		_, err := NewL3Config(WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "2001:db8::2/32"}))
+		if err == nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestWithNumberedAddressing_IPv6(t *testing.T) {
+	cfg, err := NewL3Config(WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "2002:db8::1/64"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Run("TestWithNumberedAddressing_IPv6_config_valid", func(t *testing.T) {
+		if cfg.addressingMode != AddressingModeNumbered {
+			t.Errorf("expected AddressingModeNumbered, got %v", cfg.addressingMode)
+		}
+		expected := mustParsePrefixes(t, []string{"2001:db8::1/64", "2002:db8::1/64"})
+		if !reflect.DeepEqual(cfg.prefixesIPv6, expected) {
+			t.Errorf("expected addresses %v, got %v", expected, cfg.prefixesIPv6)
+		}
+	})
+	t.Run("TestWithNumberedAddressing_IPv6_config_invalid", func(t *testing.T) {
+		_, err = NewL3Config(WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "zzzz:db8::1/64"}))
+		if err == nil {
+			t.Error("expected error for invalid IPv6 address, got nil")
+		}
+	})
+}
+
+func TestWithNumberedAddressing_IPv4AndIPv6(t *testing.T) {
+	cfg, err := NewL3Config(
+		WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "10.0.1.1/24"}),
+		WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "2002:db8::1/64"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Run("TestWithNumberedAddressing_IPv4AndIPv6_config", func(t *testing.T) {
+		expectedV4 := mustParsePrefixes(t, []string{"10.0.0.1/24", "10.0.1.1/24"})
+		expectedV6 := mustParsePrefixes(t, []string{"2001:db8::1/64", "2002:db8::1/64"})
+		if !reflect.DeepEqual(cfg.prefixesIPv4, expectedV4) {
+			t.Errorf("expected IPv4 addresses %v, got %v", expectedV4, cfg.prefixesIPv4)
+		}
+		if !reflect.DeepEqual(cfg.prefixesIPv6, expectedV6) {
+			t.Errorf("expected IPv6 addresses %v, got %v", expectedV6, cfg.prefixesIPv6)
+		}
+		if cfg.addressingMode != AddressingModeNumbered {
+			t.Errorf("expected AddressingModeNumbered, got %v", cfg.addressingMode)
+		}
+		if cfg.unnumberedLoopback != "" {
+			t.Error("expected no interface for numbered addressing, got", cfg.unnumberedLoopback)
+		}
+	})
+
+	t.Run("TestWithNumberedAddressing_IPv4AndIPv6_updates", func(t *testing.T) {
+		updates, err := cfg.ToYGOT("eth1/1", "default")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		foundAllV4, foundAllV6 := math.MaxInt32, math.MaxInt32
+		for _, u := range updates {
+			if ru, ok := u.(gnmiext.ReplacingUpdate); ok {
+				if ifList, ok := ru.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList); ok {
+					// check we have the correct number of IPv4 addresses
+					addrItems := ifList.GetAddrItems()
+					if addrItems == nil || len(addrItems.AddrList) != len(cfg.prefixesIPv4) {
+						t.Errorf("expected %d IPv4 address, got %d", len(cfg.prefixesIPv4), len(addrItems.AddrList))
+					}
+					foundAllV4 = len(addrItems.AddrList)
+					// check if the expected IPv4 address is present
+					for _, prefix := range cfg.prefixesIPv4 {
+						if ifList.GetAddrItems().GetAddrList(prefix.String()) != nil {
+							foundAllV4--
+						}
+					}
+				}
+				if ifList, ok := ru.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv6Items_InstItems_DomItems_DomList_IfItems_IfList); ok {
+					// check we have the correct number of IPv6 addresses
+					addrItems := ifList.GetAddrItems()
+					if addrItems == nil || len(addrItems.AddrList) != len(cfg.prefixesIPv6) {
+						t.Errorf("expected 1 IPv6 address, got %d", len(addrItems.AddrList))
+					}
+					foundAllV6 = len(addrItems.AddrList)
+					for _, prefix := range cfg.prefixesIPv6 {
+						if ifList.GetAddrItems().GetAddrList(prefix.String()) != nil {
+							foundAllV6--
+						}
+					}
+				}
+			}
+			if foundAllV4 == 0 && foundAllV6 == 0 {
+				break
+			}
+		}
+		if foundAllV4 != 0 {
+			t.Error("expected IPv4 address to be present in updates")
+		}
+		if foundAllV6 != 0 {
+			t.Error("expected IPv6 address to be present in updates")
+		}
+	})
+}
+
+func TestWithUnnumberedAddressing(t *testing.T) {
+	t.Run("Interface in P2P medium, valid loopback", func(t *testing.T) {
+		cfg, err := NewL3Config(
+			WithMedium(L3MediumTypeP2P),
+			WithUnnumberedAddressing("lo0"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.addressingMode != AddressingModeUnnumbered {
+			t.Errorf("expected AddressingModeUnnumbered, got %v", cfg.addressingMode)
+		}
+		expected := "lo0"
+		if !reflect.DeepEqual(cfg.unnumberedLoopback, expected) {
+			t.Errorf("expected addresses %v, got %v", expected, cfg.unnumberedLoopback)
+		}
+		if cfg.prefixesIPv4 != nil || cfg.prefixesIPv6 != nil {
+			t.Error("expected no addresses set for unnumbered addressing")
+		}
+	})
+	t.Run("Invalid Loopback Interface", func(t *testing.T) {
+		_, err := NewL3Config(WithUnnumberedAddressing("eth1/1"))
+		if err == nil {
+			t.Error("expected error for invalid loopback interface name, got nil")
+		}
+	})
+	t.Run("Interface not in P2P medium", func(t *testing.T) {
+		_, err := NewL3Config(
+			WithUnnumberedAddressing("lo0"),
+		)
+		if err == nil {
+			t.Error("expected error for unnumbered addressing on non-P2P medium, got nil")
+		}
+	})
+}
+
+func TestWithMedium(t *testing.T) {
+	t.Run("Valid Medium Type", func(t *testing.T) {
+		cfg, err := NewL3Config(WithMedium(L3MediumTypeP2P))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.medium != L3MediumTypeP2P {
+			t.Errorf("expected Medium %v, got %v", L3MediumTypeP2P, cfg.medium)
+		}
+	})
+	t.Run("Invalid Medium Type", func(t *testing.T) {
+		_, err := NewL3Config(WithMedium(L3MediumType(99)))
+		if err == nil {
+			t.Error("expected error for invalid medium type, got nil")
+		}
+	})
+}
+
+func TestWithSparseModePIM(t *testing.T) {
+	cfg, err := NewL3Config(WithSparseModePIM())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.pimSparseMode {
+		t.Errorf("expected PIMSparseMode true, got false")
+	}
+}
+
+func TestWithISIS(t *testing.T) {
+	cfg, err := NewL3Config(WithISIS("UNDERLAY", true, false))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.isisCfg == nil {
+		t.Fatal("expected isisCfg to be set")
+	}
+	if cfg.isisCfg.Name != "UNDERLAY" || !cfg.isisCfg.V4Enable || cfg.isisCfg.V6Enable {
+		t.Errorf("unexpected ISIS config: %+v", cfg.isisCfg)
+	}
+}
+
+func TestToYGOT_Numbered(t *testing.T) {
+	cfg, err := NewL3Config(
+		WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+		WithMedium(L3MediumTypeBroadcast),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	updates, err := cfg.ToYGOT("eth1/1", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(updates) == 0 {
+		t.Fatal("expected at least one update")
+	}
+}
+
+func TestToYGOT_Unnumbered(t *testing.T) {
+	t.Run("Unnumbered addressing", func(t *testing.T) {
+		cfg, err := NewL3Config(
+			WithMedium(L3MediumTypeP2P),
+			WithUnnumberedAddressing("lo0"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		updates, err := cfg.ToYGOT("eth1/1", "default")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(updates) == 0 {
+			t.Fatal("expected at least one update")
+		}
+	})
+	t.Run("Unnumbered addressing with medium not P2P", func(t *testing.T) {
+		for _, medium := range []L3MediumType{L3MediumTypeBroadcast, L3MediumTypeUnset} {
+			_, err := NewL3Config(
+				WithMedium(medium),
+				WithUnnumberedAddressing("lo0"),
+			)
+			if err == nil {
+				t.Fatal("expected error for unnumbered addressing on non-P2P medium, got nil")
+			}
+		}
+	})
+}
+
+func TestToYGOT_WithISIS(t *testing.T) {
+	cfg, err := NewL3Config(
+		WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+		WithISIS("UNDERLAY", true, false),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	updates, err := cfg.ToYGOT("eth1/1", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(updates) < 2 {
+		t.Errorf("expected at least two updates (addressing + isis), got %d", len(updates))
+	}
+}
+
+func TestToYGOT_ISISNameUnset(t *testing.T) {
+	cfg, err := NewL3Config(
+		WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Manually set isisCfg with empty name to simulate error
+	cfg.isisCfg = &ISISConfig{Name: ""}
+	_, err = cfg.ToYGOT("eth1/1", "default")
+	if err == nil {
+		t.Error("expected error when ISIS name is not set")
+	}
+}
+
+func TestToYGOT_WithISIS_DualStack(t *testing.T) {
+	vrfName := "test"
+	interfaceName := "eth1/1"
+	isisName := "UNDERLAY"
+	cfg, err := NewL3Config(
+		WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+		WithNumberedAddressingIPv6([]string{"2001:db8::1/64"}),
+		WithISIS(isisName, true, true),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updates, err := cfg.ToYGOT(interfaceName, vrfName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(updates) < 2 {
+		t.Errorf("expected at least two updates (addressing + isis), got %d", len(updates))
+	}
+
+	expect := &nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList{
+		Dom:            ygot.String(vrfName),
+		Instance:       ygot.String(isisName),
+		NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on,
+		V4Enable:       ygot.Bool(true),
+		V6Enable:       ygot.Bool(true),
+	}
+	foundISIS := false
+	for _, u := range updates {
+		ur, ok := u.(gnmiext.ReplacingUpdate)
+		if ok {
+			if ur.XPath == "System/isis-items/if-items/InternalIf-list[id=eth1/1]" {
+				if ru, ok := u.(gnmiext.ReplacingUpdate); ok {
+					if val, ok := ru.Value.(*nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList); ok {
+						foundISIS = true
+						if !reflect.DeepEqual(val, expect) {
+							t.Errorf("expected ISIS config %v, got %v", expect, val)
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	if !foundISIS {
+		t.Error("expected ISIS config to be present in updates")
+	}
+}

--- a/internal/provider/cisco/nxos/iface/loopback.go
+++ b/internal/provider/cisco/nxos/iface/loopback.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+var _ gnmiext.DeviceConf = (*Loopback)(nil)
+
+type Loopback struct {
+	name        string
+	description *string
+	adminSt     bool
+	vrf         string
+	c           *L3Config
+}
+
+type LoopbackOption func(*Loopback) error
+
+// NewLoopbackInterface creates a new loopback interface with the given name and description.
+func NewLoopbackInterface(name string, description *string, opts ...LoopbackOption) (*Loopback, error) {
+	altName, err := getLoopbackShortName(name)
+	if err != nil {
+		return nil, fmt.Errorf("loopback: not a valid name: %w", err)
+	}
+	l := &Loopback{
+		name:        altName,
+		description: description,
+		adminSt:     true,
+	}
+	for _, opt := range opts {
+		if err := opt(l); err != nil {
+			return nil, err
+		}
+	}
+	return l, nil
+}
+
+var loopbackNameRgx = regexp.MustCompile(`^(?i)(Loopback|lo)(\d+)$`)
+
+func getLoopbackShortName(name string) (string, error) {
+	matches := loopbackNameRgx.FindStringSubmatch(name)
+	if len(matches) == 3 {
+		return "lo" + matches[2], nil
+	}
+	return "", fmt.Errorf("invalid loopback interface name %s", name)
+}
+
+func WithLoopbackL3(c *L3Config) LoopbackOption {
+	return func(p *Loopback) error {
+		if c == nil {
+			return errors.New("loopback: l3 configuration cannot be nil")
+		}
+		if c.addressingMode == AddressingModeUnnumbered {
+			return errors.New("loopback: unnumbered addressing mode is not supported for loopback interfaces")
+		}
+		if c.medium != L3MediumTypeUnset {
+			return errors.New("loopback: medium type cannot be set for loopback interfaces")
+		}
+		p.c = c
+		return nil
+	}
+}
+
+func WithLoopbackVRF(vrf string) LoopbackOption {
+	return func(p *Loopback) error {
+		if vrf == "" {
+			return errors.New("physif: VRF name cannot be empty")
+		}
+		p.vrf = vrf
+		return nil
+	}
+}
+
+func WithLoopbackAdminState(adminSt bool) LoopbackOption {
+	return func(p *Loopback) error {
+		p.adminSt = adminSt
+		return nil
+	}
+}
+
+func (l *Loopback) ToYGOT(client gnmiext.Client) ([]gnmiext.Update, error) {
+	ll := &nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList{
+		Descr:   l.description,
+		AdminSt: nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+	}
+	if !l.adminSt {
+		ll.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_down
+	}
+	if l.vrf != "" {
+		ll.GetOrCreateRtvrfMbrItems().TDn = ygot.String("System/inst-items/Inst-list[name=" + l.vrf + "]")
+	}
+
+	updates := []gnmiext.Update{
+		gnmiext.ReplacingUpdate{
+			XPath: "System/intf-items/lb-items/LbRtdIf-list[id=" + l.name + "]",
+			Value: ll,
+		},
+	}
+
+	vrfName := l.vrf
+	if vrfName == "" {
+		vrfName = "default"
+	}
+
+	if l.c != nil {
+		l3Updates, err := l.c.ToYGOT(l.name, vrfName)
+		if err != nil {
+			return nil, fmt.Errorf("loopback: fail to create ygot objects for L3 config %w ", err)
+		}
+		if l3Updates != nil {
+			updates = append(updates, l3Updates...)
+		}
+	}
+	return updates, nil
+}
+
+func (l *Loopback) Reset(client gnmiext.Client) ([]gnmiext.Update, error) {
+	return []gnmiext.Update{
+		gnmiext.ReplacingUpdate{
+			XPath: "System/intf-items/lb-items/LbRtdIf-list[id=" + l.name + "]",
+			Value: &nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList{},
+		},
+	}, nil
+}

--- a/internal/provider/cisco/nxos/iface/loopback_test.go
+++ b/internal/provider/cisco/nxos/iface/loopback_test.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+const (
+	loopbackName         = "Loopback0"
+	loopbackShortName    = "lo0"
+	loopbackDescription  = "Test Loopback Interface"
+	loopbackVRFName      = "test-vrf"
+	loopbackISISName     = "UNDERLAY"
+	loopbackISISV4Enable = true
+	loopbackISISV6Enable = false
+)
+
+func Test_NewLoopback(t *testing.T) {
+	validNames := []string{"Loopback0", "loopback123", "lo1", "lo99"}
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewLoopbackInterface(name, nil)
+			if err != nil {
+				t.Fatalf("failed to create physical interface: %v", err)
+			}
+		})
+	}
+	invalidNames := []string{"test", "Loopback", "lo", "Loopback1/2", "lo1.1", "eth100"}
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewLoopbackInterface(name, nil)
+			if err == nil {
+				t.Fatalf("created interface with invalid name: %s", name)
+			}
+		})
+	}
+}
+
+func Test_Loopback_ToYGOT_BaseConfig(t *testing.T) {
+	t.Run("No additional base options", func(t *testing.T) {
+		p, err := NewLoopbackInterface(loopbackName, ygot.String(loopbackDescription))
+		if err != nil {
+			t.Fatalf("failed to create loopback interface: %v", err)
+		}
+
+		got, err := p.ToYGOT(&gnmiext.ClientMock{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		// single update affecting only base configuration of physical interface
+		if len(got) != 1 {
+			t.Errorf("expected 2 update, got %d", len(got))
+		}
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.XPath != "System/intf-items/lb-items/LbRtdIf-list[id="+p.name+"]" {
+			t.Errorf("wrong xpath, expected 'System/intf-items/lb-items/LbRtdIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
+		}
+		// correct initialization
+		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList{
+			Descr:   ygot.String(loopbackDescription),
+			AdminSt: nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+		}
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList)
+		notification, err := ygot.Diff(phGot, phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	t.Run("With VRF", func(t *testing.T) {
+		p, err := NewLoopbackInterface(loopbackName, ygot.String(loopbackDescription), WithLoopbackVRF("test-vrf"))
+		if err != nil {
+			t.Fatalf("failed to create loopback interface: %v", err)
+		}
+		got, err := p.ToYGOT(&gnmiext.ClientMock{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Errorf("expected 1 update, got %d", len(got))
+		}
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.XPath != "System/intf-items/lb-items/LbRtdIf-list[id="+p.name+"]" {
+			t.Errorf("wrong xpath, expected 'System/intf-items/lb-items/LbRtdIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
+		}
+
+		llRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList{
+			Descr:   ygot.String(loopbackDescription),
+			AdminSt: nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			RtvrfMbrItems: &nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList_RtvrfMbrItems{
+				TDn: ygot.String("System/inst-items/Inst-list[name=test-vrf]"),
+			},
+		}
+		llGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList)
+		notification, err := ygot.Diff(llGot, llRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+}
+
+func Test_Loopback_ToYGOT_WithL3Config(t *testing.T) {
+	l3cfg, err := NewL3Config(
+		WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
+		WithSparseModePIM(),
+		WithISIS(loopbackISISName, loopbackISISV4Enable, loopbackISISV6Enable),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, err := NewLoopbackInterface(loopbackName, ygot.String(loopbackDescription),
+		WithLoopbackL3(l3cfg),
+		WithLoopbackVRF("test-vrf"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create loopback interface: %v", err)
+	}
+	got, err := p.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(got) != 4 {
+		t.Errorf("expected 3 updates (base + L3), got %d", len(got))
+	}
+	t.Run("PIM config", func(t *testing.T) {
+		pimUpdate := got[1].(gnmiext.ReplacingUpdate)
+		if pimUpdate.XPath != "System/pim-items/inst-items/dom-items/Dom-list[name=test-vrf]/if-items/If-list[id="+loopbackShortName+"]" {
+			t.Errorf("wrong xpath, expected 'System/pim-items/inst-items/dom-items/Dom-list[name=test-vrf]/if-items/If-list[id="+loopbackShortName+"]', got '%s'", pimUpdate.XPath)
+		}
+		expected := &nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList{
+			AdminSt:       nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+			PimSparseMode: ygot.Bool(true),
+		}
+		pimGot := pimUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList)
+		notification, err := ygot.Diff(pimGot, expected)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	t.Run("Addressing", func(t *testing.T) {
+		aUpdate := got[2].(gnmiext.ReplacingUpdate)
+		if aUpdate.XPath != "System/ipv4-items/inst-items/dom-items/Dom-list[name=test-vrf]/if-items/If-list[id="+loopbackShortName+"]" {
+			t.Errorf("wrong xpath, expected 'System/ipv4-items/inst-items/dom-items/Dom-list[name=test-vrf]/if-items/If-list[id="+loopbackShortName+"]', got '%s'", aUpdate.XPath)
+		}
+		expected := &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
+			AddrItems: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems{
+				AddrList: map[string]*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems_AddrList{
+					"10.0.0.1/24": {
+						Addr: ygot.String("10.0.0.1/24"),
+					},
+				},
+			},
+		}
+		aGot := aUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
+		notification, err := ygot.Diff(aGot, expected)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	t.Run("ISIS", func(t *testing.T) {
+		iUpdate := got[3].(gnmiext.ReplacingUpdate)
+
+		isisRef := &nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList{
+			Instance:       ygot.String(loopbackISISName),
+			V4Enable:       ygot.Bool(loopbackISISV4Enable),
+			V6Enable:       ygot.Bool(loopbackISISV6Enable),
+			NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on,
+			Dom:            ygot.String(loopbackVRFName),
+		}
+		isisGot := iUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList)
+		notification, err := ygot.Diff(isisGot, isisRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+		if iUpdate.XPath != "System/isis-items/if-items/InternalIf-list[id="+loopbackShortName+"]" {
+			t.Errorf("wrong xpath, expected 'System/isis-items/if-items/InternalIf-list[id="+loopbackShortName+"]', got '%s'", iUpdate.XPath)
+		}
+	})
+}
+
+func Test_Loopback_ToYGOT_InvalidL3Config(t *testing.T) {
+	t.Run("With unnumbered addressing", func(t *testing.T) {
+		l3cfg, err := NewL3Config(
+			WithMedium(L3MediumTypeP2P),
+			WithUnnumberedAddressing("loopback1"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, err = NewLoopbackInterface(loopbackName, ygot.String(loopbackDescription), WithLoopbackL3(l3cfg))
+		if err == nil {
+			t.Fatalf("expected error for unnumbered addressing, got nil")
+		}
+	})
+	t.Run("With medium ", func(t *testing.T) {
+		l3cfg, err := NewL3Config(
+			WithMedium(L3MediumTypeP2P),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, err = NewLoopbackInterface(loopbackName, ygot.String(loopbackDescription), WithLoopbackL3(l3cfg))
+		if err == nil {
+			t.Fatalf("expected error for medium type, got nil")
+		}
+	})
+}

--- a/internal/provider/cisco/nxos/iface/physif_test.go
+++ b/internal/provider/cisco/nxos/iface/physif_test.go
@@ -1,0 +1,606 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+const (
+	physIfDescription  = "test interface"
+	physIfVRFName      = "test-vrf"
+	physIfName         = "eth1/1"
+	physIfISISName     = "test-isis"
+	physIfISISV4Enable = true
+	physIfISISV6Enable = false
+)
+
+func Test_PhysIf_NewPhysicalInterface(t *testing.T) {
+	validNames := []string{"Ethernet1/1", "ethernet1/2", "eth1/1", "eTH1/2", "Eth1/3"}
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewPhysicalInterface(name, nil)
+			if err != nil {
+				t.Fatalf("failed to create physical interface: %v", err)
+			}
+		})
+	}
+	invalidNames := []string{"test", "ether1/1", "ethernet1.1", "eth1/1/1", "port-channel01", "po100"}
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewPhysicalInterface(name, nil)
+			if err == nil {
+				t.Fatalf("created interface with invalid name: %s", name)
+			}
+		})
+	}
+}
+
+// tests base configuration of the physical interface is correctly initialized
+func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
+	t.Run("No additional base options", func(t *testing.T) {
+		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription))
+		if err != nil {
+			t.Fatalf("failed to create physical interface")
+		}
+
+		got, err := p.ToYGOT(&gnmiext.ClientMock{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// single update affecting only base configuration of physical interface
+		if len(got) != 1 {
+			t.Errorf("expected 2 update, got %d", len(got))
+		}
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+p.name+"]" {
+			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
+		}
+
+		// correct initialization
+		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+			Descr:         ygot.String(physIfDescription),
+			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			UserCfgdFlags: ygot.String("admin_state"),
+		}
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(phGot, phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+	t.Run("MTU and VRF", func(t *testing.T) {
+		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription),
+			WithPhysIfMTU(9216),
+			WithPhysIfVRF(physIfVRFName),
+		)
+		if err != nil {
+			t.Fatalf("failed to create physical interface")
+		}
+
+		got, err := p.ToYGOT(&gnmiext.ClientMock{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// single update affecting only base configuration of physical interface
+		if len(got) != 1 {
+			t.Errorf("expected 2 update, got %d", len(got))
+		}
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+p.name+"]" {
+			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
+		}
+
+		// correct initialization
+		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+			Descr:         ygot.String(physIfDescription),
+			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			Mtu:           ygot.Uint32(9216),
+			UserCfgdFlags: ygot.String("admin_mtu,admin_state"),
+		}
+		phRef.GetOrCreateRtvrfMbrItems().TDn = ygot.String("System/inst-items/Inst-list[name=" + physIfVRFName + "]")
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(phGot, phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+}
+
+func Test_PhysIf_Reset_BaseConfig(t *testing.T) {
+	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription))
+	if err != nil {
+		t.Fatalf("failed to create physical interface")
+	}
+
+	got, err := p.Reset(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// expect 2 updates: base config and spanning tree
+	if len(got) != 2 {
+		t.Errorf("expected 2 update, got %d", len(got))
+	}
+	t.Run("Base config", func(t *testing.T) {
+		// checks on base config update
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type EditingUpdate")
+		}
+		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+p.name+"]" {
+			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
+		}
+		phRef := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{}
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(phGot, &phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+}
+
+// Test_PhysIf_ToYGOT_WithL2AndL3 verifies that when both L2 and L3 options are supplied,
+// only the last one is applied, per contract.
+func Test_PhysIf_ToYGOT_WithL2AndL3(t *testing.T) {
+	l2cfg, err := NewL2Config()
+	if err != nil {
+		t.Fatalf("unexpected error while creating L2 config: %v", err)
+	}
+	l3cfg, err := NewL3Config()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Run("L2 with VRF is not allowed", func(t *testing.T) {
+		_, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfVRF(physIfVRFName))
+		if err == nil {
+			t.Fatalf("expected error when creating physical interface with L2 and VRF, got nil")
+		}
+	})
+	t.Run("L2 then L3, expect only L3", func(t *testing.T) {
+		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfL3(l3cfg))
+		if err != nil {
+			t.Fatalf("failed to create physical interface")
+		}
+		if p.l2 != nil {
+			t.Errorf("expected L2 to be nil")
+		}
+		if p.l3 == nil {
+			t.Errorf("expected L3 to be set")
+		}
+	})
+
+	t.Run("L3 then L2, expect only L2", func(t *testing.T) {
+		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg), WithPhysIfL2(l2cfg))
+		if err != nil {
+			t.Fatalf("failed to create physical interface")
+		}
+		if p.l2 == nil {
+			t.Errorf("expected L2 to be set")
+		}
+		if p.l3 != nil {
+			t.Errorf("expected L3 to be nil")
+		}
+	})
+}
+
+func Test_PhysIf_ToYGOT_WithL2_Trunk(t *testing.T) {
+	l2cfg, err := NewL2Config(
+		WithSpanningTree(SpanningTreeModeEdge),
+		WithSwithPortMode(SwitchPortModeTrunk),
+		WithNativeVlan(100),
+		WithAllowedVlans([]uint16{10, 20, 30}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error while creating L2 config: %v", err)
+	}
+	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg))
+	if err != nil {
+		t.Fatalf("failed to create physical interface")
+	}
+	got, err := p.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 update, got %d", len(got))
+	}
+	t.Run("Base config", func(t *testing.T) {
+		// check base config: additional layer option and switchport mode
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.Value == nil {
+			t.Errorf("expected value to be set")
+		}
+		phRef := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+			Descr:         ygot.String(physIfDescription),
+			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
+			Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_trunk,
+			NativeVlan:    ygot.String("vlan-100"), // required by NX-OS
+			TrunkVlans:    ygot.String("10,20,30"),
+			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+		}
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(phGot, &phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	// check l2 config: a single update for spanning tree
+	t.Run("Spanning tree config", func(t *testing.T) {
+		l2Update, ok := got[1].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		expectPath := "System/stp-items/inst-items/if-items/If-list[id=" + p.name + "]"
+		if l2Update.XPath != expectPath {
+			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, l2Update.XPath)
+		}
+		stRef := nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{
+			AdminSt: nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+			Mode:    nxos.Cisco_NX_OSDevice_Stp_IfMode_edge,
+		}
+		stGot := l2Update.Value.(*nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList)
+		if *stGot != stRef {
+			t.Errorf("spanning tree config mismatch")
+		}
+	})
+}
+
+func Test_PhysIf_ToYGOT_WithL2_Access(t *testing.T) {
+	l2cfg, err := NewL2Config(
+		WithSpanningTree(SpanningTreeModeEdge),
+		WithSwithPortMode(SwitchPortModeAccess),
+		WithAccessVlan(10),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error while creating L2 config: %v", err)
+	}
+	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg))
+	if err != nil {
+		t.Fatalf("failed to create physical interface")
+	}
+	got, err := p.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 update, got %d", len(got))
+	}
+	t.Run("Base config", func(t *testing.T) {
+		// check base config: additional layer option and switchport mode
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.Value == nil {
+			t.Errorf("expected value to be set")
+		}
+		phRef := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+			Descr:         ygot.String(physIfDescription),
+			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
+			Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_access,
+			AccessVlan:    ygot.String("10"),
+			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+		}
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(phGot, &phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	// check l2 config: a single update for spanning tree
+	t.Run("Spanning tree config", func(t *testing.T) {
+		l2Update, ok := got[1].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		expectPath := "System/stp-items/inst-items/if-items/If-list[id=" + p.name + "]"
+		if l2Update.XPath != expectPath {
+			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, l2Update.XPath)
+		}
+		stRef := nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{
+			AdminSt: nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+			Mode:    nxos.Cisco_NX_OSDevice_Stp_IfMode_edge,
+		}
+		stGot := l2Update.Value.(*nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList)
+		if *stGot != stRef {
+			t.Errorf("spanning tree config mismatch")
+		}
+	})
+}
+
+func Test_PhysIf_ToYGOT_WithL3(t *testing.T) {
+	l3cfg, err := NewL3Config(
+		WithMedium(L3MediumTypeP2P),
+		WithUnnumberedAddressing("loopback0"),
+		WithSparseModePIM(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg))
+	if err != nil {
+		t.Fatalf("failed to create physical interface")
+	}
+	got, err := p.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 2 update, got %d", len(got))
+	}
+
+	t.Run("Base config", func(t *testing.T) {
+		// check base config: additional layer option and switchport mode
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.Value == nil {
+			t.Errorf("expected value to be set")
+		}
+		phExpect := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			Descr:         ygot.String(physIfDescription),
+			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+			Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
+			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+		}
+		ph := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(ph, &phExpect)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	t.Run("PIM config", func(t *testing.T) {
+		// check l2 config: a single update for spanning tree
+		l3Update, ok := got[1].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		expectPath := "System/pim-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=" + p.name + "]"
+		if l3Update.XPath != expectPath {
+			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, l3Update.XPath)
+		}
+		pimRef := nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList{
+			AdminSt:       nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+			PimSparseMode: ygot.Bool(true),
+		}
+		pimGot := l3Update.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList)
+		notification, err := ygot.Diff(&pimRef, pimGot)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	t.Run("Addressing config: unnumbered loopback0", func(t *testing.T) {
+		// check addressing config: a single update for addressing
+		aUpdate, ok := got[2].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		expectPath := "System/ipv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=" + p.name + "]"
+		if aUpdate.XPath != expectPath {
+			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, aUpdate.XPath)
+		}
+		addrRef := nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
+			Unnumbered: ygot.String("lo0"),
+		}
+		addrGot := aUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
+		notification, err := ygot.Diff(&addrRef, addrGot)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	// numbered addressing
+	t.Run("Addressing config: numbered", func(t *testing.T) {
+		l3cfg, err := NewL3Config(
+			WithNumberedAddressingIPv4([]string{"192.0.2.1/8"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p2, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg))
+		if err != nil {
+			t.Fatalf("failed to create physical interface")
+		}
+		got, err := p2.ToYGOT(&gnmiext.ClientMock{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		aUpdate, ok := got[1].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		addrGot := aUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
+		if addrGot.Unnumbered != nil {
+			t.Errorf("expected unnumbered to be nil")
+		}
+		if addrGot.GetAddrItems().GetAddrList("192.0.2.1/8") == nil {
+			t.Errorf("address is not set")
+		}
+	})
+}
+
+func Test_PhysIf_Reset_WithL3(t *testing.T) {
+	l3cfg, err := NewL3Config(
+		WithMedium(L3MediumTypeP2P),
+		WithUnnumberedAddressing("loopback0"),
+		WithSparseModePIM(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg))
+	if err != nil {
+		t.Fatalf("failed to create physical interface")
+	}
+	got, err := p.Reset(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// expect 2 updates: base config and L2 spanning tree reset, which is not automatically reset. The L3 config
+	// is automatically removed when resetting the physical interface.
+	if len(got) != 2 {
+		t.Errorf("expected 2 update, got %d", len(got))
+	}
+	t.Run("Base config", func(t *testing.T) {
+		// check base config: additional layer option and switchport mode
+		phUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		phGot := phUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		phExpect := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{}
+		notification, err := ygot.Diff(&phExpect, phGot)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+}
+
+// Configuring a VRF on an interface influences the xpath in several updates
+func Test_PhysIf_ToYGOT_VRF(t *testing.T) {
+	l3cfg, err := NewL3Config(
+		WithMedium(L3MediumTypeP2P),
+		WithUnnumberedAddressing("loopback0"),
+		WithSparseModePIM(),
+		WithISIS(physIfISISName, physIfISISV4Enable, physIfISISV6Enable),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription),
+		WithPhysIfVRF(physIfVRFName),
+		WithPhysIfL3(l3cfg),
+	)
+	if err != nil {
+		t.Fatalf("failed to create physical interface")
+	}
+
+	got, err := p.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// single update affecting only base configuration of physical interface
+	if len(got) != 4 {
+		t.Errorf("expected 4 update, got %d", len(got))
+	}
+
+	t.Run("Base config", func(t *testing.T) {
+		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
+		if !ok {
+			t.Errorf("expected value to be of type ReplacingUpdate")
+		}
+		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+physIfName+"]" {
+			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id="+physIfName+"]', got '%s'", bUpdate.XPath)
+		}
+
+		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+			Descr:         ygot.String(physIfDescription),
+			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+			Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
+			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+		}
+		phRef.GetOrCreateRtvrfMbrItems().TDn = ygot.String("System/inst-items/Inst-list[name=" + physIfVRFName + "]")
+		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+		notification, err := ygot.Diff(phGot, phRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+	})
+
+	t.Run("PIM config", func(t *testing.T) {
+		pimUpdate := got[1].(gnmiext.ReplacingUpdate)
+		if pimUpdate.XPath != "System/pim-items/inst-items/dom-items/Dom-list[name="+physIfVRFName+"]/if-items/If-list[id="+physIfName+"]" {
+			t.Errorf("wrong xpath, expected 'System/pim-items/inst-items/dom-items/Dom-list[name="+physIfVRFName+"]/if-items/If-list[id="+physIfName+"]', got '%s'", pimUpdate.XPath)
+		}
+	})
+
+	t.Run("Addressing", func(t *testing.T) {
+		aUpdate := got[2].(gnmiext.ReplacingUpdate)
+		if aUpdate.XPath != "System/ipv4-items/inst-items/dom-items/Dom-list[name="+physIfVRFName+"]/if-items/If-list[id="+physIfName+"]" {
+			t.Errorf("wrong xpath, expected 'System/ipv4-items/inst-items/dom-items/Dom-list[name="+physIfVRFName+"]/if-items/If-list[id="+physIfName+"]', got '%s'", aUpdate.XPath)
+		}
+	})
+
+	t.Run("ISIS", func(t *testing.T) {
+		iUpdate := got[3].(gnmiext.ReplacingUpdate)
+
+		isisRef := &nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList{
+			Instance:       ygot.String(physIfISISName),
+			V4Enable:       ygot.Bool(physIfISISV4Enable),
+			V6Enable:       ygot.Bool(physIfISISV6Enable),
+			NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on,
+			Dom:            ygot.String(physIfVRFName),
+		}
+		isisGot := iUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList)
+		notification, err := ygot.Diff(isisGot, isisRef)
+		if err != nil {
+			t.Errorf("failed to compute diff")
+		}
+		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+			t.Errorf("unexpected diff: %s", notification)
+		}
+		if iUpdate.XPath != "System/isis-items/if-items/InternalIf-list[id="+physIfName+"]" {
+			t.Errorf("wrong xpath, expected 'System/isis-items/if-items/InternalIf-list[id="+physIfName+"]', got '%s'", iUpdate.XPath)
+		}
+	})
+}


### PR DESCRIPTION
Still in draft as it introduces a change to the `interface` API and needs to be discussed. 

The pkg `iface` implements the configuration of physical interfaces on cisco devices using the `gnmiext` client. The package supports configuring L2 and L3 interfaces such as the examples below. We generated a list of relevant xpaths by quering the NXAPI server of a Cisco N9k 10.4(3) lite version.

L2 example:
```
 interface eth1/1
 description $description
 mtu 9216
 switchport
 switchport mode trunk
 spanning-tree port type (edge trunk | network)
 no shutdown
```

L3 example:
```
 interface eth1/2
 description example
 mtu 9216
 medium p2p
 ip unnumbered loopback0
 ip router isis UNDERLAY
 isis network point-to-point
 ip pim sparse-mode
 no shutdown
 vrf member mgmt0
```