### PR TITLE
cisco-nxos-provider: fix ISIS updates

### DIFF
--- a/internal/provider/cisco/nxos/isis/interface.go
+++ b/internal/provider/cisco/nxos/isis/interface.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/openconfig/ygot/ygot"
 
@@ -15,15 +16,16 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/iface"
 )
 
-var _ gnmiext.DeviceConf = (*Interface)(nil)
+var (
+	ErrUnsupported error = errors.New("isis: unsupported interface type for isis")
+)
 
 type Interface struct {
-	interfaceName string // interface name, e.g., Ethernet1/1
-	instanceName  string // name of the ISIS process/instance
-	v4Enable      bool   // enable ISIS support for IPv4 address family
-	v6Enable      bool   // enable ISIS support for IPv6 address family
-	p2p           bool   // set the network type to point-to-point (if false no-op)
-	vrf           string // VRF name, if empty, defaults to "default"
+	name     string // interface name, e.g., Ethernet1/1
+	v4Enable bool   // enable ISIS support for IPv4 address family
+	v6Enable bool   // enable ISIS support for IPv6 address family
+	p2p      bool   // set the network type to point-to-point (if false no-op)
+	bfd      bool   // enable BFD for the interface
 }
 
 type IfOption func(*Interface) error
@@ -31,20 +33,18 @@ type IfOption func(*Interface) error
 // NewInterface creates a new ISIS interface configuration instance for the given interface name and ISIS instance name.
 // Interface name must be a valid physical or loopback interface name (e.g., Ethernet1/1, lo0). Unless specified otherwise,
 // the interface will be configured in the default VRF. IPv4 and IPv6 address familites are enabled by default.
-func NewInterface(interfaceName, isisInstanceName string, opts ...IfOption) (*Interface, error) {
-	shortName, err := iface.ShortName(interfaceName)
+func NewInterface(name string, opts ...IfOption) (*Interface, error) {
+	shortName, err := iface.ShortName(name)
 	if err != nil {
-		return nil, fmt.Errorf("isis: not a valid interface name %q: %w", interfaceName, err)
+		return nil, fmt.Errorf("isis: not a valid interface name %q: %w", name, err)
 	}
-	if isisInstanceName == "" {
-		return nil, errors.New("isis: instance name cannot be empty")
+	if !strings.HasPrefix(shortName, "eth") && !strings.HasPrefix(shortName, "lo") {
+		return nil, ErrUnsupported
 	}
 	i := &Interface{
-		interfaceName: shortName,
-		instanceName:  isisInstanceName,
-		v4Enable:      true,
-		v6Enable:      true,
-		vrf:           "default",
+		name:     shortName,
+		v4Enable: true,
+		v6Enable: true,
 	}
 	for _, opt := range opts {
 		if err := opt(i); err != nil {
@@ -52,17 +52,6 @@ func NewInterface(interfaceName, isisInstanceName string, opts ...IfOption) (*In
 		}
 	}
 	return i, nil
-}
-
-// WithVRF sets the VRF name for the interface. If not set, defaults to "default".
-func WithVRF(vrf string) IfOption {
-	return func(i *Interface) error {
-		if vrf == "" {
-			return errors.New("isis: vrf name cannot be empty")
-		}
-		i.vrf = vrf
-		return nil
-	}
 }
 
 // WithIPv4 sets the support for the IPv4 address family for ISIS on the interface. Enabled by default.
@@ -87,30 +76,25 @@ func WithPointToPoint() IfOption {
 		return nil
 	}
 }
+func WithBFD() IfOption {
+	return func(i *Interface) error {
+		i.bfd = true
+		return nil
+	}
+}
 
-// ToYGOT returns the YGOT updates to configure the ISIS interface:
-//  1. an editing update to ensure that the ISIS feature is enabled on the device
-//  2. a replacing update to re-configure the interface to use a given ISIS instance on a given VRF
-//
-// Note: this does not configure any L3 parameters on the interface. It is assumed that the interface
-// has already been configured with an appropriate L3 configuration via the pkg `iface`.
-//
-// The caller must be aware of the following behavior when applying the updates:
-//   - applying the editing update will enable the ISIS feature on the device if not already enabled
-//   - the update sets the network type for ISIS as point-to-point
-//   - it queries to check if the interface exists on the device before attempting applying the
-//     configuration. If the interface does not exist or is empty, an error is returned.
-func (i *Interface) ToYGOT(ctx context.Context, client gnmiext.Client) ([]gnmiext.Update, error) {
-	exists, err := iface.Exists(ctx, client, i.interfaceName)
+var ErrInterfaceNotFound = fmt.Errorf("interface not found on device")
+
+func (i *Interface) toYGOT(ctx context.Context, client gnmiext.Client) (*nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList_DomItems_DomList_IfItems_IfList, error) {
+	exists, err := iface.Exists(ctx, client, i.name)
 	if err != nil {
-		return nil, fmt.Errorf("isis: failed to check interface %q existence: %w", i.interfaceName, err)
+		return nil, fmt.Errorf("isis: failed to check interface %q existence: %w", i.name, err)
 	}
 	if !exists {
-		return nil, fmt.Errorf("isis: interface %q does not exist on the device", i.interfaceName)
+		return nil, ErrInterfaceNotFound
 	}
-	value := &nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList{
-		Dom:            ygot.String(i.vrf),
-		Instance:       ygot.String(i.instanceName),
+	value := &nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList_DomItems_DomList_IfItems_IfList{
+		Id:             ygot.String(i.name),
 		V4Enable:       ygot.Bool(i.v4Enable),
 		V6Enable:       ygot.Bool(i.v6Enable),
 		NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_UNSET,
@@ -118,25 +102,8 @@ func (i *Interface) ToYGOT(ctx context.Context, client gnmiext.Client) ([]gnmiex
 	if i.p2p {
 		value.NetworkTypeP2P = nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on
 	}
-	return []gnmiext.Update{
-		gnmiext.EditingUpdate{
-			XPath: "System/fm-items/isis-items",
-			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_IsisItems{
-				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
-			},
-		},
-		gnmiext.ReplacingUpdate{
-			XPath: "System/isis-items/if-items/InternalIf-list[id=" + i.interfaceName + "]",
-			Value: value,
-		},
-	}, nil
-}
-
-// Reset removes the ISIS configuration from the interface.
-func (i *Interface) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
-	return []gnmiext.Update{
-		gnmiext.DeletingUpdate{
-			XPath: "System/isis-items/if-items/InternalIf-list[id=" + i.interfaceName + "]",
-		},
-	}, nil
+	if i.bfd {
+		value.V4Bfd = nxos.Cisco_NX_OSDevice_Isis_BfdT_enabled
+	}
+	return value, nil
 }

--- a/internal/provider/cisco/nxos/isis/interface_test.go
+++ b/internal/provider/cisco/nxos/isis/interface_test.go
@@ -1,86 +1,115 @@
-// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 package isis
 
 import (
 	"context"
+	"errors"
 	"testing"
-
-	"github.com/openconfig/ygot/ygot"
 
 	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+	"github.com/openconfig/ygot/ygot"
 )
 
 func Test_Interface_NewInterface(t *testing.T) {
 	tests := []struct {
 		name      string
 		ifName    string
-		isisInst  string
-		opts      []IfOption
-		wantShort string
-		wantVRF   string
-		wantV4    bool
-		wantV6    bool
-		wantP2P   bool
 		expectErr bool
 	}{
 		{
-			name:      "Physical, default VRF, default AFs",
+			name:      "Valid interface name Ethernet1/1",
 			ifName:    "Ethernet1/1",
-			isisInst:  "ISIS1",
-			wantShort: "eth1/1",
-			wantVRF:   "default",
-			wantV4:    true,
-			wantV6:    true,
-			wantP2P:   false,
+			expectErr: false,
 		},
 		{
-			name:      "Loopback, custom VRF, IPv4 only, P2P",
+			name:      "Valid interface name lo0",
 			ifName:    "lo0",
-			isisInst:  "ISIS2",
-			opts:      []IfOption{WithVRF("mgmt"), WithIPv6(false), WithPointToPoint()},
-			wantShort: "lo0",
-			wantVRF:   "mgmt",
-			wantV4:    true,
-			wantV6:    false,
-			wantP2P:   true,
-		},
-		{
-			name:      "Physical, IPv6 only",
-			ifName:    "Ethernet1/2",
-			isisInst:  "ISIS3",
-			opts:      []IfOption{WithIPv4(false)},
-			wantShort: "eth1/2",
-			wantVRF:   "default",
-			wantV4:    false,
-			wantV6:    true,
-			wantP2P:   false,
+			expectErr: false,
 		},
 		{
 			name:      "Invalid interface name",
-			ifName:    "notanif",
-			isisInst:  "ISIS4",
+			ifName:    "invalid1/1",
 			expectErr: true,
 		},
 		{
-			name:      "Empty ISIS instance name",
-			ifName:    "Ethernet1/3",
-			isisInst:  "",
+			name:      "Unallowed interface: port-channel",
+			ifName:    "port-channel10",
 			expectErr: true,
 		},
 		{
-			name:      "Empty VRF",
+			name:      "Unallowed interface: management",
+			ifName:    "mgmt0",
+			expectErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewInterface(tc.ifName)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("NewInterface(%q) expectErr=%v, got err=%v", tc.ifName, tc.expectErr, err)
+			}
+		})
+	}
+}
+func Test_Interface_toYGOT(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifName    string
+		opts      []IfOption
+		exists    bool
+		want      *nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList_DomItems_DomList_IfItems_IfList
+		expectErr bool
+	}{
+		{
+			name:   "Default IPv4/IPv6, interface exists",
+			ifName: "Ethernet1/1",
+			exists: true,
+			want: &nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList_DomItems_DomList_IfItems_IfList{
+				Id:             ygot.String("eth1/1"),
+				V4Enable:       ygot.Bool(true),
+				V6Enable:       ygot.Bool(true),
+				NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_UNSET,
+				V4Bfd:          0,
+			},
+		},
+		{
+			name:   "IPv6 only, P2P, BFD",
+			ifName: "Ethernet1/2",
+			opts:   []IfOption{WithIPv4(false), WithIPv6(true), WithPointToPoint(), WithBFD()},
+			exists: true,
+			want: &nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList_DomItems_DomList_IfItems_IfList{
+				Id:             ygot.String("eth1/2"),
+				V4Enable:       ygot.Bool(false),
+				V6Enable:       ygot.Bool(true),
+				NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on,
+				V4Bfd:          nxos.Cisco_NX_OSDevice_Isis_BfdT_enabled,
+			},
+		},
+		{
+			name:      "Interface does not exist",
 			ifName:    "Ethernet1/4",
-			isisInst:  "ISIS5",
-			opts:      []IfOption{WithVRF("")},
+			exists:    false,
 			expectErr: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			intf, err := NewInterface(tc.ifName, tc.isisInst, tc.opts...)
+			intf, err := NewInterface(tc.ifName, tc.opts...)
+			if err != nil {
+				t.Fatalf("unexpected error from NewInterface: %v", err)
+			}
+			got, err := intf.toYGOT(context.Background(), &gnmiext.ClientMock{
+				ExistsFunc: func(ctx context.Context, xpath string) (bool, error) {
+					if tc.expectErr {
+						return false, errors.New("error")
+					}
+					return tc.exists, nil
+				},
+			})
+
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -90,137 +119,15 @@ func Test_Interface_NewInterface(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if intf.interfaceName != tc.wantShort {
-				t.Errorf("expected short interface name %q, got %q", tc.wantShort, intf.interfaceName)
-			}
-			if intf.vrf != tc.wantVRF {
-				t.Errorf("expected VRF %q, got %q", tc.wantVRF, intf.vrf)
-			}
-			if intf.v4Enable != tc.wantV4 {
-				t.Errorf("expected v4Enable %v, got %v", tc.wantV4, intf.v4Enable)
-			}
-			if intf.v6Enable != tc.wantV6 {
-				t.Errorf("expected v6Enable %v, got %v", tc.wantV6, intf.v6Enable)
+			if tc.want != nil {
+				notification, err := ygot.Diff(got, tc.want)
+				if err != nil {
+					t.Errorf("failed to compute diff: %v", err)
+				}
+				if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+					t.Errorf("unexpected diff: %s", notification)
+				}
 			}
 		})
-	}
-}
-
-func Test_Interface_ToYGOT(t *testing.T) {
-	i, err := NewInterface("Ethernet1/1", "ISIS1",
-		WithVRF("mgmt"),
-		WithIPv4(true),
-		WithIPv6(false),
-		WithPointToPoint(),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	updates, err := i.ToYGOT(t.Context(), &gnmiext.ClientMock{
-		ExistsFunc: func(_ context.Context, xpath string) (bool, error) {
-			return true, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error from ToYGOT: %v", err)
-	}
-	if len(updates) != 2 {
-		t.Errorf("expected 2 updates, got %d", len(updates))
-	}
-	t.Run("Enable ISIS feature", func(t *testing.T) {
-		u, ok := updates[0].(gnmiext.EditingUpdate)
-		if !ok {
-			t.Fatalf("expected EditingUpdate, got %T", updates[0])
-		}
-		if u.XPath != "System/fm-items/isis-items" {
-			t.Errorf("expected XPath System/fm-items/isis-items, got %s", u.XPath)
-		}
-		gotVal, ok := u.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_IsisItems)
-		if !ok {
-			t.Errorf("expected value of type *nxos.Cisco_NX_OSDevice_System_FmItems_IsisItems, got %T", u.Value)
-		}
-		if gotVal.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
-			t.Errorf("expected AdminSt enabled, got %v", gotVal.AdminSt)
-		}
-	})
-	t.Run("Configure ISIS interface", func(t *testing.T) {
-		u, ok := updates[1].(gnmiext.ReplacingUpdate)
-		if !ok {
-			t.Fatalf("expected ReplacingUpdate, got %T", updates[1])
-		}
-		if u.XPath != "System/isis-items/if-items/InternalIf-list[id="+i.interfaceName+"]" {
-			t.Errorf("unexpected XPath, got %s", u.XPath)
-		}
-		gotVal, ok := u.Value.(*nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList)
-		if !ok {
-			t.Errorf("expected value of type *nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList, got %T", u.Value)
-		}
-		expectedVal := &nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList{
-			Dom:            ygot.String(i.vrf),
-			Instance:       ygot.String(i.instanceName),
-			V4Enable:       ygot.Bool(i.v4Enable),
-			V6Enable:       ygot.Bool(i.v6Enable),
-			NetworkTypeP2P: nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_on,
-		}
-		diffNotifications, err := ygot.Diff(gotVal, expectedVal)
-		if err != nil {
-			t.Errorf("failed to compute diff")
-		}
-		if len(diffNotifications.Update) > 0 || len(diffNotifications.Delete) > 0 {
-			t.Errorf("unexpected diff: %s", diffNotifications)
-		}
-	})
-}
-
-func Test_Interface_ToYGOT_NoP2P(t *testing.T) {
-	i, err := NewInterface("Ethernet1/1", "ISIS1",
-		WithVRF("mgmt"),
-		WithIPv4(true),
-		WithIPv6(false),
-		// No WithPointToPoint()
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	updates, err := i.ToYGOT(t.Context(), &gnmiext.ClientMock{
-		ExistsFunc: func(_ context.Context, xpath string) (bool, error) {
-			return true, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error from ToYGOT: %v", err)
-	}
-	u, ok := updates[1].(gnmiext.ReplacingUpdate)
-	if !ok {
-		t.Fatalf("expected ReplacingUpdate, got %T", updates[1])
-	}
-	gotVal, ok := u.Value.(*nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList)
-	if !ok {
-		t.Fatalf("expected value of type *nxos.Cisco_NX_OSDevice_System_IsisItems_IfItems_InternalIfList, got %T", u.Value)
-	}
-	// Check that NetworkTypeP2P is not set or is set to the default
-	if gotVal.NetworkTypeP2P != nxos.Cisco_NX_OSDevice_Isis_NetworkTypeP2PSt_UNSET {
-		t.Errorf("expected NetworkTypeP2P to be unset or off, got %v", gotVal.NetworkTypeP2P)
-	}
-}
-
-func TestReset(t *testing.T) {
-	i, err := NewInterface("Ethernet1/1", "ISIS1")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	updates, err := i.Reset(t.Context(), nil)
-	if err != nil {
-		t.Fatalf("unexpected error from Reset: %v", err)
-	}
-	if len(updates) != 1 {
-		t.Errorf("expected 1 update, got %d", len(updates))
-	}
-	u, ok := updates[0].(gnmiext.DeletingUpdate)
-	if !ok {
-		t.Fatalf("expected DeletingUpdate, got %T", updates[0])
-	}
-	if u.XPath != "System/isis-items/if-items/InternalIf-list[id="+i.interfaceName+"]" {
-		t.Errorf("unexpected XPath, got %s", u.XPath)
 	}
 }


### PR DESCRIPTION
* We were previously adding an interface to an ISIS process by updating
  the yang data model at two different locations:
  - System/isis-items/if-items/InternalIf-list[id=eth1/1] (ReplacingUpdate)
  - System/isis-items/inst-items/Inst-list[name=UNDERLAY] (ReplacingUpdate)
* These two updates caused the interface to flap (probably as they
reference each other and a change in one triggers an update in the
other).  This behavior can be avoided by adding the interfaces directly
into the second path and performing a single ReplacingUpdate. As a
consequence, we change the data model for ISIS and include a list of
member interfaces as a field.
* Forbid configuring ISIS on port-channels
* Add support to enable `bfd` on the interface by adding an Option to
  the Interface constructor