### PR TITLE
cisco-nxos-provider: refactor 'interface' configuration

### DIFF
--- a/internal/provider/cisco/nxos/iface/l2config.go
+++ b/internal/provider/cisco/nxos/iface/l2config.go
@@ -28,8 +28,8 @@ const (
 type L2Config struct {
 	spanningTree SpanningTreeMode
 	switchPort   SwitchPortMode
-	accessVlan   *uint16
-	nativeVlan   *uint16
+	accessVlan   uint16
+	nativeVlan   uint16
 	allowedVlans []uint16
 }
 
@@ -75,7 +75,7 @@ func WithAccessVlan(vlan uint16) L2Option {
 		if vlan < 1 || vlan > 4094 {
 			return errors.New("access VLAN must be between 1 and 4094")
 		}
-		c.accessVlan = &vlan
+		c.accessVlan = vlan
 		return nil
 	}
 }
@@ -88,7 +88,7 @@ func WithNativeVlan(vlan uint16) L2Option {
 		if vlan < 1 || vlan > 4094 {
 			return errors.New("native VLAN must be between 1 and 4094")
 		}
-		c.nativeVlan = &vlan
+		c.nativeVlan = vlan
 		return nil
 	}
 }

--- a/internal/provider/cisco/nxos/iface/l2config_test.go
+++ b/internal/provider/cisco/nxos/iface/l2config_test.go
@@ -16,7 +16,7 @@ func TestL2Config_AccessModeOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating L2 config: %v", err)
 	}
-	if l2.accessVlan == nil || *l2.accessVlan != 100 {
+	if l2.accessVlan != 100 {
 		t.Errorf("expected accessVlan to be 100, got %v", l2.accessVlan)
 	}
 
@@ -57,7 +57,7 @@ func TestL2Config_TrunkModeOptions(t *testing.T) {
 			t.Fatalf("unexpected error while creating L2 config: %v", err)
 		}
 
-		if l2.nativeVlan == nil || *l2.nativeVlan != 200 {
+		if l2.nativeVlan != 200 {
 			t.Errorf("expected nativeVlan to be 200, got %v", l2.nativeVlan)
 		}
 		expected := []uint16{10, 20, 30}

--- a/internal/provider/cisco/nxos/iface/l3config_test.go
+++ b/internal/provider/cisco/nxos/iface/l3config_test.go
@@ -68,7 +68,7 @@ func TestL3Config_ConflictingAddressingModes(t *testing.T) {
 			t.Errorf("expected no addressesInterface, got %s", c.unnumberedLoopback)
 		}
 		if len(c.prefixesIPv4) != 1 || c.prefixesIPv4[0].String() != "10.0.0.1/24" {
-			t.Errorf("expected IPv4 addresses to be 10.0.1/24, got %v", c.prefixesIPv4)
+			t.Errorf("expected IPv4 addresses to be 10.0.0.1/24, got %v", c.prefixesIPv4)
 		}
 		if len(c.prefixesIPv6) != 0 {
 			t.Errorf("expected no IPv6 addresses, got %v", c.prefixesIPv6)
@@ -117,25 +117,25 @@ func TestL3Config_OverlapAddresses(t *testing.T) {
 	t.Run("WithNumberedAddressingIPv4_duplicates", func(t *testing.T) {
 		_, err := NewL3Config(WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "10.0.0.1/24"}))
 		if err == nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal("expected error for duplicate IPv4 addresses, got nil")
 		}
 	})
 	t.Run("WithNumberedAddressingIPv4_overlap", func(t *testing.T) {
 		_, err := NewL3Config(WithNumberedAddressingIPv4([]string{"10.0.0.1/24", "10.0.0.1/8"}))
 		if err == nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal("expected error for overlapping IPv4 addresses, got nil")
 		}
 	})
 	t.Run("WithNumberedAddressingIPv6_duplicates", func(t *testing.T) {
 		_, err := NewL3Config(WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "2001:db8::1/64"}))
 		if err == nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal("expected error for duplicate IPv6 addresses, got nil")
 		}
 	})
 	t.Run("WithNumberedAddressingIPv6_overlap", func(t *testing.T) {
 		_, err := NewL3Config(WithNumberedAddressingIPv6([]string{"2001:db8::1/64", "2001:db8::2/32"}))
 		if err == nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatal("expected error for overlapping IPv6 addresses, got nil")
 		}
 	})
 }

--- a/internal/provider/cisco/nxos/iface/loopback.go
+++ b/internal/provider/cisco/nxos/iface/loopback.go
@@ -117,9 +117,7 @@ func (l *Loopback) ToYGOT(client gnmiext.Client) ([]gnmiext.Update, error) {
 		if err != nil {
 			return nil, fmt.Errorf("loopback: fail to create ygot objects for L3 config %w ", err)
 		}
-		if l3Updates != nil {
-			updates = append(updates, l3Updates...)
-		}
+		updates = append(updates, l3Updates...)
 	}
 	return updates, nil
 }

--- a/internal/provider/cisco/nxos/iface/physif_test.go
+++ b/internal/provider/cisco/nxos/iface/physif_test.go
@@ -25,7 +25,7 @@ func Test_PhysIf_NewPhysicalInterface(t *testing.T) {
 	validNames := []string{"Ethernet1/1", "ethernet1/2", "eth1/1", "eTH1/2", "Eth1/3"}
 	for _, name := range validNames {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewPhysicalInterface(name, nil)
+			_, err := NewPhysicalInterface(name)
 			if err != nil {
 				t.Fatalf("failed to create physical interface: %v", err)
 			}
@@ -34,7 +34,7 @@ func Test_PhysIf_NewPhysicalInterface(t *testing.T) {
 	invalidNames := []string{"test", "ether1/1", "ethernet1.1", "eth1/1/1", "port-channel01", "po100"}
 	for _, name := range invalidNames {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewPhysicalInterface(name, nil)
+			_, err := NewPhysicalInterface(name)
 			if err == nil {
 				t.Fatalf("created interface with invalid name: %s", name)
 			}
@@ -45,7 +45,7 @@ func Test_PhysIf_NewPhysicalInterface(t *testing.T) {
 // tests base configuration of the physical interface is correctly initialized
 func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
 	t.Run("No additional base options", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription))
+		p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription))
 		if err != nil {
 			t.Fatalf("failed to create physical interface")
 		}
@@ -57,7 +57,7 @@ func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
 
 		// single update affecting only base configuration of physical interface
 		if len(got) != 1 {
-			t.Errorf("expected 2 update, got %d", len(got))
+			t.Errorf("expected 1 update, got %d", len(got))
 		}
 		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
 		if !ok {
@@ -83,7 +83,9 @@ func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
 		}
 	})
 	t.Run("MTU and VRF", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription),
+		p, err := NewPhysicalInterface(
+			physIfName,
+			WithDescription(physIfDescription),
 			WithPhysIfMTU(9216),
 			WithPhysIfVRF(physIfVRFName),
 		)
@@ -98,7 +100,7 @@ func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
 
 		// single update affecting only base configuration of physical interface
 		if len(got) != 1 {
-			t.Errorf("expected 2 update, got %d", len(got))
+			t.Errorf("expected 1 update, got %d", len(got))
 		}
 		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
 		if !ok {
@@ -128,7 +130,7 @@ func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
 }
 
 func Test_PhysIf_Reset_BaseConfig(t *testing.T) {
-	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription))
+	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription))
 	if err != nil {
 		t.Fatalf("failed to create physical interface")
 	}
@@ -176,13 +178,13 @@ func Test_PhysIf_ToYGOT_WithL2AndL3(t *testing.T) {
 	}
 
 	t.Run("L2 with VRF is not allowed", func(t *testing.T) {
-		_, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfVRF(physIfVRFName))
+		_, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfVRF(physIfVRFName))
 		if err == nil {
 			t.Fatalf("expected error when creating physical interface with L2 and VRF, got nil")
 		}
 	})
 	t.Run("L2 then L3, expect only L3", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfL3(l3cfg))
+		p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfL3(l3cfg))
 		if err != nil {
 			t.Fatalf("failed to create physical interface")
 		}
@@ -195,7 +197,7 @@ func Test_PhysIf_ToYGOT_WithL2AndL3(t *testing.T) {
 	})
 
 	t.Run("L3 then L2, expect only L2", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg), WithPhysIfL2(l2cfg))
+		p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg), WithPhysIfL2(l2cfg))
 		if err != nil {
 			t.Fatalf("failed to create physical interface")
 		}
@@ -218,7 +220,7 @@ func Test_PhysIf_ToYGOT_WithL2_Trunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating L2 config: %v", err)
 	}
-	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg))
+	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg))
 	if err != nil {
 		t.Fatalf("failed to create physical interface")
 	}
@@ -287,7 +289,7 @@ func Test_PhysIf_ToYGOT_WithL2_Access(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating L2 config: %v", err)
 	}
-	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL2(l2cfg))
+	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg))
 	if err != nil {
 		t.Fatalf("failed to create physical interface")
 	}
@@ -312,7 +314,7 @@ func Test_PhysIf_ToYGOT_WithL2_Access(t *testing.T) {
 			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
 			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
 			Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_access,
-			AccessVlan:    ygot.String("10"),
+			AccessVlan:    ygot.String("vlan-10"),
 			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
 		}
 		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
@@ -355,7 +357,7 @@ func Test_PhysIf_ToYGOT_WithL3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg))
+	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg))
 	if err != nil {
 		t.Fatalf("failed to create physical interface")
 	}
@@ -448,7 +450,7 @@ func Test_PhysIf_ToYGOT_WithL3(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		p2, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg))
+		p2, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg))
 		if err != nil {
 			t.Fatalf("failed to create physical interface")
 		}
@@ -480,7 +482,7 @@ func Test_PhysIf_Reset_WithL3(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription), WithPhysIfL3(l3cfg))
+	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg))
 	if err != nil {
 		t.Fatalf("failed to create physical interface")
 	}
@@ -522,7 +524,9 @@ func Test_PhysIf_ToYGOT_VRF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	p, err := NewPhysicalInterface(physIfName, ygot.String(physIfDescription),
+	p, err := NewPhysicalInterface(
+		physIfName,
+		WithDescription(physIfDescription),
 		WithPhysIfVRF(physIfVRFName),
 		WithPhysIfL3(l3cfg),
 	)


### PR DESCRIPTION
- Avoid pointer types and embrace zero values of types
- Avoid unnecessary nil check when spreading nil slices
- Check MTU configuration for valid value
- Correctly set access vlan to 'vlan-<id>' string
- Correctly compute range statement of trunk vlans with range identifiers (e.g. '10-11') for consecutive ids