### PR TITLE
cisco-nxos-provider: refactor `Trustpoint` configuration

### DIFF
--- a/internal/provider/cisco/nxos/crypto/trustpoint.go
+++ b/internal/provider/cisco/nxos/crypto/trustpoint.go
@@ -10,42 +10,28 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
 )
 
+var _ gnmiext.DeviceConf = (*Trustpoint)(nil)
+
 type Trustpoint struct {
 	ID string
 }
 
-var _ gnmiext.DeviceConf = Trustpoints{}
-
-type Trustpoints []*Trustpoint
-
-func (t Trustpoints) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
-	items := &nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems{TPList: make(map[string]*nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems_TPList, len(t))}
-	for _, tp := range t {
-		list := &nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems_TPList{
-			Name: ygot.String(tp.ID),
-		}
-		list.PopulateDefaults()
-
-		if err := items.AppendTPList(list); err != nil {
-			return nil, err
-		}
-	}
-
+func (t *Trustpoint) ToYGOT(_ gnmiext.Client) ([]gnmiext.Update, error) {
+	v := &nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems_TPList{}
+	v.PopulateDefaults()
+	v.Name = ygot.String(t.ID)
 	return []gnmiext.Update{
 		gnmiext.ReplacingUpdate{
-			XPath: "System/userext-items/pkiext-items/tp-items",
-			Value: items,
+			XPath: "System/userext-items/pkiext-items/tp-items/TP-list[name=" + t.ID + "]",
+			Value: v,
 		},
 	}, nil
 }
 
-func (t Trustpoints) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
-	items := &nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems{}
-	items.PopulateDefaults()
+func (t *Trustpoint) Reset(_ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{
-		gnmiext.ReplacingUpdate{
-			XPath: "System/userext-items/pkiext-items/tp-items",
-			Value: items,
+		gnmiext.DeletingUpdate{
+			XPath: "System/userext-items/pkiext-items/tp-items/TP-list[name=" + t.ID + "]",
 		},
 	}, nil
 }

--- a/internal/provider/cisco/nxos/crypto/trustpoint_test.go
+++ b/internal/provider/cisco/nxos/crypto/trustpoint_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Test_Trustpoint(t *testing.T) {
-	tp := &Trustpoints{{ID: "mytrustpoint"}}
+	tp := &Trustpoint{ID: "mytrustpoint"}
 
 	got, err := tp.ToYGOT(&gnmiext.ClientMock{})
 	if err != nil {
@@ -30,26 +30,22 @@ func Test_Trustpoint(t *testing.T) {
 		t.Errorf("expected value to be of type ReplacingUpdate")
 	}
 
-	if update.XPath != "System/userext-items/pkiext-items/tp-items" {
-		t.Errorf("expected key 'System/userext-items/pkiext-items/tp-items' to be present")
+	if update.XPath != "System/userext-items/pkiext-items/tp-items/TP-list[name=mytrustpoint]" {
+		t.Errorf("expected key 'System/userext-items/pkiext-items/tp-items/TP-list[name=mytrustpoint]' to be present")
 	}
 
-	ti, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems)
+	ti, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems_TPList)
 	if !ok {
 		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems")
 	}
 
-	want := &nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems{
-		TPList: map[string]*nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems_TPList{
-			"mytrustpoint": {
-				Name:            ygot.String("mytrustpoint"),
-				KeyType:         nxos.Cisco_NX_OSDevice_Pki_KeyType_Type_RSA,
-				RevokeCheckConf: nxos.Cisco_NX_OSDevice_Pki_CertRevokeCheck_crl,
-				EnrollmentType:  nxos.Cisco_NX_OSDevice_Pki_CertEnrollType_none,
-			},
-		},
+	want := &nxos.Cisco_NX_OSDevice_System_UserextItems_PkiextItems_TpItems_TPList{
+		Name:            ygot.String("mytrustpoint"),
+		KeyType:         nxos.Cisco_NX_OSDevice_Pki_KeyType_Type_RSA,
+		RevokeCheckConf: nxos.Cisco_NX_OSDevice_Pki_CertRevokeCheck_crl,
+		EnrollmentType:  nxos.Cisco_NX_OSDevice_Pki_CertEnrollType_none,
 	}
 	if !reflect.DeepEqual(ti, want) {
-		t.Errorf("unexpected value for 'System/userext-items/pkiext-items/tp-items': got=%+v, want=%+v", ti, want)
+		t.Errorf("unexpected value for 'System/userext-items/pkiext-items/tp-items/TP-list[name=mytrustpoint]': got=%+v, want=%+v", ti, want)
 	}
 }

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -413,17 +413,11 @@ func (step *Trustpoints) Exec(ctx context.Context, s *Scope) error {
 	if step.Spec == nil {
 		return nil
 	}
-	t := make(crypto.Trustpoints, 0, len(step.Spec.Certificates))
 	for _, trustpoint := range step.Spec.Certificates {
-		t = append(t, &crypto.Trustpoint{ID: trustpoint.Name})
-	}
-	if err := s.GNMI.Update(ctx, t); err != nil {
-		return err
-	}
-	if step.DryRun {
-		return nil
-	}
-	for _, trustpoint := range step.Spec.Certificates {
+		tp := &crypto.Trustpoint{ID: trustpoint.Name}
+		if err := s.GNMI.Update(ctx, tp); err != nil {
+			return fmt.Errorf("failed to get trustpoint %s: %w", trustpoint.Name, err)
+		}
 		cert, err := s.Client.Certificate(ctx, trustpoint.Source.SecretRef)
 		if err != nil {
 			return fmt.Errorf("failed to get trustpoint certificate from secret: %w", err)


### PR DESCRIPTION
This patch rewrites the implementation for configuring PKI trustpoins on Cisco NX-OS devices.

It supports the following configuration:

```
crypto ca trustpoint <name>
 revocation-check crl
!
crypto ca import <name> pkcs12 <file>
```

Certificates are imported using the gNOI Cert service.