### PR TITLE
Cache golangci-lint analysis in GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -30,6 +30,13 @@ jobs:
         with:
           check-latest: true
           go-version: 1.24.5
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-
       - name: Run prepare make target
         run: make generate
       - name: Run golangci-lint

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # FIXME: Exclude cisco nx-os provider from golangci-lint as it includes
           # a lot of generated code that will exceed the runners's constraints.
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.1
           go list -f '{{.Dir}}' ./... | grep -v nxos/ | xargs $(go env GOPATH)/bin/golangci-lint run
       - name: Run shellcheck
         uses: ludeeus/action-shellcheck@2.0.0


### PR DESCRIPTION
This would automatically be done by using the official golangci-lint-action. However, as we manually run golangci-lint in order to exclude certain packages, we also need to manually build the cache.