### PR TITLE
cisco-nxos-provider: gnmiext standard JSON

### DIFF
--- a/internal/provider/cisco/nxos/bgp/bgp_test.go
+++ b/internal/provider/cisco/nxos/bgp/bgp_test.go
@@ -605,7 +605,7 @@ func TestBGPPeer_ToYGOT_MissingBGPInstance(t *testing.T) {
 	}
 
 	client := &gnmiext.ClientMock{
-		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 			return gnmiext.ErrNil
 		},
 	}
@@ -628,7 +628,7 @@ func TestBGPPeer_ToYGOT_GetError(t *testing.T) {
 
 	expectedErr := errors.New("get error")
 	client := &gnmiext.ClientMock{
-		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 			return expectedErr
 		},
 	}
@@ -650,7 +650,7 @@ func TestBGPPeer_ToYGOT_Success(t *testing.T) {
 	}
 
 	client := &gnmiext.ClientMock{
-		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 			if xpath != "System/bgp-items/inst-items" {
 				t.Errorf("BGPPeer.ToYGOT() unexpected xpath = %v", xpath)
 			}

--- a/internal/provider/cisco/nxos/snmp/snmp_test.go
+++ b/internal/provider/cisco/nxos/snmp/snmp_test.go
@@ -94,7 +94,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 	tests := []struct {
 		name            string
 		snmp            *SNMP
-		mockGet         func(ctx context.Context, xpath string, dest ygot.GoStruct) error
+		mockGet         func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error
 		wantErr         bool
 		wantUpdateCount int
 		wantContact     string
@@ -125,7 +125,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 				},
 				Traps: []string{},
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 					res.LocalUserList["admin"] = &nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList{}
@@ -155,7 +155,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 					},
 				},
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -177,7 +177,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 					},
 				},
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -190,7 +190,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 			snmp: &SNMP{
 				Traps: []string{"invalid-trap-name"},
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -211,7 +211,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 					},
 				},
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -223,7 +223,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 		{
 			name: "empty configuration",
 			snmp: &SNMP{},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -239,7 +239,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 				Location: "", // Empty location should use DME_UNSET_PROPERTY_MARKER
 				SrcIf:    "", // Empty source interface should use DME_UNSET_PROPERTY_MARKER
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -268,7 +268,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 					},
 				},
 			},
-			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+			mockGet: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 				if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 					res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				}
@@ -329,7 +329,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 
 func TestSNMP_Reset(t *testing.T) {
 	mockClient := &gnmiext.ClientMock{
-		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct) error {
+		GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
 			if res, ok := dest.(*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems); ok {
 				res.LocalUserList = make(map[string]*nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList)
 				res.LocalUserList["admin"] = &nxos.Cisco_NX_OSDevice_System_SnmpItems_InstItems_LclUserItems_LocalUserList{}


### PR DESCRIPTION
* In some gNMI responses Cisco returns JSON objects that are not
      compliant with RFC7951, e.g., operational data. This commit adds an
    option to unmarshall gNMI responses using std JSON instead of ygot
    unmarshaller. This option allows a developer to define customized ygot
    structs that can be still processed by the gnmiext package. An example
    to do is provided in client_test.go.