### PR TITLE
cisco-nxos-provider: fix PhysIf.Reset

### DIFF
--- a/internal/provider/cisco/nxos/iface/l2config.go
+++ b/internal/provider/cisco/nxos/iface/l2config.go
@@ -34,6 +34,9 @@ type L2Config struct {
 }
 
 func NewL2Config(opts ...L2Option) (*L2Config, error) {
+	if len(opts) == 0 {
+		return nil, errors.New("no options provided for L2Config")
+	}
 	l2cfg := &L2Config{}
 	for _, opt := range opts {
 		if err := opt(l2cfg); err != nil {

--- a/internal/provider/cisco/nxos/iface/l3config.go
+++ b/internal/provider/cisco/nxos/iface/l3config.go
@@ -41,6 +41,9 @@ type L3Config struct {
 }
 
 func NewL3Config(opts ...L3Option) (*L3Config, error) {
+	if len(opts) == 0 {
+		return nil, errors.New("no options provided for L2Config")
+	}
 	cfg := &L3Config{}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {

--- a/internal/provider/cisco/nxos/iface/physif.go
+++ b/internal/provider/cisco/nxos/iface/physif.go
@@ -246,16 +246,16 @@ func (p *PhysIf) createL3(pl *nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_
 
 // Reset clears config of the physical interface as well as L2, L3 options.
 //   - In this Cisco Nexus version devices clean up parts of the  models that are related but in different paths of the YANG tree
-//   - Once the base configuration is reset, the remote device will automatically remove the physical interface in the port-channel.
 //   - The same occurs for the L2 and L3 configurations options, except for the spanning tree configuration, which is not automatically reset.
 func (p *PhysIf) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{
 		gnmiext.ReplacingUpdate{
+			XPath: "System/stp-items/inst-items/if-items/If-list[id=" + p.name + "]",
+			Value: &nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{},
+		},
+		gnmiext.ReplacingUpdate{
 			XPath: "System/intf-items/phys-items/PhysIf-list[id=" + p.name + "]",
 			Value: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{},
-		},
-		gnmiext.DeletingUpdate{ // reset spanning tree
-			XPath: "System/stp-items/inst-items/if-items/If-list[id=" + p.name + "]",
 		},
 	}, nil
 }

--- a/internal/provider/cisco/nxos/iface/physif_test.go
+++ b/internal/provider/cisco/nxos/iface/physif_test.go
@@ -4,6 +4,7 @@
 package iface
 
 import (
+	"context"
 	"testing"
 
 	"github.com/openconfig/ygot/ygot"
@@ -19,531 +20,608 @@ const (
 )
 
 func Test_PhysIf_NewPhysicalInterface(t *testing.T) {
-	validNames := []string{"Ethernet1/1", "ethernet1/2", "eth1/1", "eTH1/2", "Eth1/3"}
-	for _, name := range validNames {
-		t.Run(name, func(t *testing.T) {
-			_, err := NewPhysicalInterface(name)
+	tests := []struct {
+		name        string
+		input       string
+		shouldError bool
+	}{
+		// Valid names
+		{"valid: Ethernet1/1", "Ethernet1/1", false},
+		{"valid: eth1/1", "eth1/1", false},
+		// Invalid names
+		{"invalid: lo1", "lo1", true},
+		{"invalid: empty string", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPhysicalInterface(tt.input)
+			if tt.shouldError && err == nil {
+				t.Errorf("expected error for input %q, got nil", tt.input)
+			}
+			if !tt.shouldError && err != nil {
+				t.Errorf("unexpected error for input %q: %v", tt.input, err)
+			}
+		})
+	}
+}
+
+func Test_PhysIf_ToYGOT_WithOptions_Invalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     []PhysIfOption
+		shouldError bool
+	}{
+		{
+			name:        "valid: with description",
+			options:     []PhysIfOption{WithDescription("test interface")},
+			shouldError: false,
+		},
+		{
+			name:        "invalid: nil L2 config",
+			options:     []PhysIfOption{WithPhysIfL2(nil)},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPhysicalInterface("eth1/1", tt.options...)
+			if (err != nil) != tt.shouldError {
+				t.Fatalf("Expected error: %v, got error: %v", tt.shouldError, err)
+			}
+		})
+	}
+}
+
+// mustNewL2Config is a helper to create L2Config and panic on error.
+func mustNewL2Config(opts ...L2Option) *L2Config {
+	l2cfg, err := NewL2Config(opts...)
+	if err != nil {
+		panic("failed to create L2Config: " + err.Error())
+	}
+	return l2cfg
+}
+
+// mustNewL2Config is a helper to create L3Config and panic on error.
+func mustNewL3Config(opts ...L3Option) *L3Config {
+	l3cfg, err := NewL3Config(opts...)
+	if err != nil {
+		panic("failed to create L3Config: " + err.Error())
+	}
+	return l3cfg
+}
+
+type updateCheck struct {
+	updateIdx   int    // the position we want to check in the returned slice of updates
+	expectType  string // "EditingUpdate" or "ReplacingUpdate"
+	expectXPath string // the expected XPath of the update
+	expectValue any    // the expected ygot object that should be in the update
+}
+
+func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
+	tests := []struct {
+		name                    string
+		ifName                  string
+		options                 []PhysIfOption
+		expectedNumberOfUpdates int
+		updateChecks            []updateCheck
+	}{
+		{
+			name:                    "No additional base options",
+			ifName:                  "eth1/1",
+			options:                 []PhysIfOption{WithDescription("this is a test")},
+			expectedNumberOfUpdates: 1,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("this is a test"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						UserCfgdFlags: ygot.String("admin_state"),
+					},
+				},
+			},
+		},
+		{
+			name:   "MTU and VRF",
+			ifName: "eth1/2",
+			options: []PhysIfOption{
+				WithDescription("this is a second test"),
+				WithPhysIfMTU(9216),
+				WithPhysIfVRF(physIfVRFName),
+			},
+			expectedNumberOfUpdates: 1,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/2]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("this is a second test"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Mtu:           ygot.Uint32(9216),
+						UserCfgdFlags: ygot.String("admin_mtu,admin_state"),
+						RtvrfMbrItems: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList_RtvrfMbrItems{
+							TDn: ygot.String("System/inst-items/Inst-list[name=test-vrf]"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "L2 then L3, expect only L3",
+			ifName: "eth1/4",
+			options: []PhysIfOption{
+				WithDescription("L2 then L3 test"),
+				WithPhysIfL2(mustNewL2Config(
+					WithSpanningTree(SpanningTreeModeEdge),
+					WithSwithPortMode(SwitchPortModeTrunk),
+				)),
+				WithPhysIfL3(mustNewL3Config(
+					WithMedium(L3MediumTypeP2P),
+					WithUnnumberedAddressing("loopback0"),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/4]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("L2 then L3 test"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+						Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+					},
+				},
+			},
+		},
+		{
+			name:   "L3 then L2, expect only L2",
+			ifName: "eth1/5",
+			options: []PhysIfOption{
+				WithDescription("L3 then L2 test"),
+				WithPhysIfL3(mustNewL3Config(
+					WithMedium(L3MediumTypeP2P),
+					WithUnnumberedAddressing("loopback0"),
+				)),
+				WithPhysIfL2(mustNewL2Config(
+					WithSpanningTree(SpanningTreeModeEdge),
+					WithSwithPortMode(SwitchPortModeAccess),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/5]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("L3 then L2 test"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_access,
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+					},
+				},
+			},
+		},
+		{
+			name:   "L2 trunk configuration",
+			ifName: "eth1/3",
+			options: []PhysIfOption{
+				WithDescription("L2 trunk test"),
+				WithPhysIfL2(mustNewL2Config(
+					WithSpanningTree(SpanningTreeModeEdge),
+					WithSwithPortMode(SwitchPortModeTrunk),
+					WithNativeVlan(100),
+					WithAllowedVlans([]uint16{10, 20, 30}),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/3]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("L2 trunk test"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
+						Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_trunk,
+						NativeVlan:    ygot.String("vlan-100"),
+						TrunkVlans:    ygot.String("10,20,30"),
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/stp-items/inst-items/if-items/If-list[id=eth1/3]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{
+						AdminSt: nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+						Mode:    nxos.Cisco_NX_OSDevice_Stp_IfMode_edge,
+					},
+				},
+			},
+		},
+		{
+			name:   "L2 access configuration",
+			ifName: "eth2/2",
+			options: []PhysIfOption{
+				WithDescription("L2 access test"),
+				WithPhysIfL2(mustNewL2Config(
+					WithSpanningTree(SpanningTreeModeEdge),
+					WithSwithPortMode(SwitchPortModeAccess),
+					WithAccessVlan(10),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth2/2]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("L2 access test"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
+						Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_access,
+						AccessVlan:    ygot.String("vlan-10"),
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/stp-items/inst-items/if-items/If-list[id=eth2/2]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{
+						AdminSt: nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
+						Mode:    nxos.Cisco_NX_OSDevice_Stp_IfMode_edge,
+					},
+				},
+			},
+		},
+		{
+			name:   "L3 unnumbered configuration",
+			ifName: "eth1/1",
+			options: []PhysIfOption{
+				WithDescription("test interface"),
+				WithPhysIfL3(mustNewL3Config(
+					WithMedium(L3MediumTypeP2P),
+					WithUnnumberedAddressing("loopback0"),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Descr:         ygot.String("test interface"),
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+						Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/ipv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=eth1/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
+						Unnumbered: ygot.String("lo0"),
+					},
+				},
+			},
+		},
+		{
+			name:   "L3 numbered configuration",
+			ifName: "eth3/1",
+			options: []PhysIfOption{
+				WithDescription("test interface"),
+				WithPhysIfL3(mustNewL3Config(
+					WithNumberedAddressingIPv4([]string{"192.0.2.1/8"}),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth3/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Descr:         ygot.String("test interface"),
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/ipv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=eth3/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
+						AddrItems: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems{
+							AddrList: map[string]*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems_AddrList{
+								"192.0.2.1/8": {
+									Addr: ygot.String("192.0.2.1/8"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "VRF with L3 unnumbered configuration",
+			ifName: "eth1/1",
+			options: []PhysIfOption{
+				WithDescription("test interface"),
+				WithPhysIfVRF(physIfVRFName),
+				WithPhysIfL3(mustNewL3Config(
+					WithMedium(L3MediumTypeP2P),
+					WithUnnumberedAddressing("loopback0"),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("test interface"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+						Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+						RtvrfMbrItems: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList_RtvrfMbrItems{
+							TDn: ygot.String("System/inst-items/Inst-list[name=test-vrf]"),
+						},
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/ipv4-items/inst-items/dom-items/Dom-list[name=test-vrf]/if-items/If-list[id=eth1/1]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
+						Unnumbered: ygot.String("lo0"),
+					},
+				},
+			},
+		},
+		{
+			name:   "VRF with L3 numbered configuration",
+			ifName: "eth3/3",
+			options: []PhysIfOption{
+				WithDescription("test interface"),
+				WithPhysIfVRF(physIfVRFName),
+				WithPhysIfL3(mustNewL3Config(
+					WithNumberedAddressingIPv4([]string{"192.0.2.1/8"}),
+				)),
+			},
+			expectedNumberOfUpdates: 2,
+			updateChecks: []updateCheck{
+				{
+					updateIdx:   0,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/intf-items/phys-items/PhysIf-list[id=eth3/3]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
+						Descr:         ygot.String("test interface"),
+						AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
+						Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
+						UserCfgdFlags: ygot.String("admin_layer,admin_state"),
+						RtvrfMbrItems: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList_RtvrfMbrItems{
+							TDn: ygot.String("System/inst-items/Inst-list[name=test-vrf]"),
+						},
+					},
+				},
+				{
+					updateIdx:   1,
+					expectType:  "ReplacingUpdate",
+					expectXPath: "System/ipv4-items/inst-items/dom-items/Dom-list[name=test-vrf]/if-items/If-list[id=eth3/3]",
+					expectValue: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
+						AddrItems: &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems{
+							AddrList: map[string]*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems_AddrList{
+								"192.0.2.1/8": {
+									Addr: ygot.String("192.0.2.1/8"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewPhysicalInterface(tt.ifName, tt.options...)
 			if err != nil {
 				t.Fatalf("failed to create physical interface: %v", err)
 			}
+
+			updates, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
+			if err != nil {
+				t.Fatalf("unexpected error during ToYGOT: %v", err)
+			}
+
+			if len(updates) != tt.expectedNumberOfUpdates {
+				t.Fatalf("expected %d updates, got %d", tt.expectedNumberOfUpdates, len(updates))
+			}
+
+			validateUpdates(t, updates, tt.updateChecks)
 		})
 	}
-	invalidNames := []string{"test", "ether1/1", "ethernet1.1", "eth1/1/1", "port-channel01", "po100"}
-	for _, name := range invalidNames {
-		t.Run(name, func(t *testing.T) {
-			_, err := NewPhysicalInterface(name)
-			if err == nil {
-				t.Fatalf("created interface with invalid name: %s", name)
+}
+
+func Test_PhysIf_Reset(t *testing.T) {
+	tests := []struct {
+		name          string
+		ifName        string
+		options       []PhysIfOption
+		expectUpdates []struct {
+			XPath string
+			Value any
+		}
+	}{
+		{
+			name:   "basic reset",
+			ifName: "eth1/1",
+			options: []PhysIfOption{
+				WithDescription("test interface"),
+			},
+			expectUpdates: []struct {
+				XPath string
+				Value any
+			}{
+				{
+					XPath: "System/stp-items/inst-items/if-items/If-list[id=eth1/1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{},
+				},
+				{
+					XPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{},
+				},
+			},
+		},
+		{
+			name:   "reset with L2 configuration",
+			ifName: "eth1/2",
+			options: []PhysIfOption{
+				WithDescription("L2 test interface"),
+				WithPhysIfL2(&L2Config{}),
+			},
+			expectUpdates: []struct {
+				XPath string
+				Value any
+			}{
+				{
+					XPath: "System/stp-items/inst-items/if-items/If-list[id=eth1/2]",
+					Value: &nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{},
+				},
+				{
+					XPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/2]",
+					Value: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{},
+				},
+			},
+		},
+		{
+			name:   "reset with L3 configuration",
+			ifName: "eth1/3",
+			options: []PhysIfOption{
+				WithDescription("L3 test interface"),
+				WithPhysIfL3(&L3Config{
+					medium:             L3MediumTypeP2P,
+					unnumberedLoopback: "lo0",
+				}),
+			},
+			expectUpdates: []struct {
+				XPath string
+				Value any
+			}{
+				{
+					XPath: "System/stp-items/inst-items/if-items/If-list[id=eth1/3]",
+					Value: &nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{},
+				},
+				{
+					XPath: "System/intf-items/phys-items/PhysIf-list[id=eth1/3]",
+					Value: &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewPhysicalInterface(tt.ifName, tt.options...)
+			if err != nil {
+				t.Fatalf("failed to create physical interface: %v", err)
+			}
+
+			got, err := p.Reset(context.Background(), nil)
+			if err != nil {
+				t.Errorf("unexpected error during reset: %v", err)
+			}
+
+			if len(got) != len(tt.expectUpdates) {
+				t.Errorf("expected %d updates, got %d", len(tt.expectUpdates), len(got))
+			}
+
+			for i, expect := range tt.expectUpdates {
+				if i >= len(got) {
+					t.Errorf("missing update for expected xpath '%s'", expect.XPath)
+					continue
+				}
+				update, ok := got[i].(gnmiext.ReplacingUpdate)
+				if !ok {
+					t.Errorf("expected value to be of type ReplacingUpdate at index %d", i)
+					continue
+				}
+				if update.XPath != expect.XPath {
+					t.Errorf("wrong xpath at index %d, expected '%s', got '%s'", i, expect.XPath, update.XPath)
+				}
+
+				expectValue := expect.Value.(ygot.GoStruct)
+				notification, err := ygot.Diff(update.Value, expectValue)
+				if err != nil {
+					t.Errorf("failed to compute diff at index %d: %v", i, err)
+				}
+				if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+					t.Errorf("unexpected diff at index %d: %s", i, notification)
+				}
 			}
 		})
 	}
 }
 
-// tests base configuration of the physical interface is correctly initialized
-func Test_PhysIf_ToYGOT_BaseConfig(t *testing.T) {
-	t.Run("No additional base options", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription))
+func validateUpdates(t *testing.T, updates []gnmiext.Update, updateChecks []updateCheck) {
+	for _, check := range updateChecks {
+		var update any
+		switch check.expectType {
+		case "EditingUpdate":
+			update, _ = updates[check.updateIdx].(gnmiext.EditingUpdate)
+		case "ReplacingUpdate":
+			update, _ = updates[check.updateIdx].(gnmiext.ReplacingUpdate)
+		default:
+			t.Fatalf("unknown expectType: %s", check.expectType)
+		}
+		if update == nil {
+			t.Errorf("expected value to be of type %s at index %d", check.expectType, check.updateIdx)
+			continue
+		}
+		var xpath string
+		var value any
+		switch u := update.(type) {
+		case gnmiext.EditingUpdate:
+			xpath = u.XPath
+			value = u.Value
+		case gnmiext.ReplacingUpdate:
+			xpath = u.XPath
+			value = u.Value
+		}
+		if xpath != check.expectXPath {
+			t.Errorf("wrong xpath at index %d, expected '%s', got '%s'", check.updateIdx, check.expectXPath, xpath)
+		}
+		valueGoStruct, ok1 := value.(ygot.GoStruct)
+		expectValueGoStruct, ok2 := check.expectValue.(ygot.GoStruct)
+		if !ok1 || !ok2 {
+			t.Errorf("failed to type assert value or expectValue to ygot.GoStruct at index %d", check.updateIdx)
+			continue
+		}
+		notification, err := ygot.Diff(valueGoStruct, expectValueGoStruct)
 		if err != nil {
-			t.Fatalf("failed to create physical interface")
-		}
-
-		got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-
-		// single update affecting only base configuration of physical interface
-		if len(got) != 1 {
-			t.Errorf("expected 1 update, got %d", len(got))
-		}
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+p.name+"]" {
-			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
-		}
-
-		// correct initialization
-		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
-			Descr:         ygot.String(physIfDescription),
-			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
-			UserCfgdFlags: ygot.String("admin_state"),
-		}
-		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(phGot, phRef)
-		if err != nil {
-			t.Errorf("failed to compute diff")
+			t.Errorf("failed to compute diff: %v", err)
 		}
 		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
+			t.Errorf("unexpected diff at index %d: %s", check.updateIdx, notification)
 		}
-	})
-	t.Run("MTU and VRF", func(t *testing.T) {
-		p, err := NewPhysicalInterface(
-			physIfName,
-			WithDescription(physIfDescription),
-			WithPhysIfMTU(9216),
-			WithPhysIfVRF(physIfVRFName),
-		)
-		if err != nil {
-			t.Fatalf("failed to create physical interface")
-		}
-
-		got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-
-		// single update affecting only base configuration of physical interface
-		if len(got) != 1 {
-			t.Errorf("expected 1 update, got %d", len(got))
-		}
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+p.name+"]" {
-			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
-		}
-
-		// correct initialization
-		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
-			Descr:         ygot.String(physIfDescription),
-			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
-			Mtu:           ygot.Uint32(9216),
-			UserCfgdFlags: ygot.String("admin_mtu,admin_state"),
-		}
-		phRef.GetOrCreateRtvrfMbrItems().TDn = ygot.String("System/inst-items/Inst-list[name=" + physIfVRFName + "]")
-		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(phGot, phRef)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-}
-
-func Test_PhysIf_Reset_BaseConfig(t *testing.T) {
-	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription))
-	if err != nil {
-		t.Fatalf("failed to create physical interface")
 	}
-
-	got, err := p.Reset(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// expect 2 updates: base config and spanning tree
-	if len(got) != 2 {
-		t.Errorf("expected 2 update, got %d", len(got))
-	}
-	t.Run("Base config", func(t *testing.T) {
-		// checks on base config update
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type EditingUpdate")
-		}
-		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+p.name+"]" {
-			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id=%s]', got '%s'", p.name, bUpdate.XPath)
-		}
-		phRef := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{}
-		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(phGot, &phRef)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-}
-
-// Test_PhysIf_ToYGOT_WithL2AndL3 verifies that when both L2 and L3 options are supplied,
-// only the last one is applied, per contract.
-func Test_PhysIf_ToYGOT_WithL2AndL3(t *testing.T) {
-	l2cfg, err := NewL2Config()
-	if err != nil {
-		t.Fatalf("unexpected error while creating L2 config: %v", err)
-	}
-	l3cfg, err := NewL3Config()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	t.Run("L2 with VRF is not allowed", func(t *testing.T) {
-		_, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfVRF(physIfVRFName))
-		if err == nil {
-			t.Fatalf("expected error when creating physical interface with L2 and VRF, got nil")
-		}
-	})
-	t.Run("L2 then L3, expect only L3", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg), WithPhysIfL3(l3cfg))
-		if err != nil {
-			t.Fatalf("failed to create physical interface")
-		}
-		if p.l2 != nil {
-			t.Errorf("expected L2 to be nil")
-		}
-		if p.l3 == nil {
-			t.Errorf("expected L3 to be set")
-		}
-	})
-
-	t.Run("L3 then L2, expect only L2", func(t *testing.T) {
-		p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg), WithPhysIfL2(l2cfg))
-		if err != nil {
-			t.Fatalf("failed to create physical interface")
-		}
-		if p.l2 == nil {
-			t.Errorf("expected L2 to be set")
-		}
-		if p.l3 != nil {
-			t.Errorf("expected L3 to be nil")
-		}
-	})
-}
-
-func Test_PhysIf_ToYGOT_WithL2_Trunk(t *testing.T) {
-	l2cfg, err := NewL2Config(
-		WithSpanningTree(SpanningTreeModeEdge),
-		WithSwithPortMode(SwitchPortModeTrunk),
-		WithNativeVlan(100),
-		WithAllowedVlans([]uint16{10, 20, 30}),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error while creating L2 config: %v", err)
-	}
-	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg))
-	if err != nil {
-		t.Fatalf("failed to create physical interface")
-	}
-	got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(got) != 2 {
-		t.Errorf("expected 2 update, got %d", len(got))
-	}
-	t.Run("Base config", func(t *testing.T) {
-		// check base config: additional layer option and switchport mode
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		if bUpdate.Value == nil {
-			t.Errorf("expected value to be set")
-		}
-		phRef := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
-			Descr:         ygot.String(physIfDescription),
-			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
-			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
-			Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_trunk,
-			NativeVlan:    ygot.String("vlan-100"), // required by NX-OS
-			TrunkVlans:    ygot.String("10,20,30"),
-			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
-		}
-		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(phGot, &phRef)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-
-	// check l2 config: a single update for spanning tree
-	t.Run("Spanning tree config", func(t *testing.T) {
-		l2Update, ok := got[1].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		expectPath := "System/stp-items/inst-items/if-items/If-list[id=" + p.name + "]"
-		if l2Update.XPath != expectPath {
-			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, l2Update.XPath)
-		}
-		stRef := nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{
-			AdminSt: nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
-			Mode:    nxos.Cisco_NX_OSDevice_Stp_IfMode_edge,
-		}
-		stGot := l2Update.Value.(*nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList)
-		if *stGot != stRef {
-			t.Errorf("spanning tree config mismatch")
-		}
-	})
-}
-
-func Test_PhysIf_ToYGOT_WithL2_Access(t *testing.T) {
-	l2cfg, err := NewL2Config(
-		WithSpanningTree(SpanningTreeModeEdge),
-		WithSwithPortMode(SwitchPortModeAccess),
-		WithAccessVlan(10),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error while creating L2 config: %v", err)
-	}
-	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL2(l2cfg))
-	if err != nil {
-		t.Fatalf("failed to create physical interface")
-	}
-	got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(got) != 2 {
-		t.Errorf("expected 2 update, got %d", len(got))
-	}
-	t.Run("Base config", func(t *testing.T) {
-		// check base config: additional layer option and switchport mode
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		if bUpdate.Value == nil {
-			t.Errorf("expected value to be set")
-		}
-		phRef := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
-			Descr:         ygot.String(physIfDescription),
-			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
-			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer2,
-			Mode:          nxos.Cisco_NX_OSDevice_L1_Mode_access,
-			AccessVlan:    ygot.String("vlan-10"),
-			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
-		}
-		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(phGot, &phRef)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-
-	// check l2 config: a single update for spanning tree
-	t.Run("Spanning tree config", func(t *testing.T) {
-		l2Update, ok := got[1].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		expectPath := "System/stp-items/inst-items/if-items/If-list[id=" + p.name + "]"
-		if l2Update.XPath != expectPath {
-			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, l2Update.XPath)
-		}
-		stRef := nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList{
-			AdminSt: nxos.Cisco_NX_OSDevice_Nw_IfAdminSt_enabled,
-			Mode:    nxos.Cisco_NX_OSDevice_Stp_IfMode_edge,
-		}
-		stGot := l2Update.Value.(*nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList)
-		if *stGot != stRef {
-			t.Errorf("spanning tree config mismatch")
-		}
-	})
-}
-
-func Test_PhysIf_ToYGOT_WithL3(t *testing.T) {
-	l3cfg, err := NewL3Config(
-		WithMedium(L3MediumTypeP2P),
-		WithUnnumberedAddressing("loopback0"),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg))
-	if err != nil {
-		t.Fatalf("failed to create physical interface")
-	}
-	got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(got) != 2 {
-		t.Errorf("expected 2 update, got %d", len(got))
-	}
-
-	t.Run("Base config", func(t *testing.T) {
-		// check base config: additional layer option and switchport mode
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		if bUpdate.Value == nil {
-			t.Errorf("expected value to be set")
-		}
-		phExpect := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
-			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
-			Descr:         ygot.String(physIfDescription),
-			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
-			Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
-			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
-		}
-		ph := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(ph, &phExpect)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-
-	t.Run("Addressing config: unnumbered loopback0", func(t *testing.T) {
-		// check addressing config: a single update for addressing
-		aUpdate, ok := got[1].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		expectPath := "System/ipv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=" + p.name + "]"
-		if aUpdate.XPath != expectPath {
-			t.Errorf("wrong xpath, expected '%s', got '%s'", expectPath, aUpdate.XPath)
-		}
-		addrRef := nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList{
-			Unnumbered: ygot.String("lo0"),
-		}
-		addrGot := aUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
-		notification, err := ygot.Diff(&addrRef, addrGot)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-
-	// numbered addressing
-	t.Run("Addressing config: numbered", func(t *testing.T) {
-		l3cfg, err := NewL3Config(
-			WithNumberedAddressingIPv4([]string{"192.0.2.1/8"}),
-		)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		p2, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg))
-		if err != nil {
-			t.Fatalf("failed to create physical interface")
-		}
-		got, err := p2.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		aUpdate, ok := got[1].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		addrGot := aUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
-		if addrGot.Unnumbered != nil {
-			t.Errorf("expected unnumbered to be nil")
-		}
-		if addrGot.GetAddrItems().GetAddrList("192.0.2.1/8") == nil {
-			t.Errorf("address is not set")
-		}
-	})
-}
-
-func Test_PhysIf_Reset_WithL3(t *testing.T) {
-	l3cfg, err := NewL3Config(
-		WithMedium(L3MediumTypeP2P),
-		WithUnnumberedAddressing("loopback0"),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	p, err := NewPhysicalInterface(physIfName, WithDescription(physIfDescription), WithPhysIfL3(l3cfg))
-	if err != nil {
-		t.Fatalf("failed to create physical interface")
-	}
-	got, err := p.Reset(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	// expect 2 updates: base config and L2 spanning tree reset, which is not automatically reset. The L3 config
-	// is automatically removed when resetting the physical interface.
-	if len(got) != 2 {
-		t.Errorf("expected 2 update, got %d", len(got))
-	}
-	t.Run("Base config", func(t *testing.T) {
-		// check base config: additional layer option and switchport mode
-		phUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		phGot := phUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		phExpect := nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{}
-		notification, err := ygot.Diff(&phExpect, phGot)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-}
-
-// Configuring a VRF on an interface influences the xpath in several updates
-func Test_PhysIf_ToYGOT_VRF(t *testing.T) {
-	l3cfg, err := NewL3Config(
-		WithMedium(L3MediumTypeP2P),
-		WithUnnumberedAddressing("loopback0"),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	p, err := NewPhysicalInterface(
-		physIfName,
-		WithDescription(physIfDescription),
-		WithPhysIfVRF(physIfVRFName),
-		WithPhysIfL3(l3cfg),
-	)
-	if err != nil {
-		t.Fatalf("failed to create physical interface")
-	}
-
-	got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// single update affecting only base configuration of physical interface
-	if len(got) != 2 {
-		t.Errorf("expected 2 update, got %d", len(got))
-	}
-
-	t.Run("Base config", func(t *testing.T) {
-		bUpdate, ok := got[0].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Errorf("expected value to be of type ReplacingUpdate")
-		}
-		if bUpdate.XPath != "System/intf-items/phys-items/PhysIf-list[id="+physIfName+"]" {
-			t.Errorf("wrong xpath, expected 'System/intf-items/phys-items/PhysIf-list[id="+physIfName+"]', got '%s'", bUpdate.XPath)
-		}
-
-		phRef := &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList{
-			Descr:         ygot.String(physIfDescription),
-			AdminSt:       nxos.Cisco_NX_OSDevice_L1_AdminSt_up,
-			Layer:         nxos.Cisco_NX_OSDevice_L1_Layer_Layer3,
-			Medium:        nxos.Cisco_NX_OSDevice_L1_Medium_p2p,
-			UserCfgdFlags: ygot.String("admin_layer,admin_state"),
-		}
-		phRef.GetOrCreateRtvrfMbrItems().TDn = ygot.String("System/inst-items/Inst-list[name=" + physIfVRFName + "]")
-		phGot := bUpdate.Value.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
-		notification, err := ygot.Diff(phGot, phRef)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", notification)
-		}
-	})
-
-	t.Run("Addressing", func(t *testing.T) {
-		aUpdate := got[1].(gnmiext.ReplacingUpdate)
-		if aUpdate.XPath != "System/ipv4-items/inst-items/dom-items/Dom-list[name="+physIfVRFName+"]/if-items/If-list[id="+physIfName+"]" {
-			t.Errorf("wrong xpath, expected 'System/ipv4-items/inst-items/dom-items/Dom-list[name="+physIfVRFName+"]/if-items/If-list[id="+physIfName+"]', got '%s'", aUpdate.XPath)
-		}
-	})
 }


### PR DESCRIPTION
* DeletingUpdates fail when trying to delete the spanning tree of a physical interface from the data model. Instead, it suffices to unset the value.
* Refactored the tests to adopt a more table-driven style.
* Return error when initializing L2Config and L3Config with no Options.