### PR TITLE
cisco-nxos-provider: refactor `ACL` configuration

### DIFF
--- a/internal/provider/cisco/nxos/acl/acl.go
+++ b/internal/provider/cisco/nxos/acl/acl.go
@@ -4,8 +4,10 @@
 package acl
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
+	"strings"
 
 	"github.com/openconfig/ygot/ygot"
 
@@ -15,17 +17,31 @@ import (
 
 var _ gnmiext.DeviceConf = (*ACL)(nil)
 
-// ACL represents an access control list.
+// ACL represents an IPv4 or IPv6 access control list, depending on the rules it contains.
+// It can only contain either IPv4 or IPv6 rules, never both.
 type ACL struct {
-	// The items of the access control list.
-	Items []*Item
-}
-
-type Item struct {
 	// The name of the access list.
+	// This name must be unique across IPv4 and IPv6 access lists.
 	Name string
 	// A list of rules to apply.
 	Rules []*Rule
+}
+
+func (a *ACL) XPath() string {
+	if len(a.Rules) > 0 && a.Rules[0].Source.Addr().Is6() {
+		return "System/acl-items/ipv6-items/name-items/ACL-list[name=" + a.Name + "]"
+	}
+	return "System/acl-items/ipv4-items/name-items/ACL-list[name=" + a.Name + "]"
+}
+
+func (a *ACL) Validate() error {
+	errs := make([]error, 0, len(a.Rules))
+	for _, r := range a.Rules {
+		if err := r.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 type Rule struct {
@@ -33,69 +49,107 @@ type Rule struct {
 	Seq uint32
 	// The action type of ACL Rule. Either 'permit' or 'deny'.
 	Action Action
+	// The protocol of the ACL Rule. Defaults to 'ip' if not specified.
+	Protocol Protocol
+	// The description of the ACL Rule.
+	Description string
 	// Source IP address or network. Use 'any' to match any source.
 	Source netip.Prefix
 	// Destination IP address or network. Use 'any' to match any target.
 	Destination netip.Prefix
 }
 
+func (r Rule) Validate() error {
+	if r.Source.Addr().Is4() != r.Destination.Addr().Is4() {
+		return errors.New("acl: rule contains both ipv4 and ipv6 rules")
+	}
+	return nil
+}
+
 //go:generate go run golang.org/x/tools/cmd/stringer@v0.35.0 -type=Action
 type Action uint8
 
 const (
-	Permit Action = iota
+	Permit Action = iota + 1
 	Deny
 )
 
-// returns a single update forcing the removal of existing ACLs on the target device. Differential updates
-// are currently not applicable to ACLs; the entire tree must be replaced.
-func (a *ACL) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
-	items := &nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems{}
-	items.PopulateDefaults()
-	for _, i := range a.Items {
-		aclList := items.GetOrCreateACLList(i.Name)
-		aclList.PopulateDefaults()
-		aclListItems := aclList.GetOrCreateSeqItems()
-		aclListItems.PopulateDefaults()
+type Protocol uint8
 
-		for _, r := range i.Rules {
-			aceList := aclListItems.GetOrCreateACEList(r.Seq)
-			aceList.PopulateDefaults()
-			// seq
-			aceList.SeqNum = ygot.Uint32(r.Seq)
-			// action
-			var action nxos.E_Cisco_NX_OSDevice_Acl_ActionType
-			switch r.Action {
-			case Permit:
-				action = nxos.Cisco_NX_OSDevice_Acl_ActionType_permit
-			case Deny:
-				action = nxos.Cisco_NX_OSDevice_Acl_ActionType_deny
-			default:
-				return nil, fmt.Errorf("acl: invalid action type: %s", r.Action)
-			}
-			aceList.Action = action
-			aceList.SrcPrefix = ygot.String(r.Source.Addr().String())
-			aceList.SrcPrefixLength = ygot.Uint8(uint8(r.Source.Bits())) //nolint:gosec
-			aceList.DstPrefix = ygot.String(r.Destination.Addr().String())
-			aceList.DstPrefixLength = ygot.Uint8(uint8(r.Destination.Bits())) //nolint:gosec
+const (
+	IP   Protocol = 0
+	ICMP Protocol = 1
+	TCP  Protocol = 6
+	UDP  Protocol = 17
+	OSPF Protocol = 89
+	PIM  Protocol = 103
+)
+
+func ProtocolFrom(s string) Protocol {
+	switch strings.ToLower(s) {
+	case "ip":
+		return IP
+	case "icmp":
+		return ICMP
+	case "tcp":
+		return TCP
+	case "udp":
+		return UDP
+	case "ospf":
+		return OSPF
+	case "pim":
+		return PIM
+	default:
+		return 0 // unknown protocol - default to 0 == "ip"
+	}
+}
+
+// ToYGOT returns a single update forcing the replacement of an ACL configuration.
+func (a *ACL) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+	list := &nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems_ACLList{}
+	list.PopulateDefaults()
+	list.Name = ygot.String(a.Name)
+	for _, r := range a.Rules {
+		entry := list.GetOrCreateSeqItems().GetOrCreateACEList(r.Seq)
+		entry.PopulateDefaults()
+		var action nxos.E_Cisco_NX_OSDevice_Acl_ActionType
+		switch r.Action {
+		case Permit:
+			action = nxos.Cisco_NX_OSDevice_Acl_ActionType_permit
+		case Deny:
+			action = nxos.Cisco_NX_OSDevice_Acl_ActionType_deny
+		default:
+			return nil, fmt.Errorf("acl: invalid action type: %s", r.Action)
+		}
+		entry.Action = action
+		entry.Protocol = ygot.Uint8(uint8(r.Protocol))
+		entry.SrcPrefix = ygot.String(r.Source.Addr().String())
+		entry.SrcPrefixLength = ygot.Uint8(uint8(r.Source.Bits())) //nolint:gosec
+		entry.DstPrefix = ygot.String(r.Destination.Addr().String())
+		entry.DstPrefixLength = ygot.Uint8(uint8(r.Destination.Bits())) //nolint:gosec
+		if r.Description != "" {
+			entry.Remark = ygot.String(r.Description)
 		}
 	}
 	return []gnmiext.Update{
 		gnmiext.ReplacingUpdate{
-			XPath: "System/acl-items/ipv4-items/name-items",
-			Value: items,
+			XPath: a.XPath(),
+			Value: list,
 		},
 	}, nil
 }
 
-func (v *ACL) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
-	items := &nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems{}
-	items.PopulateDefaults()
-
+// Reset returns a single update deleting the YANG entry of the ACL.
+func (a *ACL) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
 	return []gnmiext.Update{
-		gnmiext.ReplacingUpdate{
-			XPath: "System/acl-items/ipv4-items/name-items",
-			Value: items,
+		gnmiext.DeletingUpdate{
+			XPath: a.XPath(),
 		},
 	}, nil
 }

--- a/internal/provider/cisco/nxos/acl/acl_test.go
+++ b/internal/provider/cisco/nxos/acl/acl_test.go
@@ -13,17 +13,15 @@ import (
 
 func Test_ACL(t *testing.T) {
 	a := &ACL{
-		Items: []*Item{
+		Name: "ACL-SNMP-VTY",
+		Rules: []*Rule{
 			{
-				Name: "ACL-SNMP-VTY",
-				Rules: []*Rule{
-					{
-						Seq:         10,
-						Action:      Permit,
-						Source:      netip.MustParsePrefix("10.0.0.0/8"),
-						Destination: netip.MustParsePrefix("0.0.0.0/0"),
-					},
-				},
+				Seq:         10,
+				Action:      Permit,
+				Protocol:    IP,
+				Description: "Allow internal access",
+				Source:      netip.MustParsePrefix("10.0.0.0/8"),
+				Destination: netip.MustParsePrefix("0.0.0.0/0"),
 			},
 		},
 	}
@@ -34,7 +32,7 @@ func Test_ACL(t *testing.T) {
 	}
 
 	if len(got) != 1 {
-		t.Errorf("expected 1 key, got %d", len(got))
+		t.Errorf("expected 1 update, got %d", len(got))
 	}
 
 	update, ok := got[0].(gnmiext.ReplacingUpdate)
@@ -42,40 +40,139 @@ func Test_ACL(t *testing.T) {
 		t.Errorf("expected value to be of type ReplacingUpdate")
 	}
 
-	if update.XPath != "System/acl-items/ipv4-items/name-items" {
-		t.Errorf("expected key 'System/acl-items/ipv4-items/name-items' to be present")
+	expectedXPath := "System/acl-items/ipv4-items/name-items/ACL-list[name=ACL-SNMP-VTY]"
+	if update.XPath != expectedXPath {
+		t.Errorf("expected XPath '%s', got '%s'", expectedXPath, update.XPath)
 	}
 
-	items, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems)
+	aclList, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems_ACLList)
 	if !ok {
-		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems")
+		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems_ACLList")
 	}
 
-	if len(items.ACLList) != 1 {
-		t.Errorf("expected 1 ACL, got %d", len(items.ACLList))
+	if *aclList.Name != "ACL-SNMP-VTY" {
+		t.Errorf("expected ACL name to be 'ACL-SNMP-VTY', got %v", *aclList.Name)
 	}
 
-	if len(items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList) != 1 {
-		t.Errorf("expected 1 rule, got %d", len(items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList))
+	if len(aclList.SeqItems.ACEList) != 1 {
+		t.Errorf("expected 1 rule, got %d", len(aclList.SeqItems.ACEList))
 	}
 
-	if items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].Action != nxos.Cisco_NX_OSDevice_Acl_ActionType_permit {
-		t.Errorf("expected action to be 'permit', got %v", items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].Action)
+	rule := aclList.SeqItems.ACEList[10]
+	if rule.Action != nxos.Cisco_NX_OSDevice_Acl_ActionType_permit {
+		t.Errorf("expected action to be 'permit', got %v", rule.Action)
 	}
 
-	if *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].SrcPrefix != "10.0.0.0" {
-		t.Errorf("expected source prefix to be '10.0.0.0', got %v", *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].SrcPrefix)
+	if *rule.SrcPrefix != "10.0.0.0" {
+		t.Errorf("expected source prefix to be '10.0.0.0', got %v", *rule.SrcPrefix)
 	}
 
-	if *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].SrcPrefixLength != 8 {
-		t.Errorf("expected source mask to be '8', got %d", *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].SrcPrefixLength)
+	if *rule.SrcPrefixLength != 8 {
+		t.Errorf("expected source prefix length to be '8', got %d", *rule.SrcPrefixLength)
 	}
 
-	if *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].DstPrefix != "0.0.0.0" {
-		t.Errorf("expected source prefix to be '0.0.0.0', got %v", *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].DstPrefix)
+	if *rule.DstPrefix != "0.0.0.0" {
+		t.Errorf("expected destination prefix to be '0.0.0.0', got %v", *rule.DstPrefix)
 	}
 
-	if *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].DstPrefixLength != 0 {
-		t.Errorf("expected source mask to be '0', got %d", *items.ACLList["ACL-SNMP-VTY"].SeqItems.ACEList[10].DstPrefixLength)
+	if *rule.DstPrefixLength != 0 {
+		t.Errorf("expected destination prefix length to be '0', got %d", *rule.DstPrefixLength)
+	}
+
+	if *rule.Protocol != uint8(IP) {
+		t.Errorf("expected protocol to be '%d' (IP), got %d", uint8(IP), *rule.Protocol)
+	}
+
+	if *rule.Remark != "Allow internal access" {
+		t.Errorf("expected remark to be 'Allow internal access', got %v", *rule.Remark)
+	}
+}
+
+func Test_ACL_IPv6(t *testing.T) {
+	a := &ACL{
+		Name: "ACL-IPv6-TEST",
+		Rules: []*Rule{
+			{
+				Seq:         20,
+				Action:      Deny,
+				Protocol:    TCP,
+				Description: "Block IPv6 traffic",
+				Source:      netip.MustParsePrefix("2001:db8::/32"),
+				Destination: netip.MustParsePrefix("::/0"),
+			},
+		},
+	}
+
+	got, err := a.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Errorf("expected 1 update, got %d", len(got))
+	}
+
+	update, ok := got[0].(gnmiext.ReplacingUpdate)
+	if !ok {
+		t.Errorf("expected value to be of type ReplacingUpdate")
+	}
+
+	expectedXPath := "System/acl-items/ipv6-items/name-items/ACL-list[name=ACL-IPv6-TEST]"
+	if update.XPath != expectedXPath {
+		t.Errorf("expected XPath '%s', got '%s'", expectedXPath, update.XPath)
+	}
+}
+
+func Test_ACL_Validation_MixedIPVersions(t *testing.T) {
+	a := &ACL{
+		Name: "ACL-MIXED",
+		Rules: []*Rule{
+			{
+				Seq:         10,
+				Action:      Permit,
+				Protocol:    IP,
+				Source:      netip.MustParsePrefix("10.0.0.0/8"),
+				Destination: netip.MustParsePrefix("2001:db8::/32"), // IPv6 destination with IPv4 source
+			},
+		},
+	}
+
+	_, err := a.ToYGOT(&gnmiext.ClientMock{})
+	if err == nil {
+		t.Errorf("expected validation error for mixed IP versions, got nil")
+	}
+}
+
+func Test_ACL_EmptyDescription(t *testing.T) {
+	a := &ACL{
+		Name: "ACL-NO-DESC",
+		Rules: []*Rule{
+			{
+				Seq:         10,
+				Action:      Permit,
+				Protocol:    UDP,
+				Description: "", // Empty description
+				Source:      netip.MustParsePrefix("192.168.1.0/24"),
+				Destination: netip.MustParsePrefix("0.0.0.0/0"),
+			},
+		},
+	}
+
+	got, err := a.ToYGOT(&gnmiext.ClientMock{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	update := got[0].(gnmiext.ReplacingUpdate)
+	aclList := update.Value.(*nxos.Cisco_NX_OSDevice_System_AclItems_Ipv4Items_NameItems_ACLList)
+	rule := aclList.SeqItems.ACEList[10]
+
+	// Remark should not be set when description is empty
+	if rule.Remark != nil {
+		t.Errorf("expected remark to be nil for empty description, got %v", *rule.Remark)
+	}
+
+	if *rule.Protocol != uint8(UDP) {
+		t.Errorf("expected protocol to be '%d' (UDP), got %d", uint8(UDP), *rule.Protocol)
 	}
 }

--- a/internal/provider/cisco/nxos/acl/action_string.go
+++ b/internal/provider/cisco/nxos/acl/action_string.go
@@ -8,8 +8,8 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[Permit-0]
-	_ = x[Deny-1]
+	_ = x[Permit-1]
+	_ = x[Deny-2]
 }
 
 const _Action_name = "PermitDeny"
@@ -17,8 +17,9 @@ const _Action_name = "PermitDeny"
 var _Action_index = [...]uint8{0, 6, 10}
 
 func (i Action) String() string {
+	i -= 1
 	if i >= Action(len(_Action_index)-1) {
-		return "Action(" + strconv.FormatInt(int64(i), 10) + ")"
+		return "Action(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _Action_name[_Action_index[i]:_Action_index[i+1]]
 }

--- a/internal/provider/cisco/nxos/iface/portchannel_test.go
+++ b/internal/provider/cisco/nxos/iface/portchannel_test.go
@@ -51,6 +51,7 @@ func Test_PortChannel_NewPortChannel(t *testing.T) {
 		})
 	}
 }
+
 func Test_PortChannel_ToYGOT_WithOptions_Invalid(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -157,12 +158,13 @@ func Test_PortChannel_ToYGOT_GnmiClient(t *testing.T) {
 		})
 	}
 }
+
 func Test_PortChannel_ToYGOT_Updates(t *testing.T) {
 	type updateCheck struct {
-		updateIdx   int         // the position we want to check in the returned slice of updates
-		expectType  string      // "EditingUpdate" or "ReplacingUpdate"
-		expectXPath string      // the expected XPath of the update
-		expectValue interface{} // the expected ygot object that should be in the update
+		updateIdx   int    // the position we want to check in the returned slice of updates
+		expectType  string // "EditingUpdate" or "ReplacingUpdate"
+		expectXPath string // the expected XPath of the update
+		expectValue any    // the expected ygot object that should be in the update
 	}
 
 	tests := []struct {
@@ -282,7 +284,7 @@ func Test_PortChannel_ToYGOT_Updates(t *testing.T) {
 				t.Fatalf("expected %d updates, got %d", tt.expectedNumberOfUpdates, len(updates))
 			}
 			for _, check := range tt.updateChecks {
-				var update interface{}
+				var update any
 				switch check.expectType {
 				case "EditingUpdate":
 					update, _ = updates[check.updateIdx].(gnmiext.EditingUpdate)
@@ -296,7 +298,7 @@ func Test_PortChannel_ToYGOT_Updates(t *testing.T) {
 					continue
 				}
 				var xpath string
-				var value interface{}
+				var value any
 				switch u := update.(type) {
 				case gnmiext.EditingUpdate:
 					xpath = u.XPath


### PR DESCRIPTION
This patch rewrites the implementation for configuring access control
lists on Cisco NX-OS devices.

It supports the following configuration:

```
ip access-list ACL-SNMP-VTY
 10 permit ip 10.0.0.0/8 any
```
