### PR TITLE
cisco-nxos-provider: add helpers for testing

### DIFF
--- a/internal/provider/cisco/nxos/iface/loopback.go
+++ b/internal/provider/cisco/nxos/iface/loopback.go
@@ -114,9 +114,8 @@ func (l *Loopback) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update
 
 func (l *Loopback) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{
-		gnmiext.ReplacingUpdate{
+		gnmiext.DeletingUpdate{
 			XPath: "System/intf-items/lb-items/LbRtdIf-list[id=" + l.name + "]",
-			Value: &nxos.Cisco_NX_OSDevice_System_IntfItems_LbItems_LbRtdIfList{},
 		},
 	}, nil
 }

--- a/internal/provider/cisco/nxos/nve/nve.go
+++ b/internal/provider/cisco/nxos/nve/nve.go
@@ -227,15 +227,19 @@ func (n *NVE) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 	}
 
 	val.SuppressARP = n.suppressARP
-
+	adminSt := nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled
+	if !n.adminSt {
+		adminSt = nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled
+	}
 	if n.mcastL2 != nil {
 		val.McastGroupL2 = ygot.String(n.mcastL2.String())
 	}
 	if n.mcastL3 != nil {
+
 		updates = append(updates, gnmiext.EditingUpdate{
 			XPath: "/System/fm-items/ngmvpn-items",
 			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
-				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+				AdminSt: adminSt,
 			},
 		})
 		val.McastGroupL3 = ygot.String(n.mcastL3.String())
@@ -244,12 +248,11 @@ func (n *NVE) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 	if n.holdDownTime != 0 {
 		val.HoldDownTime = ygot.Uint16(n.holdDownTime)
 	}
-
 	return append(updates, []gnmiext.Update{
 		gnmiext.EditingUpdate{
 			XPath: "/System/fm-items/nvo-items",
 			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
-				AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+				AdminSt: adminSt,
 			},
 		},
 		gnmiext.ReplacingUpdate{

--- a/internal/provider/cisco/nxos/nve/nve_test.go
+++ b/internal/provider/cisco/nxos/nve/nve_test.go
@@ -10,6 +10,7 @@ import (
 
 	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/testutils"
 )
 
 func Test_NewNVE(t *testing.T) {
@@ -117,54 +118,43 @@ func Test_NewNVE(t *testing.T) {
 	}
 }
 
-// updateCheck is used to validate updates in tests and helper functions.
-type updateCheck struct {
-	updateIdx   int    // the position we want to check in the returned slice of updates
-	expectType  string // "EditingUpdate", "ReplacingUpdate", or "DeletingUpdate"
-	expectXPath string // the expected XPath of the update
-	expectValue any    // the expected ygot object that should be in the update
-}
-
 func Test_NVE_ToYGOT(t *testing.T) {
 	tests := []struct {
-		name                    string
-		options                 []NVEOption
-		expectedNumberOfUpdates int
-		updateChecks            []updateCheck
+		name            string
+		options         []NVEOption
+		expectedUpdates []gnmiext.Update
 	}{
 		{
-			name:                    "valid: default NVE",
-			options:                 nil,
-			expectedNumberOfUpdates: 2,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   0,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/nvo-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+			name:    "valid: default NVE",
+			options: nil,
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
 					},
 				},
-				{
-					updateIdx:   1,
-					expectType:  "ReplacingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+				gnmiext.ReplacingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
 						AdminSt: nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled,
 					},
 				},
 			},
 		},
 		{
-			name:                    "valid: set admin state to disabled",
-			options:                 []NVEOption{WithAdminState(false)},
-			expectedNumberOfUpdates: 2,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   1,
-					expectType:  "ReplacingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+			name:    "valid: set admin state to disabled",
+			options: []NVEOption{WithAdminState(false)},
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+				gnmiext.ReplacingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
 						AdminSt: nxos.Cisco_NX_OSDevice_Nw_AdminSt_disabled,
 					},
 				},
@@ -176,13 +166,16 @@ func Test_NVE_ToYGOT(t *testing.T) {
 				WithAdminState(false),
 				WithHostReachabilityProtocol(HostReachFloodAndLearn),
 			},
-			expectedNumberOfUpdates: 2,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   1,
-					expectType:  "ReplacingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+				gnmiext.ReplacingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
 						AdminSt:   nxos.Cisco_NX_OSDevice_Nw_AdminSt_disabled,
 						HostReach: nxos.Cisco_NX_OSDevice_Nvo_HostReachT_Flood_and_learn,
 					},
@@ -194,13 +187,16 @@ func Test_NVE_ToYGOT(t *testing.T) {
 			options: []NVEOption{
 				WithAdvertiseVirtualRmac(false),
 			},
-			expectedNumberOfUpdates: 2,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   1,
-					expectType:  "ReplacingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+					},
+				},
+				gnmiext.ReplacingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
 						AdminSt:       nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled,
 						AdvertiseVmac: ygot.Bool(false),
 					},
@@ -219,29 +215,22 @@ func Test_NVE_ToYGOT(t *testing.T) {
 				WithMulticastGroupL3("238.0.0.1"),
 				WithHoldDownTime(300),
 			},
-			expectedNumberOfUpdates: 3,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   0,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/ngmvpn-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/ngmvpn-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
 					},
 				},
-				{
-					updateIdx:   1,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/nvo-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
 					},
 				},
-				{
-					updateIdx:   2,
-					expectType:  "ReplacingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
+				gnmiext.ReplacingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+					Value: &nxos.Cisco_NX_OSDevice_System_EpsItems_EpIdItems_EpList{
 						AdminSt:         nxos.Cisco_NX_OSDevice_Nw_AdminSt_enabled,
 						SourceInterface: ygot.String("lo0"),
 						AnycastIntf:     ygot.String("lo1"),
@@ -263,53 +252,39 @@ func Test_NVE_ToYGOT(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error during NewNVE: %v", err)
 			}
-
 			updates, err := nve.ToYGOT(context.TODO(), &gnmiext.ClientMock{
 				ExistsFunc: func(_ context.Context, _ string) (bool, error) { return true, nil },
 			})
 			if err != nil {
 				t.Fatalf("unexpected error during ToYGOT: %v", err)
 			}
-
-			if len(updates) != tt.expectedNumberOfUpdates {
-				t.Fatalf("expected %d updates, got %d", tt.expectedNumberOfUpdates, len(updates))
-			}
-
-			validateUpdates(t, updates, tt.updateChecks)
+			testutils.AssertEqual(t, updates, tt.expectedUpdates)
 		})
 	}
 }
 
 func Test_NVE_Reset(t *testing.T) {
 	tests := []struct {
-		name                    string
-		options                 []NVEOption
-		expectedNumberOfUpdates int
-		updateChecks            []updateCheck
+		name            string
+		options         []NVEOption
+		expectedUpdates []gnmiext.Update
 	}{
 		{
-			name:                    "valid: reset default NVE",
-			options:                 nil,
-			expectedNumberOfUpdates: 3,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   0,
-					expectType:  "DeletingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+			name:    "valid: reset default NVE",
+			options: nil,
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.DeletingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
 				},
-				{
-					updateIdx:   1,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/ngmvpn-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/ngmvpn-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
 					},
 				},
-				{
-					updateIdx:   2,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/nvo-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
 					},
 				},
@@ -321,26 +296,19 @@ func Test_NVE_Reset(t *testing.T) {
 				WithSourceInterface("loopback0"),
 				WithAnycastInterface("loopback1"),
 			},
-			expectedNumberOfUpdates: 3,
-			updateChecks: []updateCheck{
-				{
-					updateIdx:   0,
-					expectType:  "DeletingUpdate",
-					expectXPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.DeletingUpdate{
+					XPath: "/System/eps-items/epId-items/Ep-list[epId=1]",
 				},
-				{
-					updateIdx:   1,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/ngmvpn-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/ngmvpn-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
 					},
 				},
-				{
-					updateIdx:   2,
-					expectType:  "EditingUpdate",
-					expectXPath: "/System/fm-items/nvo-items",
-					expectValue: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
+				gnmiext.EditingUpdate{
+					XPath: "/System/fm-items/nvo-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NvoItems{
 						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
 					},
 				},
@@ -354,87 +322,13 @@ func Test_NVE_Reset(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error during NewNVE: %v", err)
 			}
-
 			updates, err := nve.Reset(context.TODO(), &gnmiext.ClientMock{
 				ExistsFunc: func(_ context.Context, _ string) (bool, error) { return true, nil },
 			})
 			if err != nil {
 				t.Fatalf("unexpected error during Reset: %v", err)
 			}
-
-			if len(updates) != tt.expectedNumberOfUpdates {
-				t.Fatalf("expected %d updates, got %d", tt.expectedNumberOfUpdates, len(updates))
-			}
-
-			validateUpdates(t, updates, tt.updateChecks)
+			testutils.AssertEqual(t, updates, tt.expectedUpdates)
 		})
-	}
-}
-
-// validateUpdates is a helper function to validate updates against expected checks.
-func validateUpdates(t *testing.T, updates []gnmiext.Update, checks []updateCheck) {
-	for _, check := range checks {
-		if check.updateIdx >= len(updates) {
-			t.Errorf("missing update at index %d", check.updateIdx)
-			continue
-		}
-
-		update := updates[check.updateIdx]
-		var xpath string
-		var value any
-
-		switch u := update.(type) {
-		case gnmiext.DeletingUpdate:
-			if check.expectType != "DeletingUpdate" {
-				t.Errorf("expected DeletingUpdate at index %d, got %T", check.updateIdx, update)
-				continue
-			}
-			xpath = u.XPath
-		case gnmiext.EditingUpdate:
-			if check.expectType != "EditingUpdate" {
-				t.Errorf("expected EditingUpdate at index %d, got %T", check.updateIdx, update)
-				continue
-			}
-			xpath = u.XPath
-			value = u.Value
-		case gnmiext.ReplacingUpdate: // Handle ReplacingUpdate
-			if check.expectType != "ReplacingUpdate" {
-				t.Errorf("expected ReplacingUpdate at index %d, got %T", check.updateIdx, update)
-				continue
-			}
-			xpath = u.XPath
-			value = u.Value
-		default:
-			t.Errorf("unexpected update type at index %d: %T", check.updateIdx, update)
-			continue
-		}
-
-		if xpath != check.expectXPath {
-			t.Errorf("wrong xpath at index %d, expected '%s', got '%s'", check.updateIdx, check.expectXPath, xpath)
-		}
-
-		if check.expectValue != nil {
-			compareYGOTValues(t, value, check.expectValue, check.updateIdx)
-		}
-	}
-}
-
-// compareYGOTValues is a helper function to compare two ygot.GoStruct values.
-func compareYGOTValues(t *testing.T, actual, expected any, index int) {
-	actualGoStruct, ok1 := actual.(ygot.GoStruct)
-	expectedGoStruct, ok2 := expected.(ygot.GoStruct)
-	if !ok1 || !ok2 {
-		t.Errorf("failed to type assert value or expectValue to ygot.GoStruct at index %d", index)
-		return
-	}
-
-	notification, err := ygot.Diff(actualGoStruct, expectedGoStruct)
-	if err != nil {
-		t.Errorf("failed to compute diff at index %d: %v", index, err)
-		return
-	}
-
-	if len(notification.Update) > 0 || len(notification.Delete) > 0 {
-		t.Errorf("unexpected diff at index %d: %s", index, notification)
 	}
 }

--- a/internal/provider/cisco/nxos/testutils/helpers.go
+++ b/internal/provider/cisco/nxos/testutils/helpers.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package testutils
+
+import (
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+)
+
+func AssertEqual(t *testing.T, a, b []gnmiext.Update) {
+	t.Helper()
+	if len(a) != len(b) {
+		t.Fatalf("different number of updates: %d != %d", len(a), len(b))
+	}
+	for i, u := range a {
+		switch u.(type) {
+		case gnmiext.DeletingUpdate:
+			if _, ok := b[i].(gnmiext.DeletingUpdate); !ok {
+				t.Errorf("expected DeletingUpdate at index %d, got %T", i, b[i])
+				continue
+			}
+			assertEqualXPath(t, a[i].(gnmiext.DeletingUpdate).XPath, b[i].(gnmiext.DeletingUpdate).XPath, i)
+		case gnmiext.EditingUpdate:
+			if _, ok := b[i].(gnmiext.EditingUpdate); !ok {
+				t.Errorf("expected EditingUpdate at index %d, got %T", i, b[i])
+				continue
+			}
+			assertEqualXPath(t, a[i].(gnmiext.EditingUpdate).XPath, b[i].(gnmiext.EditingUpdate).XPath, i)
+			assertEqualYGot(t, a[i].(gnmiext.EditingUpdate).Value, b[i].(gnmiext.EditingUpdate).Value)
+		case gnmiext.ReplacingUpdate:
+			if _, ok := b[i].(gnmiext.ReplacingUpdate); !ok {
+				t.Errorf("expected ReplacingUpdate at index %d, got %T", i, b[i])
+				continue
+			}
+			assertEqualXPath(t, a[i].(gnmiext.ReplacingUpdate).XPath, b[i].(gnmiext.ReplacingUpdate).XPath, i)
+			assertEqualYGot(t, a[i].(gnmiext.ReplacingUpdate).Value, b[i].(gnmiext.ReplacingUpdate).Value)
+		default:
+			t.Errorf("unexpected update type at index %d: %T", i, u)
+			continue
+		}
+	}
+}
+
+func assertEqualXPath(t *testing.T, a, b string, i int) {
+	t.Helper()
+	if a != b {
+		t.Errorf("different xpath at index %d: %s != %s", i, a, b)
+	}
+}
+
+func assertEqualYGot(t *testing.T, a, b ygot.GoStruct) {
+	t.Helper()
+	notification, err := ygot.Diff(a, b)
+	if err != nil {
+		t.Errorf("failed to compute diff: %v", err)
+		return
+	}
+	if len(notification.Update) > 0 || len(notification.Delete) > 0 {
+		t.Errorf("unexpected diff: %s", notification.String())
+	}
+}


### PR DESCRIPTION
* Loopback's Reset function now returns a DeletingUpdate, which
  effectively removes the loopback from the switch instead of leaving it
unconfigured.
* NVE's ToYGOT function was setting the AdminSt field always to enabled.
* Extract duplicated code from various tests and create a `testutils`
package that can be re-used in table-driven tests.
* Use helpers in pkgs `iface` and `nve`