### PR TITLE
cisco-nxos-provider: add `PIM` configuration

### DIFF
--- a/internal/provider/cisco/nxos/iface/getter.go
+++ b/internal/provider/cisco/nxos/iface/getter.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+// Exists checks if the interface with the given name exists on the device.
+func Exists(ctx context.Context, client gnmiext.Client, name string) (bool, error) {
+	if name == "" {
+		return false, errors.New("interface name must not be empty")
+	}
+	var err error
+	switch {
+	case ethernetRe.MatchString(name):
+		matches := ethernetRe.FindStringSubmatch(name)
+		var inst nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList
+		err = client.Get(ctx, "System/intf-items/phys-items/PhysIf-list[id=eth"+matches[2]+"]", &inst)
+	case loopbackRe.MatchString(name):
+		matches := loopbackRe.FindStringSubmatch(name)
+		var inst nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList
+		err = client.Get(ctx, "System/intf-items/lb-items/LbRtdIf-list[id=lo"+matches[2]+"]", &inst)
+	default:
+		return false, fmt.Errorf(`unsupported interface format %q, expected (Ethernet|eth)\d+/\d+ or (Loopback|lo)\d+`, name)
+	}
+	if err != nil {
+		if errors.Is(err, gnmiext.ErrNil) || errors.Is(err, gnmiext.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check interface existence: %w", err)
+	}
+	return true, nil
+}

--- a/internal/provider/cisco/nxos/iface/getter_test.go
+++ b/internal/provider/cisco/nxos/iface/getter_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+func TestExists(t *testing.T) {
+	tests := []struct {
+		name          string
+		interfaceName string
+		fn            func(ctx context.Context, xpath string, dest ygot.GoStruct) error
+		wantExists    bool
+		wantErr       bool
+	}{
+		// Valid Ethernet interface cases
+		{
+			name:          "ethernet interface exists - full name",
+			interfaceName: "Ethernet1/1",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/phys-items/PhysIf-list[id=eth1/1]" {
+					return nil
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: true,
+			wantErr:    false,
+		},
+		{
+			name:          "ethernet interface exists - short name",
+			interfaceName: "eth10/24",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/phys-items/PhysIf-list[id=eth10/24]" {
+					return nil
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: true,
+			wantErr:    false,
+		},
+		{
+			name:          "ethernet interface does not exist - ErrNil",
+			interfaceName: "Ethernet2/2",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/phys-items/PhysIf-list[id=eth2/2]" {
+					return gnmiext.ErrNil
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: false,
+			wantErr:    false,
+		},
+		{
+			name:          "ethernet interface does not exist - ErrNotFound",
+			interfaceName: "eth3/3",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/phys-items/PhysIf-list[id=eth3/3]" {
+					return gnmiext.ErrNotFound
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: false,
+			wantErr:    false,
+		},
+
+		// Valid Loopback interface cases
+		{
+			name:          "loopback interface exists - full name",
+			interfaceName: "Loopback1",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/lb-items/LbRtdIf-list[id=lo1]" {
+					return nil
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: true,
+			wantErr:    false,
+		},
+		{
+			name:          "loopback interface exists - short name",
+			interfaceName: "lo100",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/lb-items/LbRtdIf-list[id=lo100]" {
+					return nil
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: true,
+			wantErr:    false,
+		},
+		{
+			name:          "loopback interface does not exist - ErrNil",
+			interfaceName: "Loopback2",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/lb-items/LbRtdIf-list[id=lo2]" {
+					return gnmiext.ErrNil
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: false,
+			wantErr:    false,
+		},
+		{
+			name:          "loopback interface does not exist - ErrNotFound",
+			interfaceName: "lo3",
+			fn: func(_ context.Context, xpath string, _ ygot.GoStruct) error {
+				if xpath == "System/intf-items/lb-items/LbRtdIf-list[id=lo3]" {
+					return gnmiext.ErrNotFound
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: false,
+			wantErr:    false,
+		},
+
+		// Error cases
+		{
+			name:          "empty interface name",
+			interfaceName: "",
+			fn: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+				return errors.New("should not be called")
+			},
+			wantExists: false,
+			wantErr:    true,
+		},
+		{
+			name:          "unsupported interface format",
+			interfaceName: "Foobar1/1",
+			fn: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+				return errors.New("should not be called")
+			},
+			wantExists: false,
+			wantErr:    true,
+		},
+		{
+			name:          "client error",
+			interfaceName: "Ethernet1/1",
+			fn: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+				if xpath == "System/intf-items/phys-items/PhysIf-list[id=eth1/1]" {
+					return errors.New("connection failed")
+				}
+				return errors.New("unexpected xpath")
+			},
+			wantExists: false,
+			wantErr:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &gnmiext.ClientMock{GetFunc: test.fn}
+			exists, err := Exists(context.Background(), mock, test.interfaceName)
+			if exists != test.wantExists {
+				t.Errorf("Exists(%q) = %v, want %v", test.interfaceName, exists, test.wantExists)
+			}
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("Exists(%q) expected error, but got none", test.interfaceName)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Exists(%q) unexpected error: %v", test.interfaceName, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/cisco/nxos/iface/name.go
+++ b/internal/provider/cisco/nxos/iface/name.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var (
+	ethernetRe = regexp.MustCompile(`(?i)^(ethernet|eth)(\d+/\d+)$`)
+	loopbackRe = regexp.MustCompile(`(?i)^(loopback|lo)(\d+)$`)
+)
+
+// ShortName converts a full interface name to its short form.
+// If the name is already in short form, it is returned as is.
+func ShortName(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("interface name must not be empty")
+	}
+	switch {
+	case ethernetRe.MatchString(name):
+		matches := ethernetRe.FindStringSubmatch(name)
+		return "eth" + matches[2], nil
+	case loopbackRe.MatchString(name):
+		matches := loopbackRe.FindStringSubmatch(name)
+		return "lo" + matches[2], nil
+	default:
+		return "", fmt.Errorf(`unsupported interface format %q, expected (Ethernet|eth)\d+/\d+ or (Loopback|lo)\d+`, name)
+	}
+}

--- a/internal/provider/cisco/nxos/iface/name_test.go
+++ b/internal/provider/cisco/nxos/iface/name_test.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iface
+
+import (
+	"testing"
+)
+
+func TestShortName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		// Valid Ethernet interface names
+		{
+			name:     "ethernet full name",
+			input:    "Ethernet1/1",
+			expected: "eth1/1",
+			wantErr:  false,
+		},
+		{
+			name:     "ethernet short name",
+			input:    "eth1/1",
+			expected: "eth1/1",
+			wantErr:  false,
+		},
+		{
+			name:     "ethernet with multiple digits",
+			input:    "Ethernet10/24",
+			expected: "eth10/24",
+			wantErr:  false,
+		},
+
+		// Valid Loopback interface names
+		{
+			name:     "loopback full name",
+			input:    "Loopback1",
+			expected: "lo1",
+			wantErr:  false,
+		},
+		{
+			name:     "loopback short name",
+			input:    "lo1",
+			expected: "lo1",
+			wantErr:  false,
+		},
+		{
+			name:     "loopback with multiple digits",
+			input:    "Loopback100",
+			expected: "lo100",
+			wantErr:  false,
+		},
+
+		// Error cases
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "unsupported interface type",
+			input:    "Foobar1/1",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid ethernet format - missing slash",
+			input:    "Ethernet11",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid loopback format",
+			input:    "Loopback1/1",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid format",
+			input:    "1/1",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "random string",
+			input:    "random",
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := ShortName(test.input)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("ShortName(%q) expected error, but got none", test.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ShortName(%q) unexpected error: %v", test.input, err)
+				return
+			}
+			if result != test.expected {
+				t.Errorf("ShortName(%q) = %q, expected %q", test.input, result, test.expected)
+			}
+		})
+	}
+}

--- a/internal/provider/cisco/nxos/pim/pim.go
+++ b/internal/provider/cisco/nxos/pim/pim.go
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pim provides a representation of Protocol Independent Multicast (PIM) configuration for Cisco NX-OS devices.
+package pim
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"regexp"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+var _ gnmiext.DeviceConf = (*RendezvousPoint)(nil)
+
+type RendezvousPoint struct {
+	// Addr is the IP address of the rendezvous point.
+	Addr netip.Addr
+	// Group is the static multicast address range for which this rendezvous point is configured.
+	Group netip.Prefix
+	// Vrf is the VRF in which to configure the rendezvous point, e.g., "default".
+	Vrf string
+}
+
+func NewRendezvousPoint(addr string, opts ...RendezvousPointOption) (*RendezvousPoint, error) {
+	if addr == "" {
+		return nil, errors.New("pim: rendezvous point address cannot be empty")
+	}
+	a, err := netip.ParseAddr(addr)
+	if err != nil {
+		return nil, fmt.Errorf("pim: failed to parse rendezvous point address %q: %w", addr, err)
+	}
+	if !a.IsValid() || !a.Is4() {
+		return nil, fmt.Errorf("pim: rendezvous point address %q is not a valid IPv4 address", addr)
+	}
+	rp := &RendezvousPoint{
+		Addr: a,
+		Vrf:  "default",
+	}
+	for _, opt := range opts {
+		if err := opt(rp); err != nil {
+			return nil, err
+		}
+	}
+	return rp, nil
+}
+
+type RendezvousPointOption func(*RendezvousPoint) error
+
+// WithGroupList adds a static group range to the rendezvous point configuration.
+func WithGroupList(group string) RendezvousPointOption {
+	return func(p *RendezvousPoint) error {
+		if group == "" {
+			return errors.New("pim: group list cannot be empty")
+		}
+		prefix, err := netip.ParsePrefix(group)
+		if err != nil {
+			return fmt.Errorf("pim: failed to parse group list %q: %w", group, err)
+		}
+		if !prefix.IsValid() || !prefix.Addr().Is4() {
+			return fmt.Errorf("pim: group list %q is not a valid IPv4 address prefix", group)
+		}
+		p.Group = prefix
+		return nil
+	}
+}
+
+// WithRendezvousPointVRF configures the VRF in which to configure the rendezvous point.
+func WithRendezvousPointVRF(vrf string) RendezvousPointOption {
+	return func(p *RendezvousPoint) error {
+		if vrf == "" {
+			return errors.New("pim: vrf cannot be empty")
+		}
+		p.Vrf = vrf
+		return nil
+	}
+}
+
+// CIDR returns the CIDR notation ("<ip>/<bits>") of the rendezvous points IPv4 address.
+// It returns an error if the address is not a valid IPv4 address.
+func (p *RendezvousPoint) CIDR() (string, error) {
+	if !p.Addr.IsValid() || !p.Addr.Is4() {
+		return "", fmt.Errorf("pim: rendezvous point address %q is not a valid IPv4 address", p.Addr)
+	}
+	prefix, err := p.Addr.Prefix(32)
+	if err != nil {
+		return "", fmt.Errorf("pim: failed to create prefix for rendezvous point address %q: %w", p.Addr, err)
+	}
+	return prefix.String(), nil
+}
+
+func (p *RendezvousPoint) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	cidr, err := p.CIDR()
+	if err != nil {
+		return nil, err
+	}
+	rp := &nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList{}
+	rp.Addr = ygot.String(cidr)
+	if p.Group.IsValid() {
+		list := rp.GetOrCreateRpgrplistItems().GetOrCreateRPGrpListList(p.Group.String())
+		list.Bidir = ygot.Bool(false)
+		list.Override = ygot.Bool(false)
+	}
+	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/pim-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_PimItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		},
+		gnmiext.ReplacingUpdate{
+			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + p.Vrf + "]/staticrp-items/rp-items/StaticRP-list[addr=" + cidr + "]",
+			Value: rp,
+		},
+	}, nil
+}
+
+func (p *RendezvousPoint) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	cidr, err := p.CIDR()
+	if err != nil {
+		return nil, err
+	}
+	return []gnmiext.Update{
+		gnmiext.DeletingUpdate{
+			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + p.Vrf + "]/staticrp-items/rp-items/StaticRP-list[addr=" + cidr + "]",
+		},
+	}, nil
+}
+
+var _ gnmiext.DeviceConf = (*AnycastPeer)(nil)
+
+// AnycastPeer represents a PIM anycast rendezvous point peer configuration.
+// It is used to configure anycast rendezvous point peers for redundancy.
+type AnycastPeer struct {
+	Addr netip.Addr
+	// Vrf is the VRF in which to configure the anycast peer, e.g., "default".
+	Vrf string
+}
+
+func NewAnycastPeer(addr string, opts ...AnycastPeerOption) (*AnycastPeer, error) {
+	if addr == "" {
+		return nil, errors.New("pim: anycast rendezvous point address cannot be empty")
+	}
+	a, err := netip.ParseAddr(addr)
+	if err != nil {
+		return nil, fmt.Errorf("pim: failed to parse anycast rendezvous point address %q: %w", addr, err)
+	}
+	if !a.IsValid() || !a.Is4() {
+		return nil, fmt.Errorf("pim: anycast rendezvous point address %q is not a valid IPv4 address", addr)
+	}
+	ap := &AnycastPeer{
+		Addr: a,
+		Vrf:  "default",
+	}
+	for _, opt := range opts {
+		if err := opt(ap); err != nil {
+			return nil, err
+		}
+	}
+	return ap, nil
+}
+
+type AnycastPeerOption func(*AnycastPeer) error
+
+// WithAnycastPeerVRF configures the VRF in which to configure the anycast peer.
+func WithAnycastPeerVRF(vrf string) AnycastPeerOption {
+	return func(a *AnycastPeer) error {
+		if vrf == "" {
+			return errors.New("pim: vrf cannot be empty")
+		}
+		a.Vrf = vrf
+		return nil
+	}
+}
+
+// CIDR returns the CIDR notation ("<ip>/<bits>") of the anycast rendezvous point IPv4 address.
+// It returns an error if the address is not a valid IPv4 address.
+func (a *AnycastPeer) CIDR() (string, error) {
+	if !a.Addr.IsValid() || !a.Addr.Is4() {
+		return "", fmt.Errorf("pim: anycast rendezvous point address %q is not a valid IPv4 address", a.Addr)
+	}
+	prefix, err := a.Addr.Prefix(32)
+	if err != nil {
+		return "", fmt.Errorf("pim: failed to create prefix for anycast rendezvous point address %q: %w", a.Addr, err)
+	}
+	return prefix.String(), nil
+}
+
+func (a *AnycastPeer) ToYGOT(client gnmiext.Client) ([]gnmiext.Update, error) {
+	cidr, err := a.CIDR()
+	if err != nil {
+		return nil, err
+	}
+	ap := &nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_AcastrpfuncItems_PeerItems_AcastRPPeerList{}
+	ap.Addr = ygot.String(cidr)
+	ap.RpSetAddr = ygot.String(cidr)
+	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/pim-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_PimItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		},
+		gnmiext.ReplacingUpdate{
+			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + a.Vrf + "]/acastrpfunc-items/peer-items/AcastRPPeer-list[addr=" + cidr + "][rpSetAddr=" + cidr + "]",
+			Value: ap,
+		},
+	}, nil
+}
+
+func (a *AnycastPeer) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	cidr, err := a.CIDR()
+	if err != nil {
+		return nil, err
+	}
+	return []gnmiext.Update{
+		gnmiext.DeletingUpdate{
+			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + a.Vrf + "]/acastrpfunc-items/peer-items/AcastRPPeer-list[addr=" + cidr + "][rpSetAddr=" + cidr + "]",
+		},
+	}, nil
+}
+
+var _ gnmiext.DeviceConf = (*Interface)(nil)
+
+// Interface represents a PIM interface configuration. It is used to configure PIM on a specific interface.
+type Interface struct {
+	// Name is the short name of the interface, e.g., "eth1/2" or "lo0".
+	Name string
+	// SparseMode indicates whether the interface should be configured for sparse mode.
+	SparseMode bool
+	// Vrf is the VRF in which to configure PIM, e.g., "default".
+	Vrf string
+}
+
+var (
+	ethernetRe = regexp.MustCompile(`(?i)^(ethernet|eth)(\d+/\d+)$`)
+	loopbackRe = regexp.MustCompile(`(?i)^(loopback|lo)(\d+)$`)
+)
+
+func NewInterface(name string, opts ...InterfaceOption) (*Interface, error) {
+	if name == "" {
+		return nil, errors.New("pim: interface name cannot be empty")
+	}
+
+	// Validate and convert interface name to short form
+	var shortName string
+	switch {
+	case ethernetRe.MatchString(name):
+		matches := ethernetRe.FindStringSubmatch(name)
+		shortName = "eth" + matches[2]
+	case loopbackRe.MatchString(name):
+		matches := loopbackRe.FindStringSubmatch(name)
+		shortName = "lo" + matches[2]
+	default:
+		return nil, fmt.Errorf(`pim: unsupported interface format %q, expected (Ethernet|eth)\d+/\d+ or (Loopback|lo)\d+`, name)
+	}
+
+	i := &Interface{
+		Name: shortName,
+		Vrf:  "default",
+	}
+	for _, opt := range opts {
+		if err := opt(i); err != nil {
+			return nil, err
+		}
+	}
+	return i, nil
+}
+
+// InterfaceOption is a function that can be used to configure an Interface.
+type InterfaceOption func(*Interface) error
+
+// WithSparseMode configures the interface for PIM sparse mode.
+func WithSparseMode(enable bool) InterfaceOption {
+	return func(i *Interface) error {
+		i.SparseMode = enable
+		return nil
+	}
+}
+
+// WithInterfaceVRF configures the VRF in which to configure PIM on the interface.
+func WithInterfaceVRF(vrf string) InterfaceOption {
+	return func(i *Interface) error {
+		if vrf == "" {
+			return errors.New("pim: vrf cannot be empty")
+		}
+		i.Vrf = vrf
+		return nil
+	}
+}
+
+// ErrMissingInterface is returned when the specified interface does not exist on the device.
+// This can happen when trying to configure PIM on an interface that is not present in the
+// device's configuration (yet).
+var ErrMissingInterface = errors.New("pim: missing interface")
+
+func (i *Interface) ToYGOT(client gnmiext.Client) ([]gnmiext.Update, error) {
+	var inst nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList
+	err := client.Get(context.Background(), "System/intf-items/lb-items/LbRtdIf-list/[id="+i.Name+"]", &inst)
+	if err != nil {
+		if errors.Is(err, gnmiext.ErrNil) {
+			return nil, ErrMissingInterface
+		}
+		return nil, fmt.Errorf("pim: failed to get interface %q: %w", i.Name, err)
+	}
+	intf := &nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList{}
+	intf.PopulateDefaults()
+	intf.Ctrl = ygot.String("border")
+	intf.PimSparseMode = ygot.Bool(i.SparseMode)
+	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/pim-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_PimItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		},
+		gnmiext.EditingUpdate{
+			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + i.Vrf + "]/if-items/If-list[id=" + i.Name + "]",
+			Value: intf,
+		},
+	}, nil
+}
+
+func (i *Interface) Reset(client gnmiext.Client) ([]gnmiext.Update, error) {
+	return []gnmiext.Update{
+		gnmiext.DeletingUpdate{
+			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + i.Vrf + "]/if-items/If-list[id=" + i.Name + "]",
+		},
+	}, nil
+}

--- a/internal/provider/cisco/nxos/pim/pim_test.go
+++ b/internal/provider/cisco/nxos/pim/pim_test.go
@@ -1,0 +1,1139 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package pim
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+func TestNewRendezvousPoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		opts    []RendezvousPointOption
+		wantErr bool
+		wantVrf string
+	}{
+		{
+			name:    "valid rendezvous point",
+			addr:    "192.168.1.1",
+			wantErr: false,
+			wantVrf: "default",
+		},
+		{
+			name:    "empty address",
+			addr:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid address format",
+			addr:    "invalid-ip",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 address",
+			addr:    "2001:db8::1",
+			wantErr: true,
+		},
+		{
+			name:    "with group list",
+			addr:    "192.168.1.1",
+			opts:    []RendezvousPointOption{WithGroupList("224.0.0.0/4")},
+			wantErr: false,
+			wantVrf: "default",
+		},
+		{
+			name:    "with custom VRF",
+			addr:    "192.168.1.1",
+			opts:    []RendezvousPointOption{WithRendezvousPointVRF("management")},
+			wantErr: false,
+			wantVrf: "management",
+		},
+		{
+			name:    "with multiple options",
+			addr:    "192.168.1.1",
+			opts:    []RendezvousPointOption{WithGroupList("224.0.0.0/4"), WithRendezvousPointVRF("custom")},
+			wantErr: false,
+			wantVrf: "custom",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rp, err := NewRendezvousPoint(test.addr, test.opts...)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewRendezvousPoint() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("NewRendezvousPoint() unexpected error = %v", err)
+				return
+			}
+			if rp == nil {
+				t.Errorf("NewRendezvousPoint() returned nil")
+				return
+			}
+			if rp.Addr.String() != test.addr {
+				t.Errorf("NewRendezvousPoint() Addr = %v, want %v", rp.Addr, test.addr)
+			}
+			if rp.Vrf != test.wantVrf {
+				t.Errorf("NewRendezvousPoint() Vrf = %v, want %v", rp.Vrf, test.wantVrf)
+			}
+		})
+	}
+}
+
+func TestWithGroupList(t *testing.T) {
+	tests := []struct {
+		name    string
+		group   string
+		wantErr bool
+	}{
+		{
+			name:    "valid group list",
+			group:   "224.0.0.0/4",
+			wantErr: false,
+		},
+		{
+			name:    "empty group list",
+			group:   "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid group format",
+			group:   "invalid-prefix",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 group",
+			group:   "ff00::/8",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rp := &RendezvousPoint{}
+			opt := WithGroupList(test.group)
+			err := opt(rp)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithGroupList() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithGroupList() unexpected error = %v", err)
+				return
+			}
+			if rp.Group.String() != test.group {
+				t.Errorf("WithGroupList() Group = %v, want %v", rp.Group, test.group)
+			}
+		})
+	}
+}
+
+func TestWithRendezvousPointVRF(t *testing.T) {
+	tests := []struct {
+		name    string
+		vrf     string
+		wantErr bool
+	}{
+		{
+			name:    "valid VRF",
+			vrf:     "management",
+			wantErr: false,
+		},
+		{
+			name:    "empty VRF",
+			vrf:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rp := &RendezvousPoint{}
+			opt := WithRendezvousPointVRF(test.vrf)
+			err := opt(rp)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithRendezvousPointVRF() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithRendezvousPointVRF() unexpected error = %v", err)
+				return
+			}
+			if rp.Vrf != test.vrf {
+				t.Errorf("WithRendezvousPointVRF() Vrf = %v, want %v", rp.Vrf, test.vrf)
+			}
+		})
+	}
+}
+
+func TestRendezvousPoint_CIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid IPv4 address",
+			addr: "192.168.1.1",
+			want: "192.168.1.1/32",
+		},
+		{
+			name:    "invalid address",
+			addr:    "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rp, err := NewRendezvousPoint(test.addr)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewRendezvousPoint() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewRendezvousPoint() unexpected error = %v", err)
+			}
+
+			got, err := rp.CIDR()
+			if err != nil {
+				t.Errorf("RendezvousPoint.CIDR() unexpected error = %v", err)
+				return
+			}
+			if got != test.want {
+				t.Errorf("RendezvousPoint.CIDR() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRendezvousPoint_ToYGOT(t *testing.T) {
+	rp, err := NewRendezvousPoint("192.168.1.1")
+	if err != nil {
+		t.Fatalf("NewRendezvousPoint() unexpected error = %v", err)
+	}
+
+	got, err := rp.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("RendezvousPoint.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("RendezvousPoint.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check PIM feature enablement
+	update1, ok := got[0].(gnmiext.EditingUpdate)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected first update to be EditingUpdate")
+		return
+	}
+	if update1.XPath != "System/fm-items/pim-items" {
+		t.Errorf("RendezvousPoint.ToYGOT() expected XPath 'System/fm-items/pim-items', got %v", update1.XPath)
+	}
+
+	pimItems, ok := update1.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_PimItems)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_FmItems_PimItems")
+		return
+	}
+	if pimItems.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
+		t.Errorf("RendezvousPoint.ToYGOT() expected PIM AdminSt to be enabled")
+	}
+
+	// Check rendezvous point configuration
+	update2, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected second update to be ReplacingUpdate")
+		return
+	}
+
+	expectedXPath := "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items/StaticRP-list[addr=192.168.1.1/32]"
+	if update2.XPath != expectedXPath {
+		t.Errorf("RendezvousPoint.ToYGOT() expected XPath %v, got %v", expectedXPath, update2.XPath)
+	}
+
+	rpList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList")
+		return
+	}
+
+	if *rpList.Addr != "192.168.1.1/32" {
+		t.Errorf("RendezvousPoint.ToYGOT() expected Addr '192.168.1.1/32', got %v", *rpList.Addr)
+	}
+}
+
+func TestRendezvousPoint_ToYGOT_WithGroup(t *testing.T) {
+	rp, err := NewRendezvousPoint("192.168.1.1", WithGroupList("224.0.0.0/4"))
+	if err != nil {
+		t.Fatalf("NewRendezvousPoint() unexpected error = %v", err)
+	}
+
+	got, err := rp.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("RendezvousPoint.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("RendezvousPoint.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check rendezvous point configuration with group
+	update2, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected second update to be ReplacingUpdate")
+		return
+	}
+
+	rpList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList")
+		return
+	}
+
+	// Check that group list is configured
+	if rpList.RpgrplistItems == nil {
+		t.Errorf("RendezvousPoint.ToYGOT() expected RpgrplistItems to be configured")
+		return
+	}
+
+	groupList := rpList.RpgrplistItems.GetRPGrpListList("224.0.0.0/4")
+	if groupList == nil {
+		t.Errorf("RendezvousPoint.ToYGOT() expected group list '224.0.0.0/4' to be present")
+		return
+	}
+
+	if *groupList.Bidir != false {
+		t.Errorf("RendezvousPoint.ToYGOT() expected Bidir to be false")
+	}
+	if *groupList.Override != false {
+		t.Errorf("RendezvousPoint.ToYGOT() expected Override to be false")
+	}
+}
+
+func TestRendezvousPoint_ToYGOT_WithCustomVRF(t *testing.T) {
+	rp, err := NewRendezvousPoint("192.168.1.1", WithRendezvousPointVRF("management"))
+	if err != nil {
+		t.Fatalf("NewRendezvousPoint() unexpected error = %v", err)
+	}
+
+	got, err := rp.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("RendezvousPoint.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("RendezvousPoint.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check rendezvous point configuration with custom VRF
+	update2, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected second update to be ReplacingUpdate")
+		return
+	}
+
+	expectedXPath := "System/pim-items/inst-items/dom-items/Dom-list[name=management]/staticrp-items/rp-items/StaticRP-list[addr=192.168.1.1/32]"
+	if update2.XPath != expectedXPath {
+		t.Errorf("RendezvousPoint.ToYGOT() expected XPath %v, got %v", expectedXPath, update2.XPath)
+	}
+
+	rpList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList)
+	if !ok {
+		t.Errorf("RendezvousPoint.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_StaticrpItems_RpItems_StaticRPList")
+		return
+	}
+
+	if *rpList.Addr != "192.168.1.1/32" {
+		t.Errorf("RendezvousPoint.ToYGOT() expected Addr '192.168.1.1/32', got %v", *rpList.Addr)
+	}
+}
+
+func TestRendezvousPoint_Reset(t *testing.T) {
+	addr, err := netip.ParseAddr("192.168.1.1")
+	if err != nil {
+		t.Fatalf("Failed to parse address: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		rp           *RendezvousPoint
+		expectedPath string
+	}{
+		{
+			name: "default VRF",
+			rp: &RendezvousPoint{
+				Addr: addr,
+				Vrf:  "default",
+			},
+			expectedPath: "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items/StaticRP-list[addr=192.168.1.1/32]",
+		},
+		{
+			name: "custom VRF",
+			rp: &RendezvousPoint{
+				Addr: addr,
+				Vrf:  "management",
+			},
+			expectedPath: "System/pim-items/inst-items/dom-items/Dom-list[name=management]/staticrp-items/rp-items/StaticRP-list[addr=192.168.1.1/32]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.rp.Reset(&gnmiext.ClientMock{})
+			if err != nil {
+				t.Errorf("RendezvousPoint.Reset() unexpected error = %v", err)
+				return
+			}
+
+			if len(got) != 1 {
+				t.Errorf("RendezvousPoint.Reset() expected 1 update, got %d", len(got))
+				return
+			}
+
+			update, ok := got[0].(gnmiext.DeletingUpdate)
+			if !ok {
+				t.Errorf("RendezvousPoint.Reset() expected update to be DeletingUpdate")
+				return
+			}
+
+			if update.XPath != test.expectedPath {
+				t.Errorf("RendezvousPoint.Reset() expected XPath %v, got %v", test.expectedPath, update.XPath)
+			}
+		})
+	}
+}
+
+func TestNewAnycastPeer(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		opts    []AnycastPeerOption
+		wantErr bool
+		wantVrf string
+	}{
+		{
+			name:    "valid anycast peer",
+			addr:    "192.168.1.2",
+			wantErr: false,
+			wantVrf: "default",
+		},
+		{
+			name:    "empty address",
+			addr:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid address format",
+			addr:    "invalid-ip",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 address",
+			addr:    "2001:db8::1",
+			wantErr: true,
+		},
+		{
+			name:    "with custom VRF",
+			addr:    "192.168.1.2",
+			opts:    []AnycastPeerOption{WithAnycastPeerVRF("management")},
+			wantErr: false,
+			wantVrf: "management",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ap, err := NewAnycastPeer(test.addr, test.opts...)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewAnycastPeer() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("NewAnycastPeer() unexpected error = %v", err)
+				return
+			}
+			if ap == nil {
+				t.Errorf("NewAnycastPeer() returned nil")
+				return
+			}
+			if ap.Addr.String() != test.addr {
+				t.Errorf("NewAnycastPeer() Addr = %v, want %v", ap.Addr, test.addr)
+			}
+			if ap.Vrf != test.wantVrf {
+				t.Errorf("NewAnycastPeer() Vrf = %v, want %v", ap.Vrf, test.wantVrf)
+			}
+		})
+	}
+}
+
+func TestWithAnycastPeerVRF(t *testing.T) {
+	tests := []struct {
+		name    string
+		vrf     string
+		wantErr bool
+	}{
+		{
+			name:    "valid VRF",
+			vrf:     "management",
+			wantErr: false,
+		},
+		{
+			name:    "empty VRF",
+			vrf:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ap := &AnycastPeer{}
+			opt := WithAnycastPeerVRF(test.vrf)
+			err := opt(ap)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithAnycastPeerVRF() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithAnycastPeerVRF() unexpected error = %v", err)
+				return
+			}
+			if ap.Vrf != test.vrf {
+				t.Errorf("WithAnycastPeerVRF() Vrf = %v, want %v", ap.Vrf, test.vrf)
+			}
+		})
+	}
+}
+
+func TestAnycastPeer_CIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid IPv4 address",
+			addr: "192.168.1.2",
+			want: "192.168.1.2/32",
+		},
+		{
+			name:    "invalid address",
+			addr:    "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ap, err := NewAnycastPeer(test.addr)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewAnycastPeer() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewAnycastPeer() unexpected error = %v", err)
+			}
+
+			got, err := ap.CIDR()
+			if err != nil {
+				t.Errorf("AnycastPeer.CIDR() unexpected error = %v", err)
+				return
+			}
+			if got != test.want {
+				t.Errorf("AnycastPeer.CIDR() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAnycastPeer_ToYGOT(t *testing.T) {
+	ap, err := NewAnycastPeer("192.168.1.2")
+	if err != nil {
+		t.Fatalf("NewAnycastPeer() unexpected error = %v", err)
+	}
+
+	got, err := ap.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("AnycastPeer.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("AnycastPeer.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check PIM feature enablement
+	update1, ok := got[0].(gnmiext.EditingUpdate)
+	if !ok {
+		t.Errorf("AnycastPeer.ToYGOT() expected first update to be EditingUpdate")
+		return
+	}
+	if update1.XPath != "System/fm-items/pim-items" {
+		t.Errorf("AnycastPeer.ToYGOT() expected XPath 'System/fm-items/pim-items', got %v", update1.XPath)
+	}
+
+	pimItems, ok := update1.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_PimItems)
+	if !ok {
+		t.Errorf("AnycastPeer.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_FmItems_PimItems")
+		return
+	}
+	if pimItems.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
+		t.Errorf("AnycastPeer.ToYGOT() expected PIM AdminSt to be enabled")
+	}
+
+	// Check anycast peer configuration
+	update2, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("AnycastPeer.ToYGOT() expected second update to be ReplacingUpdate")
+		return
+	}
+
+	expectedXPath := "System/pim-items/inst-items/dom-items/Dom-list[name=default]/acastrpfunc-items/peer-items/AcastRPPeer-list[addr=192.168.1.2/32][rpSetAddr=192.168.1.2/32]"
+	if update2.XPath != expectedXPath {
+		t.Errorf("AnycastPeer.ToYGOT() expected XPath %v, got %v", expectedXPath, update2.XPath)
+	}
+
+	peerList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_AcastrpfuncItems_PeerItems_AcastRPPeerList)
+	if !ok {
+		t.Errorf("AnycastPeer.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_AcastrpfuncItems_PeerItems_AcastRPPeerList")
+		return
+	}
+
+	if *peerList.Addr != "192.168.1.2/32" {
+		t.Errorf("AnycastPeer.ToYGOT() expected Addr '192.168.1.2/32', got %v", *peerList.Addr)
+	}
+	if *peerList.RpSetAddr != "192.168.1.2/32" {
+		t.Errorf("AnycastPeer.ToYGOT() expected RpSetAddr '192.168.1.2/32', got %v", *peerList.RpSetAddr)
+	}
+}
+
+func TestAnycastPeer_ToYGOT_WithCustomVRF(t *testing.T) {
+	ap, err := NewAnycastPeer("192.168.1.2", WithAnycastPeerVRF("management"))
+	if err != nil {
+		t.Fatalf("NewAnycastPeer() unexpected error = %v", err)
+	}
+
+	got, err := ap.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("AnycastPeer.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("AnycastPeer.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check anycast peer configuration with custom VRF
+	update2, ok := got[1].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("AnycastPeer.ToYGOT() expected second update to be ReplacingUpdate")
+		return
+	}
+
+	expectedXPath := "System/pim-items/inst-items/dom-items/Dom-list[name=management]/acastrpfunc-items/peer-items/AcastRPPeer-list[addr=192.168.1.2/32][rpSetAddr=192.168.1.2/32]"
+	if update2.XPath != expectedXPath {
+		t.Errorf("AnycastPeer.ToYGOT() expected XPath %v, got %v", expectedXPath, update2.XPath)
+	}
+
+	peerList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_AcastrpfuncItems_PeerItems_AcastRPPeerList)
+	if !ok {
+		t.Errorf("AnycastPeer.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_AcastrpfuncItems_PeerItems_AcastRPPeerList")
+		return
+	}
+
+	if *peerList.Addr != "192.168.1.2/32" {
+		t.Errorf("AnycastPeer.ToYGOT() expected Addr '192.168.1.2/32', got %v", *peerList.Addr)
+	}
+	if *peerList.RpSetAddr != "192.168.1.2/32" {
+		t.Errorf("AnycastPeer.ToYGOT() expected RpSetAddr '192.168.1.2/32', got %v", *peerList.RpSetAddr)
+	}
+}
+
+func TestAnycastPeer_Reset(t *testing.T) {
+	tests := []struct {
+		name         string
+		ap           *AnycastPeer
+		expectedPath string
+	}{
+		{
+			name: "default VRF",
+			ap: &AnycastPeer{
+				Addr: mustParseAddr("192.168.1.2"),
+				Vrf:  "default",
+			},
+			expectedPath: "System/pim-items/inst-items/dom-items/Dom-list[name=default]/acastrpfunc-items/peer-items/AcastRPPeer-list[addr=192.168.1.2/32][rpSetAddr=192.168.1.2/32]",
+		},
+		{
+			name: "custom VRF",
+			ap: &AnycastPeer{
+				Addr: mustParseAddr("192.168.1.2"),
+				Vrf:  "management",
+			},
+			expectedPath: "System/pim-items/inst-items/dom-items/Dom-list[name=management]/acastrpfunc-items/peer-items/AcastRPPeer-list[addr=192.168.1.2/32][rpSetAddr=192.168.1.2/32]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.ap.Reset(&gnmiext.ClientMock{})
+			if err != nil {
+				t.Errorf("AnycastPeer.Reset() unexpected error = %v", err)
+				return
+			}
+
+			if len(got) != 1 {
+				t.Errorf("AnycastPeer.Reset() expected 1 update, got %d", len(got))
+				return
+			}
+
+			update, ok := got[0].(gnmiext.DeletingUpdate)
+			if !ok {
+				t.Errorf("AnycastPeer.Reset() expected update to be DeletingUpdate")
+				return
+			}
+
+			if update.XPath != test.expectedPath {
+				t.Errorf("AnycastPeer.Reset() expected XPath %v, got %v", test.expectedPath, update.XPath)
+			}
+		})
+	}
+}
+
+// Helper function to parse addresses for test cases
+func mustParseAddr(addr string) netip.Addr {
+	a, err := netip.ParseAddr(addr)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func TestNewInterface(t *testing.T) {
+	tests := []struct {
+		name          string
+		ifName        string
+		opts          []InterfaceOption
+		wantErr       bool
+		wantVrf       string
+		wantShortName string
+	}{
+		{
+			name:    "empty interface name",
+			ifName:  "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid Ethernet format",
+			ifName:  "Ethernet1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid Loopback format",
+			ifName:  "Loopback",
+			wantErr: true,
+		},
+		{
+			name:          "valid interface short form",
+			ifName:        "lo0",
+			wantErr:       false,
+			wantVrf:       "default",
+			wantShortName: "lo0",
+		},
+		{
+			name:          "Ethernet interface conversion",
+			ifName:        "Ethernet1/1",
+			wantErr:       false,
+			wantVrf:       "default",
+			wantShortName: "eth1/1",
+		},
+		{
+			name:          "Loopback interface conversion",
+			ifName:        "Loopback0",
+			wantErr:       false,
+			wantVrf:       "default",
+			wantShortName: "lo0",
+		},
+		{
+			name:          "with sparse mode enabled",
+			ifName:        "lo0",
+			opts:          []InterfaceOption{WithSparseMode(true)},
+			wantErr:       false,
+			wantVrf:       "default",
+			wantShortName: "lo0",
+		},
+		{
+			name:          "with sparse mode disabled",
+			ifName:        "lo0",
+			opts:          []InterfaceOption{WithSparseMode(false)},
+			wantErr:       false,
+			wantVrf:       "default",
+			wantShortName: "lo0",
+		},
+		{
+			name:          "with custom VRF",
+			ifName:        "lo0",
+			opts:          []InterfaceOption{WithInterfaceVRF("management")},
+			wantErr:       false,
+			wantVrf:       "management",
+			wantShortName: "lo0",
+		},
+		{
+			name:          "with multiple options",
+			ifName:        "Ethernet1/1",
+			opts:          []InterfaceOption{WithSparseMode(true), WithInterfaceVRF("custom")},
+			wantErr:       false,
+			wantVrf:       "custom",
+			wantShortName: "eth1/1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			intf, err := NewInterface(test.ifName, test.opts...)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("NewInterface() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("NewInterface() unexpected error = %v", err)
+				return
+			}
+			if intf == nil {
+				t.Errorf("NewInterface() returned nil")
+				return
+			}
+			if intf.Name != test.wantShortName {
+				t.Errorf("NewInterface() Name = %v, want %v", intf.Name, test.wantShortName)
+			}
+			if intf.Vrf != test.wantVrf {
+				t.Errorf("NewInterface() Vrf = %v, want %v", intf.Vrf, test.wantVrf)
+			}
+		})
+	}
+}
+
+func TestWithSparseMode(t *testing.T) {
+	tests := []struct {
+		name   string
+		enable bool
+	}{
+		{
+			name:   "enable sparse mode",
+			enable: true,
+		},
+		{
+			name:   "disable sparse mode",
+			enable: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			intf := &Interface{}
+			opt := WithSparseMode(test.enable)
+			err := opt(intf)
+			if err != nil {
+				t.Errorf("WithSparseMode() unexpected error = %v", err)
+				return
+			}
+			if intf.SparseMode != test.enable {
+				t.Errorf("WithSparseMode() SparseMode = %v, want %v", intf.SparseMode, test.enable)
+			}
+		})
+	}
+}
+
+func TestWithInterfaceVRF(t *testing.T) {
+	tests := []struct {
+		name    string
+		vrf     string
+		wantErr bool
+	}{
+		{
+			name:    "valid VRF",
+			vrf:     "management",
+			wantErr: false,
+		},
+		{
+			name:    "empty VRF",
+			vrf:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			intf := &Interface{}
+			opt := WithInterfaceVRF(test.vrf)
+			err := opt(intf)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("WithInterfaceVRF() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("WithInterfaceVRF() unexpected error = %v", err)
+				return
+			}
+			if intf.Vrf != test.vrf {
+				t.Errorf("WithInterfaceVRF() Vrf = %v, want %v", intf.Vrf, test.vrf)
+			}
+		})
+	}
+}
+
+func TestInterface_ToYGOT_MissingInterface(t *testing.T) {
+	intf, err := NewInterface("lo0")
+	if err != nil {
+		t.Fatalf("NewInterface() unexpected error = %v", err)
+	}
+
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			return gnmiext.ErrNil
+		},
+	}
+
+	_, err = intf.ToYGOT(client)
+	if err == nil {
+		t.Errorf("Interface.ToYGOT() expected error for missing interface, got nil")
+		return
+	}
+	if !errors.Is(err, ErrMissingInterface) {
+		t.Errorf("Interface.ToYGOT() error = %v, want %v", err, ErrMissingInterface)
+	}
+}
+
+func TestInterface_ToYGOT_GetError(t *testing.T) {
+	intf, err := NewInterface("lo0")
+	if err != nil {
+		t.Fatalf("NewInterface() unexpected error = %v", err)
+	}
+
+	expectedErr := errors.New("get error")
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			return expectedErr
+		},
+	}
+
+	_, err = intf.ToYGOT(client)
+	if err == nil {
+		t.Errorf("Interface.ToYGOT() expected error, got nil")
+	}
+}
+
+func TestInterface_ToYGOT_Success(t *testing.T) {
+	intf, err := NewInterface("lo0", WithSparseMode(true))
+	if err != nil {
+		t.Fatalf("NewInterface() unexpected error = %v", err)
+	}
+
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			if xpath != "System/intf-items/lb-items/LbRtdIf-list/[id=lo0]" {
+				t.Errorf("Interface.ToYGOT() unexpected xpath = %v", xpath)
+			}
+			// Simulate existing interface
+			return nil
+		},
+	}
+
+	got, err := intf.ToYGOT(client)
+	if err != nil {
+		t.Errorf("Interface.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("Interface.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check PIM feature enablement
+	update1, ok := got[0].(gnmiext.EditingUpdate)
+	if !ok {
+		t.Errorf("Interface.ToYGOT() expected first update to be EditingUpdate")
+		return
+	}
+	if update1.XPath != "System/fm-items/pim-items" {
+		t.Errorf("Interface.ToYGOT() expected XPath 'System/fm-items/pim-items', got %v", update1.XPath)
+	}
+
+	pimItems, ok := update1.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_PimItems)
+	if !ok {
+		t.Errorf("Interface.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_FmItems_PimItems")
+		return
+	}
+	if pimItems.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
+		t.Errorf("Interface.ToYGOT() expected PIM AdminSt to be enabled")
+	}
+
+	// Check interface configuration
+	update2, ok := got[1].(gnmiext.EditingUpdate)
+	if !ok {
+		t.Errorf("Interface.ToYGOT() expected second update to be EditingUpdate")
+		return
+	}
+
+	expectedXPath := "System/pim-items/inst-items/dom-items/Dom-list[name=" + intf.Vrf + "]/if-items/If-list[id=" + intf.Name + "]"
+	if update2.XPath != expectedXPath {
+		t.Errorf("Interface.ToYGOT() expected XPath %v, got %v", expectedXPath, update2.XPath)
+	}
+
+	ifList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList)
+	if !ok {
+		t.Errorf("Interface.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList")
+		return
+	}
+
+	if *ifList.Ctrl != "border" {
+		t.Errorf("Interface.ToYGOT() expected Ctrl 'border', got %v", *ifList.Ctrl)
+	}
+	if *ifList.PimSparseMode != true {
+		t.Errorf("Interface.ToYGOT() expected PimSparseMode true, got %v", *ifList.PimSparseMode)
+	}
+}
+
+func TestInterface_ToYGOT_WithCustomVRF(t *testing.T) {
+	intf, err := NewInterface("eth1/1", WithSparseMode(false), WithInterfaceVRF("management"))
+	if err != nil {
+		t.Fatalf("NewInterface() unexpected error = %v", err)
+	}
+
+	client := &gnmiext.ClientMock{
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			if xpath != "System/intf-items/lb-items/LbRtdIf-list/[id=eth1/1]" {
+				t.Errorf("Interface.ToYGOT() unexpected xpath = %v", xpath)
+			}
+			// Simulate existing interface
+			return nil
+		},
+	}
+
+	got, err := intf.ToYGOT(client)
+	if err != nil {
+		t.Errorf("Interface.ToYGOT() unexpected error = %v", err)
+		return
+	}
+
+	if len(got) != 2 {
+		t.Errorf("Interface.ToYGOT() expected 2 updates, got %d", len(got))
+		return
+	}
+
+	// Check interface configuration with custom VRF
+	update2, ok := got[1].(gnmiext.EditingUpdate)
+	if !ok {
+		t.Errorf("Interface.ToYGOT() expected second update to be EditingUpdate")
+		return
+	}
+
+	expectedXPath := "System/pim-items/inst-items/dom-items/Dom-list[name=management]/if-items/If-list[id=eth1/1]"
+	if update2.XPath != expectedXPath {
+		t.Errorf("Interface.ToYGOT() expected XPath %v, got %v", expectedXPath, update2.XPath)
+	}
+
+	ifList, ok := update2.Value.(*nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList)
+	if !ok {
+		t.Errorf("Interface.ToYGOT() expected value to be *nxos.Cisco_NX_OSDevice_System_PimItems_InstItems_DomItems_DomList_IfItems_IfList")
+		return
+	}
+
+	if *ifList.Ctrl != "border" {
+		t.Errorf("Interface.ToYGOT() expected Ctrl 'border', got %v", *ifList.Ctrl)
+	}
+	if *ifList.PimSparseMode != false {
+		t.Errorf("Interface.ToYGOT() expected PimSparseMode false, got %v", *ifList.PimSparseMode)
+	}
+}
+
+func TestInterface_Reset(t *testing.T) {
+	tests := []struct {
+		name         string
+		intf         *Interface
+		expectedPath string
+	}{
+		{
+			name: "default VRF",
+			intf: &Interface{
+				Name: "lo0",
+				Vrf:  "default",
+			},
+			expectedPath: "System/pim-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=lo0]",
+		},
+		{
+			name: "custom VRF",
+			intf: &Interface{
+				Name: "eth1/1",
+				Vrf:  "management",
+			},
+			expectedPath: "System/pim-items/inst-items/dom-items/Dom-list[name=management]/if-items/If-list[id=eth1/1]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.intf.Reset(&gnmiext.ClientMock{})
+			if err != nil {
+				t.Errorf("Interface.Reset() unexpected error = %v", err)
+				return
+			}
+
+			if len(got) != 1 {
+				t.Errorf("Interface.Reset() expected 1 update, got %d", len(got))
+				return
+			}
+
+			update, ok := got[0].(gnmiext.DeletingUpdate)
+			if !ok {
+				t.Errorf("Interface.Reset() expected update to be DeletingUpdate")
+				return
+			}
+
+			if update.XPath != test.expectedPath {
+				t.Errorf("Interface.Reset() expected XPath %v, got %v", test.expectedPath, update.XPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch adds the implementation for configuring Protocol Independent Multicast (PIM) on a Cisco NX-OS Device.

It supports the following config:
```
feature pim
!
ip pim rp-address 10.0.0.100 group-list 224.0.0.0/4
ip pim anycast-rp 10.0.0.100 10.0.0.1
ip pim anycast-rp 10.0.0.100 10.0.0.2
!
interface Ethernet1/1-2
 ip pim sparse-mode
!
interface loopback0-1
 ip pim sparse-mode
```