### PR TITLE
cisco-nxos-provider: Activate IS-IS feature as config is applied

### DIFF
--- a/internal/provider/cisco/nxos/isis/isis.go
+++ b/internal/provider/cisco/nxos/isis/isis.go
@@ -4,6 +4,7 @@
 package isis
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/openconfig/ygot/ygot"
@@ -49,10 +50,10 @@ const (
 
 func (i *ISIS) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
 	if i.Name == "" {
-		return nil, fmt.Errorf("isis: name must be set")
+		return nil, errors.New("isis: name must be set")
 	}
 	if i.NET == "" {
-		return nil, fmt.Errorf("isis: NET must be set")
+		return nil, errors.New("isis: NET must be set")
 	}
 	instList := &nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList{
 		Name: ygot.String(i.Name),
@@ -89,6 +90,12 @@ func (i *ISIS) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
 	}
 
 	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/isis-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_IsisItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		},
 		gnmiext.ReplacingUpdate{
 			XPath: "System/isis-items/inst-items/Inst-list[name=" + i.Name + "]",
 			Value: instList,

--- a/internal/provider/cisco/nxos/isis/isis_test.go
+++ b/internal/provider/cisco/nxos/isis/isis_test.go
@@ -26,12 +26,19 @@ func TestToYGOT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToYGOT() error = %v", err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("ToYGOT() expected 1 update, got %d", len(got))
+	if len(got) != 2 {
+		t.Fatalf("ToYGOT() expected 2 updates, got %d", len(got))
 	}
-	update, ok := got[0].(gnmiext.ReplacingUpdate)
+	edit, ok := got[0].(gnmiext.EditingUpdate)
 	if !ok {
-		t.Errorf("expected value to be of type ReplacingUpdate")
+		t.Errorf("expected first update to be of type ReplacingUpdate")
+	}
+	if edit.XPath != "System/fm-items/isis-items" {
+		t.Errorf("expected first update XPath 'System/fm-items/isis-items', got %s", edit.XPath)
+	}
+	update, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("expected second update to be of type ReplacingUpdate")
 	}
 	if update.XPath != "System/isis-items/inst-items/Inst-list[name=UNDERLAY]" {
 		t.Errorf("expected XPath 'System/isis-items/inst-items/Inst-list[name=UNDERLAY]', got %s", update.XPath)
@@ -118,8 +125,8 @@ func TestISIS_ToYGOT_EmptyAddressFamilies(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error for empty address families: %v", err)
 	}
-	if len(updates) != 1 {
-		t.Errorf("expected 1 update, got %d", len(updates))
+	if len(updates) != 2 {
+		t.Errorf("expected 2 updates, got %d", len(updates))
 	}
 }
 


### PR DESCRIPTION
This patch adds another update call to automatically activate the IS-IS feature when an IS-IS configuration item is applied. On the opposite note, the feature will not be deactivated, once an IS-IS item is reset, as there could potentially be other IS-IS processes running on the same device that would be influenced.