### PR TITLE
cisco-nxos-provider: refactor `NTP` configuration

### DIFF
--- a/internal/provider/cisco/nxos/ntp/ntp.go
+++ b/internal/provider/cisco/nxos/ntp/ntp.go
@@ -22,49 +22,17 @@ type Server struct {
 	Name      string
 	Preferred bool
 	Vrf       string
-	Key       uint16
-}
-
-var ignorePaths = []string{
-	"/adminSt",
-	"/passive",
-	"/ownerKey",
-	"/authSt",
-	"/loggingLevel",
-	"/allowControl",
-	"/allowPrivate",
-	"/masterStratum",
-	"/master",
-	"/ownerTag",
-	"/rateLimit",
 }
 
 func (n *NTP) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
-	updates := make([]gnmiext.Update, 0, len(n.Servers)+1)
-
 	prov := &nxos.Cisco_NX_OSDevice_System_TimeItems_ProvItems{NtpProviderList: make(map[string]*nxos.Cisco_NX_OSDevice_System_TimeItems_ProvItems_NtpProviderList, len(n.Servers))}
 	for _, s := range n.Servers {
 		l := prov.GetOrCreateNtpProviderList(s.Name)
 		l.PopulateDefaults()
-		l.KeyId = ygot.Uint16(s.Key)
 		l.Name = ygot.String(s.Name)
 		l.Preferred = ygot.Bool(s.Preferred)
 		l.ProvT = nxos.Cisco_NX_OSDevice_Datetime_ProvT_server
 		l.Vrf = ygot.String(s.Vrf)
-
-		// The `ygot.Diff` method generates multiple `Update` objects, one for each attribute.
-		// Since `ProvT` is a mandatory field, it must be included whenever a new server is created.
-		// However, the current implementation does not guarantee that `ProvT` is the first attribute in the updates,
-		// which can cause the update to fail.
-		// To address this limitation, we create a separate `Update` specifically for the `ProvT` attribute
-		// and prepend it to the list of updates.
-		update := gnmiext.EditingUpdate{
-			XPath: "System/time-items/prov-items/NtpProvider-list[name=" + s.Name + "]",
-			Value: &nxos.Cisco_NX_OSDevice_System_TimeItems_ProvItems_NtpProviderList{
-				ProvT: nxos.Cisco_NX_OSDevice_Datetime_ProvT_server,
-			},
-		}
-		updates = append(updates, update)
 	}
 
 	logging := nxos.Cisco_NX_OSDevice_Datetime_AdminState_disabled
@@ -72,22 +40,36 @@ func (n *NTP) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
 		logging = nxos.Cisco_NX_OSDevice_Datetime_AdminState_enabled
 	}
 
-	// append the updates containing all attributes of the NTP server
-	return append(updates, gnmiext.EditingUpdate{
-		XPath: "System/time-items",
-		Value: &nxos.Cisco_NX_OSDevice_System_TimeItems{
-			SrcIfItems: &nxos.Cisco_NX_OSDevice_System_TimeItems_SrcIfItems{SrcIf: ygot.String(n.SrcInterface)},
-			Logging:    logging,
-			ProvItems:  prov,
+	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/ntpd-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NtpdItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
 		},
-		IgnorePaths: ignorePaths,
-	}), nil
+		gnmiext.ReplacingUpdate{
+			XPath: "System/time-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_TimeItems{
+				SrcIfItems: &nxos.Cisco_NX_OSDevice_System_TimeItems_SrcIfItems{SrcIf: ygot.String(n.SrcInterface)},
+				Logging:    logging,
+				ProvItems:  prov,
+			},
+		},
+	}, nil
 }
 
-func (v *NTP) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
+// Reset disables the NTP feature and resets the configuration to the default values.
+func (n *NTP) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
 	ntp := &nxos.Cisco_NX_OSDevice_System_TimeItems{}
 	ntp.PopulateDefaults()
+	ntp.AdminSt = nxos.Cisco_NX_OSDevice_Datetime_AdminState_disabled
 	return []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "System/fm-items/ntpd-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NtpdItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+			},
+		},
 		gnmiext.ReplacingUpdate{
 			XPath: "System/time-items",
 			Value: ntp,

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -319,7 +319,6 @@ func (step *NTP) Exec(ctx context.Context, s *Scope) error {
 			Name:      s.Address,
 			Preferred: s.Prefer,
 			Vrf:       s.NetworkInstance,
-			Key:       uint16(i), //nolint:gosec
 		}
 	}
 	return s.GNMI.Update(ctx, n)


### PR DESCRIPTION
This patch rewrites the implementation for configuring local user accounts on Cisco NX-OS devices.

It supports the following configuration:

```
feature ntp
!
ntp logging
ntp source-interface mgmt0
ntp server pool.ntp.org prefer use-vrf management
```