### PR TITLE
cisco-nxos-provider: add support for management interface

### DIFF
--- a/internal/provider/cisco/nxos/iface/getter_test.go
+++ b/internal/provider/cisco/nxos/iface/getter_test.go
@@ -198,6 +198,41 @@ func TestExists(t *testing.T) {
 			wantExists: false,
 			wantErr:    true,
 		},
+
+		// Management interface cases
+		{
+			name:          "management interface exists",
+			interfaceName: "mgmt0",
+			fn: func(_ context.Context, xpath string) (bool, error) {
+				if xpath == "System/mgmt-items/MgmtIf-list[id=mgmt0]" {
+					return true, nil
+				}
+				return false, errors.New("unexpected xpath")
+			},
+			wantExists: true,
+			wantErr:    false,
+		},
+		{
+			name:          "management interface does not exist - ErrNil",
+			interfaceName: "mgmt0",
+			fn: func(_ context.Context, xpath string) (bool, error) {
+				if xpath == "System/mgmt-items/MgmtIf-list[id=mgmt0]" {
+					return false, nil
+				}
+				return false, errors.New("unexpected xpath")
+			},
+			wantExists: false,
+			wantErr:    false,
+		},
+		{
+			name:          "invalid management interface - mgmt1",
+			interfaceName: "mgmt1",
+			fn: func(ctx context.Context, xpath string) (bool, error) {
+				return false, errors.New("should not be called")
+			},
+			wantExists: false,
+			wantErr:    true,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/provider/cisco/nxos/iface/name_test.go
+++ b/internal/provider/cisco/nxos/iface/name_test.go
@@ -121,6 +121,20 @@ func TestShortName(t *testing.T) {
 			expected: "",
 			wantErr:  true,
 		},
+
+		// Management interface names
+		{
+			name:     "valid management interface",
+			input:    "mgmt0",
+			expected: "mgmt0",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid management interface",
+			input:    "mgmt1",
+			expected: "",
+			wantErr:  true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This patch adds support for querying the management interface (`mgmt0`) as part of the `iface.Exists` and `iface.ShortName` functions. This is provided mainly to add compatibility for cases, when a configuration item references an interface, to have a single point of checks that can be integrated, without checking for the management interface everywhere.