### PR TITLE
cisco-nxos-provider: add `BGP` configuration

### DIFF
--- a/internal/provider/cisco/nxos/bgp/bgp.go
+++ b/internal/provider/cisco/nxos/bgp/bgp.go
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package bgp provides a representation of BGP configuration for Cisco NX-OS devices.
+package bgp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strconv"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+var _ gnmiext.DeviceConf = (*BGP)(nil)
+
+type BGP struct {
+	// The Autonomous System Number of the BGP instance.
+	AsNumber string
+	// The Router Identifier of the BGP instance, must be an IPv4 address.
+	RouterID netip.Addr
+	// AddressFamilies is a list of address families configured for the BGP instance.
+	AddressFamilies []AddressFamily
+}
+
+func NewBGP(routerID string, asn uint32, opts ...BGPOption) (*BGP, error) {
+	if routerID == "" {
+		return nil, errors.New("bgp: router ID cannot be empty")
+	}
+	ip, err := netip.ParseAddr(routerID)
+	if err != nil {
+		return nil, fmt.Errorf("bgp: invalid router ID %q: %w", routerID, err)
+	}
+	if !ip.Is4() {
+		return nil, fmt.Errorf("bgp: router ID must be an IPv4 address, got %q", ip)
+	}
+
+	// TODO: support ASNs like '65000.100', ideally with a custom type
+	if asn == 0 || asn > 65535 {
+		return nil, errors.New("bgp: AS number must be between 1 and 65535")
+	}
+
+	bgp := &BGP{
+		RouterID: ip,
+		AsNumber: strconv.FormatUint(uint64(asn), 10),
+	}
+
+	for _, opt := range opts {
+		if err := opt(bgp); err != nil {
+			return nil, err
+		}
+	}
+
+	return bgp, nil
+}
+
+type BGPOption func(*BGP) error
+
+type AddressFamily interface {
+	toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList
+}
+
+// WithAddressFamily adds an address family to the BGP configuration.
+func WithAddressFamily(af AddressFamily) BGPOption {
+	return func(b *BGP) error {
+		if af == nil {
+			return errors.New("bgp: address family cannot be nil")
+		}
+		switch af.(type) {
+		case *L2EVPN, *IPv4Unicast, *IPv6Unicast:
+		default:
+			return fmt.Errorf("bgp: unsupported address family type %T", af)
+		}
+		for _, other := range b.AddressFamilies {
+			if other.toYGOT().Type == af.toYGOT().Type {
+				return fmt.Errorf("bgp: address family %T already exists", other)
+			}
+		}
+		b.AddressFamilies = append(b.AddressFamilies, af)
+		return nil
+	}
+}
+
+func (b *BGP) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	inst := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems{}
+	inst.AdminSt = nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled
+	inst.Asn = ygot.String(b.AsNumber)
+
+	dom := inst.GetOrCreateDomItems().GetOrCreateDomList("default")
+	dom.RtrId = ygot.String(b.RouterID.String())
+	dom.RtrIdAuto = nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled
+
+	hasEVPN := false
+	for _, af := range b.AddressFamilies {
+		_, ok := af.(*L2EVPN)
+		hasEVPN = hasEVPN || ok
+		if err := dom.GetOrCreateAfItems().AppendDomAfList(af.toYGOT()); err != nil {
+			return nil, fmt.Errorf("bgp: failed to append address family: %w", err)
+		}
+	}
+
+	updates := []gnmiext.Update{
+		gnmiext.ReplacingUpdate{
+			XPath: "System/fm-items/bgp-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_BgpItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		},
+		gnmiext.ReplacingUpdate{
+			XPath: "System/bgp-items/inst-items",
+			Value: inst,
+		},
+	}
+
+	if hasEVPN {
+		updates = slices.Insert(updates, 0, gnmiext.Update(gnmiext.ReplacingUpdate{
+			XPath: "System/fm-items/evpn-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_EvpnItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		}))
+	}
+
+	return updates, nil
+}
+
+func (b *BGP) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/bgp-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_BgpItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+			},
+		},
+		gnmiext.DeletingUpdate{
+			XPath: "System/bgp-items",
+		},
+	}, nil
+}
+
+var (
+	_ AddressFamily = (*L2EVPN)(nil)
+	_ AddressFamily = (*IPv4Unicast)(nil)
+	_ AddressFamily = (*IPv6Unicast)(nil)
+)
+
+type L2EVPN struct {
+	// Forward packets over multipath paths
+	MaximumPaths uint8
+	// Retain the routes based on Target VPN Extended Communities.
+	// Can be "all" to retain all routes, or a specific route-map name.
+	RetainRouteTarget string
+}
+
+func (evpn *L2EVPN) toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList {
+	af := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{}
+	af.Type = nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn
+	if evpn.MaximumPaths > 0 {
+		af.MaxExtEcmp = ygot.Uint8(evpn.MaximumPaths)
+	}
+	if evpn.RetainRouteTarget != "" {
+		rtAll, rtMap := nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled, evpn.RetainRouteTarget
+		if evpn.RetainRouteTarget == "all" {
+			rtAll, rtMap = nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled, "DME_UNSET_PROPERTY_MARKER"
+		}
+		af.RetainRttAll = rtAll
+		af.RetainRttRtMap = ygot.String(rtMap)
+	}
+	return af
+}
+
+type IPv4Unicast struct{}
+
+func (*IPv4Unicast) toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList {
+	af := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{}
+	af.Type = nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv4_ucast
+	return af
+}
+
+type IPv6Unicast struct{}
+
+func (*IPv6Unicast) toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList {
+	af := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{}
+	af.Type = nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv6_ucast
+	return af
+}
+
+var _ gnmiext.DeviceConf = (*BGPPeer)(nil)
+
+type BGPPeer struct {
+	// The BGP Peer's address.
+	Addr netip.Addr
+	// Neighbor specific description.
+	Desc string
+	// The Autonomous System Number of the Neighbor
+	AsNumber string
+	// The local source interface for the BGP session and update messages.
+	SrcIf string
+	// AddressFamilies is a list of address families configured for the BGP peer.
+	AddressFamilies []PeerAddressFamily
+}
+
+func NewBGPPeer(addr string, asn uint32, srcIf string, opts ...BGPPeerOption) (*BGPPeer, error) {
+	if addr == "" {
+		return nil, errors.New("bgp peer: address cannot be empty")
+	}
+	ip, err := netip.ParseAddr(addr)
+	if err != nil {
+		return nil, fmt.Errorf("bgp peer: invalid address %q: %w", addr, err)
+	}
+
+	if asn == 0 || asn > 65535 {
+		return nil, errors.New("bgp peer: AS number must be between 1 and 65535")
+	}
+
+	if srcIf == "" {
+		return nil, errors.New("bgp peer: source interface cannot be empty")
+	}
+
+	peer := &BGPPeer{
+		Addr:     ip,
+		Desc:     "DME_UNSET_PROPERTY_MARKER",
+		AsNumber: strconv.FormatUint(uint64(asn), 10),
+		SrcIf:    srcIf,
+	}
+	for _, opt := range opts {
+		if err := opt(peer); err != nil {
+			return nil, err
+		}
+	}
+	return peer, nil
+}
+
+type BGPPeerOption func(*BGPPeer) error
+
+// WithDescription sets the description for the BGP peer.
+func WithDescription(desc string) BGPPeerOption {
+	return func(p *BGPPeer) error {
+		if desc == "" {
+			return errors.New("bgp peer: description cannot be empty")
+		}
+		p.Desc = desc
+		return nil
+	}
+}
+
+type PeerAddressFamily interface {
+	toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList
+}
+
+// WithPeerAddressFamily adds an address family to the BGP peer configuration.
+func WithPeerAddressFamily(af PeerAddressFamily) BGPPeerOption {
+	return func(p *BGPPeer) error {
+		if af == nil {
+			return errors.New("bgp peer: address family cannot be nil")
+		}
+		switch af.(type) {
+		case *PeerL2EVPN, *PeerIPv4Unicast, *PeerIPv6Unicast:
+		default:
+			return fmt.Errorf("bgp peer: unsupported address family type %T", af)
+		}
+		for _, other := range p.AddressFamilies {
+			if other.toYGOT().Type == af.toYGOT().Type {
+				return fmt.Errorf("bgp peer: address family %T already exists", other)
+			}
+		}
+		p.AddressFamilies = append(p.AddressFamilies, af)
+		return nil
+	}
+}
+
+var ErrMissingBGPInstance = errors.New("bgp peer: missing BGP instance")
+
+func (p *BGPPeer) ToYGOT(client gnmiext.Client) ([]gnmiext.Update, error) {
+	// Ensure that the BGP instance exists and is configured on the "default" domain
+	// and return an error if it does not exist.
+	// Otherwise, by default of the gnmi specification, all missing nodes in the yang
+	// tree would be created, which would mean that we would create a new BGP instance,
+	// which is not what we want.
+	// Returning an error here allows us to handle the case where the BGP instance is not
+	// configured by requeuing the request for the BGP Peer on the k8s controller. This avoids
+	// a race condition where the BGP instance is created after the BGP Peer is created.
+	var inst nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems
+	err := client.Get(context.Background(), "System/bgp-items/inst-items", &inst)
+	if err != nil {
+		if errors.Is(err, gnmiext.ErrNil) {
+			return nil, ErrMissingBGPInstance
+		}
+		return nil, fmt.Errorf("bgp peer: failed to get BGP instance: %w", err)
+	}
+	domList := inst.GetDomItems().GetDomList("default")
+	if domList == nil {
+		return nil, ErrMissingBGPInstance
+	}
+	peer := domList.GetOrCreatePeerItems().GetOrCreatePeerList(p.Addr.String())
+	peer.Asn = ygot.String(p.AsNumber)
+	peer.AsnType = nxos.Cisco_NX_OSDevice_Bgp_PeerAsnType_none
+	peer.Name = ygot.String(p.Desc)
+	peer.SrcIf = ygot.String(p.SrcIf)
+	for _, af := range p.AddressFamilies {
+		if err := peer.AfItems.AppendPeerAfList(af.toYGOT()); err != nil {
+			return nil, fmt.Errorf("bgp peer: failed to append address family: %w", err)
+		}
+	}
+	return []gnmiext.Update{
+		gnmiext.ReplacingUpdate{
+			XPath: "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=" + p.Addr.String() + "]",
+			Value: peer,
+		},
+	}, nil
+}
+
+func (p *BGPPeer) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	return []gnmiext.Update{
+		gnmiext.DeletingUpdate{
+			XPath: "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=" + p.Addr.String() + "]",
+		},
+	}, nil
+}
+
+var (
+	_ PeerAddressFamily = (*PeerL2EVPN)(nil)
+	_ PeerAddressFamily = (*PeerIPv4Unicast)(nil)
+	_ PeerAddressFamily = (*PeerIPv6Unicast)(nil)
+)
+
+type PeerL2EVPN struct {
+	// SendStandardCommunity indicates whether to send the standard community attribute.
+	SendStandardCommunity bool
+	// SendExtendedCommunity indicates whether to send the extended community attribute.
+	SendExtendedCommunity bool
+	// RouteReflectorClient indicates whether to configure this peer as a route reflector client.
+	RouteReflectorClient bool
+}
+
+func (p *PeerL2EVPN) toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList {
+	af := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{}
+	af.Type = nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn
+	af.SendComStd = nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled
+	if p.SendStandardCommunity {
+		af.SendComStd = nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled
+	}
+	af.SendComExt = nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled
+	if p.SendExtendedCommunity {
+		af.SendComExt = nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled
+	}
+	af.Ctrl = ygot.String("DME_UNSET_PROPERTY_MARKER")
+	if p.RouteReflectorClient {
+		af.Ctrl = ygot.String("rr-client")
+	}
+	return af
+}
+
+type PeerIPv4Unicast struct{}
+
+func (p *PeerIPv4Unicast) toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList {
+	af := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{}
+	af.Type = nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv4_ucast
+	return af
+}
+
+type PeerIPv6Unicast struct{}
+
+func (p *PeerIPv6Unicast) toYGOT() *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList {
+	af := &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{}
+	af.Type = nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv6_ucast
+	return af
+}

--- a/internal/provider/cisco/nxos/bgp/bgp_test.go
+++ b/internal/provider/cisco/nxos/bgp/bgp_test.go
@@ -1,0 +1,825 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bgp
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"reflect"
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+func TestNewBGP(t *testing.T) {
+	tests := []struct {
+		name     string
+		routerID string
+		asn      uint32
+		opts     []BGPOption
+		wantErr  bool
+	}{
+		{
+			name:     "valid BGP instance",
+			routerID: "192.168.1.1",
+			asn:      65001,
+			wantErr:  false,
+		},
+		{
+			name:     "empty router ID",
+			routerID: "",
+			asn:      65001,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid router ID format",
+			routerID: "invalid-ip",
+			asn:      65001,
+			wantErr:  true,
+		},
+		{
+			name:     "IPv6 router ID",
+			routerID: "2001:db8::1",
+			asn:      65001,
+			wantErr:  true,
+		},
+		{
+			name:     "zero ASN",
+			routerID: "192.168.1.1",
+			asn:      0,
+			wantErr:  true,
+		},
+		{
+			name:     "ASN too large",
+			routerID: "192.168.1.1",
+			asn:      65536,
+			wantErr:  true,
+		},
+		{
+			name:     "with address family",
+			routerID: "192.168.1.1",
+			asn:      65001,
+			opts:     []BGPOption{WithAddressFamily(&IPv4Unicast{})},
+			wantErr:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bgp, err := NewBGP(test.routerID, test.asn, test.opts...)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewBGP() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("NewBGP() unexpected error = %v", err)
+				return
+			}
+			if bgp == nil {
+				t.Errorf("NewBGP() returned nil BGP instance")
+				return
+			}
+			if bgp.AsNumber != "65001" {
+				t.Errorf("NewBGP() AsNumber = %v, want %v", bgp.AsNumber, "65001")
+			}
+			expectedIP := netip.MustParseAddr(test.routerID)
+			if bgp.RouterID != expectedIP {
+				t.Errorf("NewBGP() RouterID = %v, want %v", bgp.RouterID, expectedIP)
+			}
+		})
+	}
+}
+
+func TestWithAddressFamily(t *testing.T) {
+	tests := []struct {
+		name    string
+		af      AddressFamily
+		wantErr bool
+	}{
+		{
+			name:    "nil address family",
+			af:      nil,
+			wantErr: true,
+		},
+		{
+			name:    "valid L2EVPN",
+			af:      &L2EVPN{},
+			wantErr: false,
+		},
+		{
+			name:    "valid IPv4Unicast",
+			af:      &IPv4Unicast{},
+			wantErr: false,
+		},
+		{
+			name:    "valid IPv6Unicast",
+			af:      &IPv6Unicast{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bgp := &BGP{}
+			opt := WithAddressFamily(test.af)
+			err := opt(bgp)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithAddressFamily() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithAddressFamily() unexpected error = %v", err)
+				return
+			}
+			if len(bgp.AddressFamilies) != 1 {
+				t.Errorf("WithAddressFamily() expected 1 address family, got %d", len(bgp.AddressFamilies))
+			}
+		})
+	}
+}
+
+func TestWithAddressFamily_Duplicate(t *testing.T) {
+	bgp := &BGP{}
+	af1 := &IPv4Unicast{}
+	af2 := &IPv4Unicast{}
+
+	// Add first address family
+	opt1 := WithAddressFamily(af1)
+	if err := opt1(bgp); err != nil {
+		t.Fatalf("WithAddressFamily() unexpected error = %v", err)
+	}
+
+	// Try to add duplicate address family
+	opt2 := WithAddressFamily(af2)
+	err := opt2(bgp)
+	if err == nil {
+		t.Errorf("WithAddressFamily() expected error for duplicate address family, got nil")
+		return
+	}
+	expectedErr := "bgp: address family *bgp.IPv4Unicast already exists"
+	if err.Error() != expectedErr {
+		t.Errorf("WithAddressFamily() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestBGP_ToYGOT(t *testing.T) {
+	bgp, err := NewBGP("192.168.1.1", 65001, WithAddressFamily(&IPv4Unicast{}))
+	if err != nil {
+		t.Fatalf("NewBGP() unexpected error = %v", err)
+	}
+
+	got, err := bgp.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("BGP.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("BGP.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check BGP feature enablement
+	update1, ok := got[0].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("BGP.ToYGOT() expected first update to be ReplacingUpdate")
+		return
+	}
+	if update1.XPath != "System/fm-items/bgp-items" {
+		t.Errorf("BGP.ToYGOT() expected XPath 'System/fm-items/bgp-items', got %v", update1.XPath)
+	}
+
+	bgpItems, ok := update1.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_BgpItems)
+	if !ok {
+		t.Errorf("BGP.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_FmItems_BgpItems")
+		return
+	}
+	if bgpItems.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
+		t.Errorf("BGP.ToYGOT() expected BGP AdminSt to be enabled")
+	}
+
+	// Check BGP instance configuration
+	update2, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("BGP.ToYGOT() expected second update to be ReplacingUpdate")
+		return
+	}
+	if update2.XPath != "System/bgp-items/inst-items" {
+		t.Errorf("BGP.ToYGOT() expected XPath 'System/bgp-items/inst-items', got %v", update2.XPath)
+	}
+
+	inst, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems)
+	if !ok {
+		t.Errorf("BGP.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems")
+		return
+	}
+
+	if inst.AdminSt != nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled {
+		t.Errorf("BGP.ToYGOT() expected instance AdminSt to be enabled")
+	}
+	if *inst.Asn != "65001" {
+		t.Errorf("BGP.ToYGOT() expected ASN '65001', got %v", *inst.Asn)
+	}
+
+	domList := inst.GetDomItems().GetDomList("default")
+	if domList == nil {
+		t.Errorf("BGP.ToYGOT() expected default domain to be present")
+		return
+	}
+	if *domList.RtrId != "192.168.1.1" {
+		t.Errorf("BGP.ToYGOT() expected router ID '192.168.1.1', got %v", *domList.RtrId)
+	}
+	if domList.RtrIdAuto != nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled {
+		t.Errorf("BGP.ToYGOT() expected router ID auto to be disabled")
+	}
+}
+
+func TestBGP_ToYGOT_WithEVPN(t *testing.T) {
+	bgp, err := NewBGP("192.168.1.1", 65001, WithAddressFamily(&L2EVPN{}))
+	if err != nil {
+		t.Fatalf("NewBGP() unexpected error = %v", err)
+	}
+
+	got, err := bgp.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("BGP.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 3 {
+		t.Errorf("BGP.ToYGOT() expected 3 updates with EVPN, got %d", len(got))
+		return
+	}
+
+	// Check EVPN feature enablement (should be first update)
+	update1, ok := got[0].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("BGP.ToYGOT() expected first update to be ReplacingUpdate")
+		return
+	}
+	if update1.XPath != "System/fm-items/evpn-items" {
+		t.Errorf("BGP.ToYGOT() expected XPath 'System/fm-items/evpn-items', got %v", update1.XPath)
+	}
+
+	evpnItems, ok := update1.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_EvpnItems)
+	if !ok {
+		t.Errorf("BGP.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_FmItems_EvpnItems")
+		return
+	}
+	if evpnItems.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
+		t.Errorf("BGP.ToYGOT() expected EVPN AdminSt to be enabled")
+	}
+}
+
+func TestBGP_Reset(t *testing.T) {
+	bgp, err := NewBGP("192.168.1.1", 65001)
+	if err != nil {
+		t.Fatalf("NewBGP() unexpected error = %v", err)
+	}
+
+	got, err := bgp.Reset(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("BGP.Reset() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("BGP.Reset() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check BGP feature disablement
+	update1, ok := got[0].(gnmiext.EditingUpdate)
+	if !ok {
+		t.Errorf("BGP.Reset() expected first update to be EditingUpdate")
+		return
+	}
+	if update1.XPath != "System/fm-items/bgp-items" {
+		t.Errorf("BGP.Reset() expected XPath 'System/fm-items/bgp-items', got %v", update1.XPath)
+	}
+
+	bgpItems, ok := update1.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_BgpItems)
+	if !ok {
+		t.Errorf("BGP.Reset() expected value to be *nxos.Cisco_NX_OSDevice_System_FmItems_BgpItems")
+		return
+	}
+	if bgpItems.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled {
+		t.Errorf("BGP.Reset() expected BGP AdminSt to be disabled")
+	}
+
+	// Check BGP deletion
+	update2, ok := got[1].(gnmiext.DeletingUpdate)
+	if !ok {
+		t.Errorf("BGP.Reset() expected second update to be DeletingUpdate")
+		return
+	}
+	if update2.XPath != "System/bgp-items" {
+		t.Errorf("BGP.Reset() expected XPath 'System/bgp-items', got %v", update2.XPath)
+	}
+}
+
+func TestAddressFamily_toYGOT(t *testing.T) {
+	tests := []struct {
+		name string
+		af   AddressFamily
+		want *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList
+	}{
+		{
+			name: "default L2EVPN",
+			af:   &L2EVPN{},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{
+				Type: nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+			},
+		},
+		{
+			name: "L2EVPN with maximum paths",
+			af:   &L2EVPN{MaximumPaths: 4},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				MaxExtEcmp: ygot.Uint8(4),
+			},
+		},
+		{
+			name: "L2EVPN with retain route target all",
+			af:   &L2EVPN{RetainRouteTarget: "all"},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{
+				Type:           nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				RetainRttAll:   nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				RetainRttRtMap: ygot.String("DME_UNSET_PROPERTY_MARKER"),
+			},
+		},
+		{
+			name: "L2EVPN with retain route target map",
+			af:   &L2EVPN{RetainRouteTarget: "my-route-map"},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{
+				Type:           nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				RetainRttAll:   nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				RetainRttRtMap: ygot.String("my-route-map"),
+			},
+		},
+		{
+			name: "IPv4Unicast",
+			af:   &IPv4Unicast{},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{
+				Type: nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv4_ucast,
+			},
+		},
+		{
+			name: "IPv6Unicast",
+			af:   &IPv6Unicast{},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_AfItems_DomAfList{
+				Type: nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv6_ucast,
+			},
+		},
+	}
+
+	for _, tests := range tests {
+		t.Run(tests.name, func(t *testing.T) {
+			got := tests.af.toYGOT()
+			if !reflect.DeepEqual(got, tests.want) {
+				t.Errorf("%T.toYGOT() = %+v, want %+v", tests.af, got, tests.want)
+			}
+		})
+	}
+}
+
+func TestNewBGPPeer(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		asn     uint32
+		srcIf   string
+		opts    []BGPPeerOption
+		wantErr bool
+	}{
+		{
+			name:    "valid BGP peer",
+			addr:    "192.168.1.2",
+			asn:     65002,
+			srcIf:   "loopback0",
+			wantErr: false,
+		},
+		{
+			name:    "empty address",
+			addr:    "",
+			asn:     65002,
+			srcIf:   "loopback0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid address format",
+			addr:    "invalid-ip",
+			asn:     65002,
+			srcIf:   "loopback0",
+			wantErr: true,
+		},
+		{
+			name:    "zero ASN",
+			addr:    "192.168.1.2",
+			asn:     0,
+			srcIf:   "loopback0",
+			wantErr: true,
+		},
+		{
+			name:    "ASN too large",
+			addr:    "192.168.1.2",
+			asn:     65536,
+			srcIf:   "loopback0",
+			wantErr: true,
+		},
+		{
+			name:    "empty source interface",
+			addr:    "192.168.1.2",
+			asn:     65002,
+			srcIf:   "",
+			wantErr: true,
+		},
+		{
+			name:    "with description",
+			addr:    "192.168.1.2",
+			asn:     65002,
+			srcIf:   "loopback0",
+			opts:    []BGPPeerOption{WithDescription("test peer")},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			peer, err := NewBGPPeer(test.addr, test.asn, test.srcIf, test.opts...)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewBGPPeer() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("NewBGPPeer() unexpected error = %v", err)
+				return
+			}
+			if peer == nil {
+				t.Errorf("NewBGPPeer() returned nil BGPPeer instance")
+				return
+			}
+			if peer.AsNumber != "65002" {
+				t.Errorf("NewBGPPeer() AsNumber = %v, want %v", peer.AsNumber, "65002")
+			}
+			expectedIP := netip.MustParseAddr(test.addr)
+			if peer.Addr != expectedIP {
+				t.Errorf("NewBGPPeer() Addr = %v, want %v", peer.Addr, expectedIP)
+			}
+			if peer.SrcIf != test.srcIf {
+				t.Errorf("NewBGPPeer() SrcIf = %v, want %v", peer.SrcIf, test.srcIf)
+			}
+		})
+	}
+}
+
+func TestWithDescription(t *testing.T) {
+	tests := []struct {
+		name    string
+		desc    string
+		wantErr bool
+	}{
+		{
+			name:    "valid description",
+			desc:    "test peer description",
+			wantErr: false,
+		},
+		{
+			name:    "empty description",
+			desc:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			peer := &BGPPeer{}
+			opt := WithDescription(test.desc)
+			err := opt(peer)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithDescription() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithDescription() unexpected error = %v", err)
+				return
+			}
+			if peer.Desc != test.desc {
+				t.Errorf("WithDescription() Desc = %v, want %v", peer.Desc, test.desc)
+			}
+		})
+	}
+}
+
+func TestWithPeerAddressFamily(t *testing.T) {
+	tests := []struct {
+		name    string
+		af      PeerAddressFamily
+		wantErr bool
+	}{
+		{
+			name:    "nil address family",
+			af:      nil,
+			wantErr: true,
+		},
+		{
+			name:    "valid PeerL2EVPN",
+			af:      &PeerL2EVPN{},
+			wantErr: false,
+		},
+		{
+			name:    "valid PeerIPv4Unicast",
+			af:      &PeerIPv4Unicast{},
+			wantErr: false,
+		},
+		{
+			name:    "valid PeerIPv6Unicast",
+			af:      &PeerIPv6Unicast{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			peer := &BGPPeer{}
+			opt := WithPeerAddressFamily(test.af)
+			err := opt(peer)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithPeerAddressFamily() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithPeerAddressFamily() unexpected error = %v", err)
+				return
+			}
+			if len(peer.AddressFamilies) != 1 {
+				t.Errorf("WithPeerAddressFamily() expected 1 address family, got %d", len(peer.AddressFamilies))
+			}
+		})
+	}
+}
+
+func TestWithPeerAddressFamily_Duplicate(t *testing.T) {
+	peer := &BGPPeer{}
+	af1 := &PeerIPv4Unicast{}
+	af2 := &PeerIPv4Unicast{}
+
+	// Add first address family
+	opt1 := WithPeerAddressFamily(af1)
+	if err := opt1(peer); err != nil {
+		t.Fatalf("WithPeerAddressFamily() unexpected error = %v", err)
+	}
+
+	// Try to add duplicate address family
+	opt2 := WithPeerAddressFamily(af2)
+	err := opt2(peer)
+	if err == nil {
+		t.Errorf("WithPeerAddressFamily() expected error for duplicate address family, got nil")
+		return
+	}
+	expectedErr := "bgp peer: address family *bgp.PeerIPv4Unicast already exists"
+	if err.Error() != expectedErr {
+		t.Errorf("WithPeerAddressFamily() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestBGPPeer_ToYGOT_MissingBGPInstance(t *testing.T) {
+	peer, err := NewBGPPeer("192.168.1.2", 65002, "loopback0")
+	if err != nil {
+		t.Fatalf("NewBGPPeer() unexpected error = %v", err)
+	}
+
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			return gnmiext.ErrNil
+		},
+	}
+
+	_, err = peer.ToYGOT(client)
+	if err == nil {
+		t.Errorf("BGPPeer.ToYGOT() expected error for missing BGP instance, got nil")
+		return
+	}
+	if !errors.Is(err, ErrMissingBGPInstance) {
+		t.Errorf("BGPPeer.ToYGOT() error = %v, want %v", err, ErrMissingBGPInstance)
+	}
+}
+
+func TestBGPPeer_ToYGOT_GetError(t *testing.T) {
+	peer, err := NewBGPPeer("192.168.1.2", 65002, "loopback0")
+	if err != nil {
+		t.Fatalf("NewBGPPeer() unexpected error = %v", err)
+	}
+
+	expectedErr := errors.New("get error")
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			return expectedErr
+		},
+	}
+
+	_, err = peer.ToYGOT(client)
+	if err == nil {
+		t.Errorf("BGPPeer.ToYGOT() expected error, got nil")
+		return
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("BGPPeer.ToYGOT() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestBGPPeer_ToYGOT_Success(t *testing.T) {
+	peer, err := NewBGPPeer("192.168.1.2", 65002, "loopback0", WithDescription("test peer"))
+	if err != nil {
+		t.Fatalf("NewBGPPeer() unexpected error = %v", err)
+	}
+
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			if xpath != "System/bgp-items/inst-items" {
+				t.Errorf("BGPPeer.ToYGOT() unexpected xpath = %v", xpath)
+			}
+			// Simulate existing BGP instance
+			inst := dest.(*nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems)
+			inst.GetOrCreateDomItems().GetOrCreateDomList("default")
+			return nil
+		},
+	}
+
+	got, err := peer.ToYGOT(client)
+	if err != nil {
+		t.Errorf("BGPPeer.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 1 {
+		t.Errorf("BGPPeer.ToYGOT() expected 1 update, got %d", len(got))
+		return
+	}
+
+	update, ok := got[0].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("BGPPeer.ToYGOT() expected update to be ReplacingUpdate")
+		return
+	}
+
+	expectedXPath := "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=192.168.1.2]"
+	if update.XPath != expectedXPath {
+		t.Errorf("BGPPeer.ToYGOT() expected XPath %v, got %v", expectedXPath, update.XPath)
+	}
+
+	peerList, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList)
+	if !ok {
+		t.Errorf("BGPPeer.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList")
+		return
+	}
+
+	if *peerList.Asn != "65002" {
+		t.Errorf("BGPPeer.ToYGOT() expected ASN '65002', got %v", *peerList.Asn)
+	}
+	if peerList.AsnType != nxos.Cisco_NX_OSDevice_Bgp_PeerAsnType_none {
+		t.Errorf("BGPPeer.ToYGOT() expected ASN type to be none")
+	}
+	if *peerList.Name != "test peer" {
+		t.Errorf("BGPPeer.ToYGOT() expected name 'test peer', got %v", *peerList.Name)
+	}
+	if *peerList.SrcIf != "loopback0" {
+		t.Errorf("BGPPeer.ToYGOT() expected source interface 'loopback0', got %v", *peerList.SrcIf)
+	}
+}
+
+func TestBGPPeer_Reset(t *testing.T) {
+	peer, err := NewBGPPeer("192.168.1.2", 65002, "loopback0")
+	if err != nil {
+		t.Fatalf("NewBGPPeer() unexpected error = %v", err)
+	}
+
+	got, err := peer.Reset(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("BGPPeer.Reset() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 1 {
+		t.Errorf("BGPPeer.Reset() expected 1 update, got %d", len(got))
+		return
+	}
+
+	update, ok := got[0].(gnmiext.DeletingUpdate)
+	if !ok {
+		t.Errorf("BGPPeer.Reset() expected update to be DeletingUpdate")
+		return
+	}
+
+	expectedXPath := "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=192.168.1.2]"
+	if update.XPath != expectedXPath {
+		t.Errorf("BGPPeer.Reset() expected XPath %v, got %v", expectedXPath, update.XPath)
+	}
+}
+
+func TestPeerAddressFamily_toYGOT(t *testing.T) {
+	tests := []struct {
+		name string
+		af   PeerAddressFamily
+		want *nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList
+	}{
+		{
+			name: "default PeerL2EVPN",
+			af:   &PeerL2EVPN{},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				SendComStd: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				SendComExt: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				Ctrl:       ygot.String("DME_UNSET_PROPERTY_MARKER"),
+			},
+		},
+		{
+			name: "PeerL2EVPN with standard community",
+			af:   &PeerL2EVPN{SendStandardCommunity: true},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				SendComStd: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				SendComExt: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				Ctrl:       ygot.String("DME_UNSET_PROPERTY_MARKER"),
+			},
+		},
+		{
+			name: "PeerL2EVPN with extended community",
+			af:   &PeerL2EVPN{SendExtendedCommunity: true},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				SendComStd: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				SendComExt: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				Ctrl:       ygot.String("DME_UNSET_PROPERTY_MARKER"),
+			},
+		},
+		{
+			name: "PeerL2EVPN with both communities",
+			af:   &PeerL2EVPN{SendStandardCommunity: true, SendExtendedCommunity: true},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				SendComStd: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				SendComExt: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				Ctrl:       ygot.String("DME_UNSET_PROPERTY_MARKER"),
+			},
+		},
+		{
+			name: "PeerL2EVPN with route reflector client",
+			af:   &PeerL2EVPN{RouteReflectorClient: true},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				SendComStd: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				SendComExt: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_disabled,
+				Ctrl:       ygot.String("rr-client"),
+			},
+		},
+		{
+			name: "PeerL2EVPN with all options",
+			af:   &PeerL2EVPN{SendStandardCommunity: true, SendExtendedCommunity: true, RouteReflectorClient: true},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type:       nxos.Cisco_NX_OSDevice_Bgp_AfT_l2vpn_evpn,
+				SendComStd: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				SendComExt: nxos.Cisco_NX_OSDevice_Bgp_AdminSt_enabled,
+				Ctrl:       ygot.String("rr-client"),
+			},
+		},
+		{
+			name: "PeerIPv4Unicast",
+			af:   &PeerIPv4Unicast{},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type: nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv4_ucast,
+			},
+		},
+		{
+			name: "PeerIPv6Unicast",
+			af:   &PeerIPv6Unicast{},
+			want: &nxos.Cisco_NX_OSDevice_System_BgpItems_InstItems_DomItems_DomList_PeerItems_PeerList_AfItems_PeerAfList{
+				Type: nxos.Cisco_NX_OSDevice_Bgp_AfT_ipv6_ucast,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.af.toYGOT()
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("%T.toYGOT() = %+v, want %+v", test.af, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/provider/cisco/nxos/gnmiext/client.go
+++ b/internal/provider/cisco/nxos/gnmiext/client.go
@@ -349,8 +349,7 @@ func (c *client) applyEditingUpdate(ctx context.Context, update *EditingUpdate) 
 	}
 
 	got := reflect.New(reflect.TypeOf(update.Value).Elem()).Interface().(ygot.GoStruct)
-	err := c.Get(ctx, update.XPath, got)
-	if err != nil && !errors.Is(err, ErrNil) {
+	if err := c.Get(ctx, update.XPath, got); err != nil && !errors.Is(err, ErrNil) {
 		return fmt.Errorf("gnmiext: failed to reflect %s onto a ygot.GoStruct: %w", update.XPath, err)
 	}
 
@@ -531,10 +530,10 @@ func diffList(got, want ygot.GoStruct) ([]*gpb.Path, error) {
 // collect returns a list of contained list element paths for the given GoStruct.
 func collect(s ygot.GoStruct) ([]string, error) {
 	rv := reflect.ValueOf(s)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Pointer {
 		return nil, fmt.Errorf("gnmiext: expected pointer to GoStruct, got %T", s)
 	}
-	for rv.Kind() == reflect.Ptr {
+	for rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
@@ -557,7 +556,7 @@ func collect(s ygot.GoStruct) ([]string, error) {
 		}
 		path := strings.Join(sp[0], "/")
 
-		if f.Kind() == reflect.Ptr {
+		if f.Kind() == reflect.Pointer {
 			gs, ok := f.Interface().(ygot.GoStruct)
 			if !ok {
 				continue


### PR DESCRIPTION
This patch adds the implementation for configuring a BGP process and related peer configuration on a Cisco NX-OS Device. 


It supports the following config:
```
feature bgp
!
router bgp 65000
  router-id 1.1.1.1
  address-family l2vpn evpn
    maximum-paths 8
    retain route-target all
  neighbor 1.1.1.2
    description EVPN peering with spine
    remote-as 65000
    update-source loopback0
    address-family l2vpn evpn
      send-community
      send-community extended
      route-reflector-client
```