### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ironcore-dev/cobalt-core @ironcore-dev/ironcore-metal
+* @felix-kaestner @afritzler @damyan @swagner-de @sven-rosenzweig @nikatza


### PR DESCRIPTION
Using individual people instead of complete teams avoids annoying non-participating people with notifications of the project.