### PR TITLE
cisco-nxos-provider: enable NVE

### DIFF
--- a/internal/provider/cisco/nxos/nve/nve.go
+++ b/internal/provider/cisco/nxos/nve/nve.go
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package nve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/iface"
+)
+
+var _ gnmiext.DeviceConf = (*NVE)(nil)
+
+type HostReachType uint
+
+const (
+	HostReachFloodAndLearn HostReachType = iota + 1
+	HostReachBGP
+)
+
+var (
+	ErrInvalidInterfaceName    = errors.New("nve: invalid interface name")
+	ErrInvalidInterfaceNumber  = errors.New("nve: interface number must be between 0 and 1023")
+	ErrInvalidHoldDownTime     = errors.New("nve: hold down time must be between 1 and 1500 seconds")
+	ErrInvalidHostReachProto   = errors.New("nve: invalid host reachability protocol")
+	ErrMissingSourceInterface  = errors.New("nve: source interface must be set before setting anycast interface")
+	ErrIdenticalInterfaceNames = errors.New("nve: source and anycast interface names must be different")
+	ErrInvalidFormatIPAddress  = errors.New("nve: failed to parse IP address")
+)
+
+// NVE represents the Network Virtualization Edge interface (nve1). This object must be
+// initialized with the NewNVE function.
+type NVE struct {
+	adminSt              bool
+	hostReach            HostReachType
+	advertiseVirtualRmac *bool
+	// the name of the loopback to use as source
+	sourceInterface string
+	// the name of the loopback to use for anycast
+	anycastInterface string
+	suppressARP      *bool
+	// multicast group for L2 VTEP discovery
+	mcastL2 *netip.Addr
+	// multicast group for L3 VTEP discovery
+	mcastL3      *netip.Addr
+	holdDownTime uint16 // in seconds
+}
+
+type NVEOption func(*NVE) error
+
+func NewNVE(opts ...NVEOption) (*NVE, error) {
+	n := &NVE{
+		adminSt: true,
+	}
+	for _, opt := range opts {
+		if err := opt(n); err != nil {
+			return nil, err
+		}
+	}
+	return n, nil
+}
+
+// WithAdminState sets the administrative state of the NVE interface. If not set, the default is `up`.
+func WithAdminState(adminSt bool) NVEOption {
+	return func(n *NVE) error {
+		n.adminSt = adminSt
+		return nil
+	}
+}
+
+// WithHostReachabilityProtocol sets the host reachability protocol for the NVE.
+func WithHostReachabilityProtocol(proto HostReachType) NVEOption {
+	return func(n *NVE) error {
+		switch proto {
+		case HostReachBGP, HostReachFloodAndLearn:
+			n.hostReach = proto
+		default:
+			return ErrInvalidHostReachProto
+		}
+		return nil
+	}
+}
+
+// WithAdvertiseVirtualRmac enables or disables the advertisement of the virtual RMAC address for the NVE interface.
+func WithAdvertiseVirtualRmac(enable bool) NVEOption {
+	return func(n *NVE) error {
+		n.advertiseVirtualRmac = ygot.Bool(enable)
+		return nil
+	}
+}
+
+// WithSourceInterface sets the source interface for the NVE. It must be a loopback interface as per the naming convention
+// defined in the `iface` package.
+func WithSourceInterface(loopback string) NVEOption {
+	return func(n *NVE) error {
+		loName, err := iface.ShortNameLoopback(loopback)
+		if err != nil {
+			return ErrInvalidInterfaceName
+		}
+		loNr, err := strconv.Atoi(loName[2:])
+		if err != nil || loNr > 1023 {
+			return ErrInvalidInterfaceNumber
+		}
+		n.sourceInterface = loName
+		return nil
+	}
+}
+
+// WithAnycastInterface sets the anycast interface for the NVE. It must be a loopback interface as per the naming convention
+// defined in the `iface` package. The anycast interface must be different from the source interface. The source interface
+// must be set before setting the anycast interface.
+func WithAnycastInterface(loopback string) NVEOption {
+	return func(n *NVE) error {
+		if n.sourceInterface == "" {
+			return ErrMissingSourceInterface
+		}
+		loName, err := iface.ShortNameLoopback(loopback)
+		if err != nil {
+			return ErrInvalidInterfaceName
+		}
+		loNr, err := strconv.Atoi(loName[2:])
+		if err != nil || loNr > 1023 {
+			return ErrInvalidInterfaceNumber
+		}
+		if loName == n.sourceInterface {
+			return ErrIdenticalInterfaceNames
+		}
+		n.anycastInterface = loName
+		return nil
+	}
+}
+
+// WithSuppressARP sets the NVE to suppress ARP requests for VTEP IP addresses. If not set, the NVE will
+// use the default behavior. When set, this is the equivalent to the configuration statement `global suppress-arp`.
+// This config will not be shown with `show running-config interface nve1` but only over gNMI.
+func WithSuppressARP(enable bool) NVEOption {
+	return func(n *NVE) error {
+		n.suppressARP = ygot.Bool(enable)
+		return nil
+	}
+}
+
+func validateMulticastAddress(addr string) (*netip.Addr, error) {
+	ip, err := netip.ParseAddr(addr)
+	if err != nil {
+		return nil, ErrInvalidFormatIPAddress
+	}
+	if !ip.Is4() || !ip.IsMulticast() {
+		return nil, fmt.Errorf("nve: invalid multicast IPv4 address: %s", addr)
+	}
+	return &ip, nil
+}
+
+// WithMulticastGroupL2 configures the global multicast group for the Layer 2 VNI.
+// Addr must be a valid IPv4 multicast address.
+func WithMulticastGroupL2(addr string) NVEOption {
+	return func(n *NVE) error {
+		ip, err := validateMulticastAddress(addr)
+		if err != nil {
+			return err
+		}
+		n.mcastL2 = ip
+		return nil
+	}
+}
+
+// WithMulticastGroupL3 configures the global multicast group for the Layer 3 VNI.
+// Addr must be a valid IPv4 multicast address.
+func WithMulticastGroupL3(addr string) NVEOption {
+	return func(n *NVE) error {
+		ip, err := validateMulticastAddress(addr)
+		if err != nil {
+			return err
+		}
+		n.mcastL3 = ip
+		return nil
+	}
+}
+
+// WithHoldDownTime sets the hold down time for the NVE interface in seconds (1-1500).
+func WithHoldDownTime(seconds uint16) NVEOption {
+	return func(n *NVE) error {
+		if seconds < 1 || seconds > 1500 {
+			return ErrInvalidHoldDownTime
+		}
+		n.holdDownTime = seconds
+		return nil
+	}
+}
+
+// ToYGOT converts the NVE configuration to these gNMI updates:
+//   - enable the NV feature on the device
+//   - configure the NVE interface with the provided settings
+//   - enable the NG-MVPN feature (only if a multicast group for L3 is set)
+func (n *NVE) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+	updates := []gnmiext.Update{}
+	val := nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{}
+
+	val.AdminSt = nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled
+	if !n.adminSt {
+		val.AdminSt = nxos.Cisco_NX_OSDevice_Nw_AdminSt_disabled
+	}
+
+	switch n.hostReach {
+	case HostReachBGP:
+		val.HostReach = nxos.Cisco_NX_OSDevice_Nvo_HostReachT_bgp
+	case HostReachFloodAndLearn:
+		val.HostReach = nxos.Cisco_NX_OSDevice_Nvo_HostReachT_Flood_and_learn
+	default:
+		// No-op
+	}
+
+	val.AdvertiseVmac = n.advertiseVirtualRmac
+
+	if n.sourceInterface != "" {
+		val.SourceInterface = ygot.String(n.sourceInterface)
+		if n.anycastInterface != "" {
+			val.AnycastIntf = ygot.String(n.anycastInterface)
+		}
+	}
+
+	val.SuppressARP = n.suppressARP
+
+	if n.mcastL2 != nil {
+		val.McastGroupL2 = ygot.String(n.mcastL2.String())
+	}
+	if n.mcastL3 != nil {
+		updates = append(updates, gnmiext.EditingUpdate{
+			XPath: "/System/fm-items/ngmvpn-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		})
+		val.McastGroupL3 = ygot.String(n.mcastL3.String())
+	}
+
+	if n.holdDownTime != 0 {
+		val.HoldDownTime = ygot.Uint16(n.holdDownTime)
+	}
+
+	return append(updates, []gnmiext.Update{
+		gnmiext.EditingUpdate{
+			XPath: "/System/fm-items/nvo-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+			},
+		},
+		gnmiext.ReplacingUpdate{
+			XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+			Value: &val,
+		},
+	}...), nil
+}
+
+// Reset removes the nve1 interface and disables the NV and NGMVPN feature on the device.
+func (n *NVE) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+	return []gnmiext.Update{
+		gnmiext.DeletingUpdate{
+			XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+		},
+		gnmiext.EditingUpdate{
+			XPath: "/System/fm-items/ngmvpn-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+			},
+		},
+		gnmiext.EditingUpdate{
+			XPath: "/System/fm-items/nvo-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+			},
+		},
+	}, nil
+}

--- a/internal/provider/cisco/nxos/nve/nve_test.go
+++ b/internal/provider/cisco/nxos/nve/nve_test.go
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package nve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+func Test_NewNVE(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     []NVEOption
+		shouldError bool
+	}{
+		{
+			name:        "valid: default NVE with no options",
+			options:     nil,
+			shouldError: false,
+		},
+		{
+			name:        "valid: set admin state to false",
+			options:     []NVEOption{WithAdminState(false)},
+			shouldError: false,
+		},
+		{
+			name:        "valid: set advertise virtual rmac to true",
+			options:     []NVEOption{WithAdvertiseVirtualRmac(true)},
+			shouldError: false,
+		},
+		{
+			name:        "valid: set advertise virtual rmac to false",
+			options:     []NVEOption{WithAdvertiseVirtualRmac(false)},
+			shouldError: false,
+		},
+		{
+			name:        "valid: set host reachability protocol to BGP",
+			options:     []NVEOption{WithHostReachabilityProtocol(HostReachBGP)},
+			shouldError: false,
+		},
+		{
+			name:        "valid: set host reachability protocol to Flood and Learn",
+			options:     []NVEOption{WithHostReachabilityProtocol(HostReachFloodAndLearn)},
+			shouldError: false,
+		},
+		{
+			name:        "valid: set host reachability protocol to random",
+			options:     []NVEOption{WithHostReachabilityProtocol(1000)},
+			shouldError: true,
+		},
+		{
+			name:        "valid: set source interface",
+			options:     []NVEOption{WithSourceInterface("loopback0")},
+			shouldError: false,
+		},
+		{
+			name:        "invalid: set invalid source interface name",
+			options:     []NVEOption{WithSourceInterface("eth1/1")},
+			shouldError: true,
+		},
+		{
+			name:        "invalid: set invalid source interface number",
+			options:     []NVEOption{WithSourceInterface("loopback1024")},
+			shouldError: true,
+		},
+		{
+			name:        "invalid: set anycast interface without source interface",
+			options:     []NVEOption{WithAnycastInterface("loopback1")},
+			shouldError: true,
+		},
+		{
+			name:        "valid: set source and anycast interfaces",
+			options:     []NVEOption{WithSourceInterface("loopback0"), WithAnycastInterface("loopback1")},
+			shouldError: false,
+		},
+		{
+			name:        "invalid: set same source and anycast interfaces",
+			options:     []NVEOption{WithSourceInterface("loopback0"), WithAnycastInterface("loopback0")},
+			shouldError: true,
+		},
+		{
+			name:        "invalid: source interface is correct but anycast is not",
+			options:     []NVEOption{WithSourceInterface("loopback0"), WithAnycastInterface("loopback1900")},
+			shouldError: true,
+		},
+		{
+			name: "valid: set all options required by example config sample",
+			options: []NVEOption{
+				WithAdminState(false),
+				WithSourceInterface("loopback0"),
+				WithAnycastInterface("loopback1"),
+				WithHostReachabilityProtocol(HostReachBGP),
+				WithAdvertiseVirtualRmac(true),
+				WithMulticastGroupL2("238.0.0.1"),
+				WithHoldDownTime(300),
+				WithSuppressARP(true),
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewNVE(tt.options...)
+			if tt.shouldError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tt.shouldError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// updateCheck is used to validate updates in tests and helper functions.
+type updateCheck struct {
+	updateIdx   int    // the position we want to check in the returned slice of updates
+	expectType  string // "EditingUpdate", "ReplacingUpdate", or "DeletingUpdate"
+	expectXPath string // the expected XPath of the update
+	expectValue any    // the expected ygot object that should be in the update
+}
+
+func Test_NVE_ToYGOT(t *testing.T) {
+	tests := []struct {
+		name                    string
+		options                 []NVEOption
+		expectedNumberOfUpdates int
+		updateChecks            []updateCheck
+	}{
+		{
+			name:                    "valid: default NVE",
+			options:                 nil,
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/nvo-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+						AdminSt: nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled,
+					},
+				},
+			},
+		},
+		{
+			name:                    "valid: set admin state to disabled",
+			options:                 []NVEOption{WithAdminState(false)},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+						AdminSt: nxos.Cisco_NX_OSDevice_Nw_AdminSt_disabled,
+					},
+				},
+			},
+		},
+		{
+			name: "valid: disabled but configured interface",
+			options: []NVEOption{
+				WithAdminState(false),
+				WithHostReachabilityProtocol(HostReachFloodAndLearn),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+						AdminSt:   nxos.Cisco_NX_OSDevice_Nw_AdminSt_disabled,
+						HostReach: nxos.Cisco_NX_OSDevice_Nvo_HostReachT_Flood_and_learn,
+					},
+				},
+			},
+		},
+		{
+			name: "valid: don't advertise virtual rmac",
+			options: []NVEOption{
+				WithAdvertiseVirtualRmac(false),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+						AdminSt:       nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled,
+						AdvertiseVmac: ygot.Bool(false),
+					},
+				},
+			},
+		},
+		{
+			name: "valid: full sample configuration",
+			options: []NVEOption{
+				WithSourceInterface("loopback0"),
+				WithAnycastInterface("loopback1"),
+				WithSuppressARP(true),
+				WithHostReachabilityProtocol(HostReachBGP),
+				WithAdvertiseVirtualRmac(true),
+				WithMulticastGroupL2("237.0.0.1"),
+				WithMulticastGroupL3("238.0.0.1"),
+				WithHoldDownTime(300),
+			},
+			expectedNumberOfUpdates: 3,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/ngmvpn-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/nvo-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+					},
+				},
+				{
+					updateIdx:   2,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+						AdminSt:         nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled,
+						SourceInterface: ygot.String("lo0"),
+						AnycastIntf:     ygot.String("lo1"),
+						SuppressARP:     ygot.Bool(true),
+						HostReach:       nxos.Cisco_NX_OSDevice_Nvo_HostReachT_bgp,
+						AdvertiseVmac:   ygot.Bool(true),
+						McastGroupL2:    ygot.String("237.0.0.1"),
+						McastGroupL3:    ygot.String("238.0.0.1"),
+						HoldDownTime:    ygot.Uint16(300),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nve, err := NewNVE(tt.options...)
+			if err != nil {
+				t.Fatalf("unexpected error during NewNVE: %v", err)
+			}
+
+			updates, err := nve.ToYGOT(context.TODO(), &gnmiext.ClientMock{
+				ExistsFunc: func(_ context.Context, _ string) (bool, error) { return true, nil },
+			})
+			if err != nil {
+				t.Fatalf("unexpected error during ToYGOT: %v", err)
+			}
+
+			if len(updates) != tt.expectedNumberOfUpdates {
+				t.Fatalf("expected %d updates, got %d", tt.expectedNumberOfUpdates, len(updates))
+			}
+
+			validateUpdates(t, updates, tt.updateChecks)
+		})
+	}
+}
+
+func Test_NVE_Reset(t *testing.T) {
+	tests := []struct {
+		name                    string
+		options                 []NVEOption
+		expectedNumberOfUpdates int
+		updateChecks            []updateCheck
+	}{
+		{
+			name:                    "valid: reset default NVE",
+			options:                 nil,
+			expectedNumberOfUpdates: 3,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "DeletingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+				},
+				{
+					updateIdx:   1,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/ngmvpn-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+				{
+					updateIdx:   2,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/nvo-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+			},
+		},
+		{
+			name: "valid: reset NVE with some options",
+			options: []NVEOption{
+				WithSourceInterface("loopback0"),
+				WithAnycastInterface("loopback1"),
+			},
+			expectedNumberOfUpdates: 3,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "DeletingUpdate",
+					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+				},
+				{
+					updateIdx:   1,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/ngmvpn-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+				{
+					updateIdx:   2,
+					expectType:  "EditingUpdate",
+					expectXPath: "/System/fm-items/nvo-items",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nve, err := NewNVE(tt.options...)
+			if err != nil {
+				t.Fatalf("unexpected error during NewNVE: %v", err)
+			}
+
+			updates, err := nve.Reset(context.TODO(), &gnmiext.ClientMock{
+				ExistsFunc: func(_ context.Context, _ string) (bool, error) { return true, nil },
+			})
+			if err != nil {
+				t.Fatalf("unexpected error during Reset: %v", err)
+			}
+
+			if len(updates) != tt.expectedNumberOfUpdates {
+				t.Fatalf("expected %d updates, got %d", tt.expectedNumberOfUpdates, len(updates))
+			}
+
+			validateUpdates(t, updates, tt.updateChecks)
+		})
+	}
+}
+
+// validateUpdates is a helper function to validate updates against expected checks.
+func validateUpdates(t *testing.T, updates []gnmiext.Update, checks []updateCheck) {
+	for _, check := range checks {
+		if check.updateIdx >= len(updates) {
+			t.Errorf("missing update at index %d", check.updateIdx)
+			continue
+		}
+
+		update := updates[check.updateIdx]
+		var xpath string
+		var value any
+
+		switch u := update.(type) {
+		case gnmiext.DeletingUpdate:
+			if check.expectType != "DeletingUpdate" {
+				t.Errorf("expected DeletingUpdate at index %d, got %T", check.updateIdx, update)
+				continue
+			}
+			xpath = u.XPath
+		case gnmiext.EditingUpdate:
+			if check.expectType != "EditingUpdate" {
+				t.Errorf("expected EditingUpdate at index %d, got %T", check.updateIdx, update)
+				continue
+			}
+			xpath = u.XPath
+			value = u.Value
+		case gnmiext.ReplacingUpdate: // Handle ReplacingUpdate
+			if check.expectType != "ReplacingUpdate" {
+				t.Errorf("expected ReplacingUpdate at index %d, got %T", check.updateIdx, update)
+				continue
+			}
+			xpath = u.XPath
+			value = u.Value
+		default:
+			t.Errorf("unexpected update type at index %d: %T", check.updateIdx, update)
+			continue
+		}
+
+		if xpath != check.expectXPath {
+			t.Errorf("wrong xpath at index %d, expected '%s', got '%s'", check.updateIdx, check.expectXPath, xpath)
+		}
+
+		if check.expectValue != nil {
+			compareYGOTValues(t, value, check.expectValue, check.updateIdx)
+		}
+	}
+}
+
+// compareYGOTValues is a helper function to compare two ygot.GoStruct values.
+func compareYGOTValues(t *testing.T, actual, expected any, index int) {
+	actualGoStruct, ok1 := actual.(ygot.GoStruct)
+	expectedGoStruct, ok2 := expected.(ygot.GoStruct)
+	if !ok1 || !ok2 {
+		t.Errorf("failed to type assert value or expectValue to ygot.GoStruct at index %d", index)
+		return
+	}
+
+	notification, err := ygot.Diff(actualGoStruct, expectedGoStruct)
+	if err != nil {
+		t.Errorf("failed to compute diff at index %d: %v", index, err)
+		return
+	}
+
+	if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+		t.Errorf("unexpected diff at index %d: %s", index, notification)
+	}
+}


### PR DESCRIPTION
This commit enables configuring the Network Virtualization Edge
(NVE) interface on cisco NXOS.

It supports the following configuration:
```
interface nve1
  no shutdown
  host-reachability protocol bgp
  advertise virtual-rmac
  source-interface loopback1 anycast loopback2
  global suppress-arp
  global mcast-group 225.0.0.0 L2
  source-interface hold-down-time 300
```

which can be achieved with:
```
nveCfg, err := nve.NewNVE(
  nve.WithHostReachabilityProtocol(nve.HostReachBGP),
  nve.WithAdvertiseVirtualRmac(true),
  nve.WithSourceInterface("Loopback1"),
  nve.WithAnycastInterface("Loopback2"),
  nve.WithSuppressARP(true),
  nve.WithMulticastGroupL2("237.0.0.1"),
  nve.WithHoldDownTime(300),
)
```