### PR TITLE
cisco-nxos-provider: rename vlan to settings

### DIFF
--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -585,7 +585,7 @@ type VLAN struct{ LongName bool }
 func (step *VLAN) Name() string             { return "VLAN" }
 func (step *VLAN) Deps() []client.ObjectKey { return nil }
 func (step *VLAN) Exec(ctx context.Context, s *Scope) error {
-	v := &vlan.VLAN{LongName: step.LongName}
+	v := &vlan.Settings{LongName: step.LongName}
 	return s.GNMI.Update(ctx, v)
 }
 

--- a/internal/provider/cisco/nxos/vlan/settings.go
+++ b/internal/provider/cisco/nxos/vlan/settings.go
@@ -12,29 +12,27 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
 )
 
-var _ gnmiext.DeviceConf = (*VLAN)(nil)
+var _ gnmiext.DeviceConf = (*Settings)(nil)
 
-type VLAN struct {
+// Settings represents the settings shared among all VLANs
+type Settings struct {
 	// If configured as "true" then long strings will be allowed when naming VLANs
 	LongName bool
 }
 
-func (n *VLAN) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+func (s *Settings) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{
 		gnmiext.EditingUpdate{
 			XPath: "System/vlanmgr-items/inst-items",
-			Value: &nxos.Cisco_NX_OSDevice_System_VlanmgrItems_InstItems{LongName: ygot.Bool(n.LongName)},
+			Value: &nxos.Cisco_NX_OSDevice_System_VlanmgrItems_InstItems{LongName: ygot.Bool(s.LongName)},
 		},
 	}, nil
 }
 
-func (v *VLAN) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
-	vlan := &nxos.Cisco_NX_OSDevice_System_VlanmgrItems_InstItems{}
-	vlan.PopulateDefaults()
+func (s *Settings) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{
-		gnmiext.EditingUpdate{
+		gnmiext.DeletingUpdate{
 			XPath: "System/vlanmgr-items/inst-items",
-			Value: vlan,
 		},
 	}, nil
 }

--- a/internal/provider/cisco/nxos/vlan/settings_test.go
+++ b/internal/provider/cisco/nxos/vlan/settings_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
 )
 
-func Test_VLAN(t *testing.T) {
-	vlan := &VLAN{
+func Test_Settings(t *testing.T) {
+	Settings := &Settings{
 		LongName: true,
 	}
 
-	got, err := vlan.ToYGOT(t.Context(), &gnmiext.ClientMock{})
+	got, err := Settings.ToYGOT(t.Context(), &gnmiext.ClientMock{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Struct `VLAN` defines a control plane setting instead of a VLAN. We here rename it to `Settings`.