### PR TITLE
cisco-nxos-provider: facilitate reconciliation with `FromYGot` and `Equals` methods

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.5
+          go-version: 1.24.6
       - name: Cache golangci-lint analysis
         uses: actions/cache@v4
         with:

--- a/config/crd/bases/networking.cloud.sap_devices.yaml
+++ b/config/crd/bases/networking.cloud.sap_devices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: devices.networking.cloud.sap
 spec:
   group: networking.cloud.sap

--- a/config/crd/bases/networking.cloud.sap_interfaces.yaml
+++ b/config/crd/bases/networking.cloud.sap_interfaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: interfaces.networking.cloud.sap
 spec:
   group: networking.cloud.sap

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/google/go-cmp v0.7.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.3
@@ -23,6 +24,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.3
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -51,7 +53,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -106,7 +107,6 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace github.com/openconfig/ygnmi => github.com/felix-kaestner/ygnmi v0.0.0-20250709083711-68dcb70888a5

--- a/internal/provider/cisco/nxos/acl/acl.go
+++ b/internal/provider/cisco/nxos/acl/acl.go
@@ -154,3 +154,11 @@ func (a *ACL) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 		},
 	}, nil
 }
+
+func (a *ACL) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (a *ACL) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/api/grpc.go
+++ b/internal/provider/cisco/nxos/api/grpc.go
@@ -101,6 +101,14 @@ func (g *GRPC) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, er
 }
 
 // returns an empty update and an error indicating that the reset is not implemented
-func (v *GRPC) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+func (g *GRPC) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{}, errors.New("grpc: reset not implemented as it effectively disables management over gNMI")
+}
+
+func (g *GRPC) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (g *GRPC) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/api/nxapi.go
+++ b/internal/provider/cisco/nxos/api/nxapi.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openconfig/ygot/ygot"
@@ -111,4 +112,12 @@ func (v *NXAPI) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, er
 			Value: nxapi,
 		},
 	}, nil
+}
+
+func (n *NXAPI) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (n *NXAPI) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/banner/banner.go
+++ b/internal/provider/cisco/nxos/banner/banner.go
@@ -53,7 +53,7 @@ func (b *Banner) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, 
 	}, nil
 }
 
-func (v *Banner) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+func (b *Banner) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	banner := &nxos.Cisco_NX_OSDevice_System_UserextItems_PreloginbannerItems{}
 	banner.PopulateDefaults()
 	return []gnmiext.Update{
@@ -62,4 +62,12 @@ func (v *Banner) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, e
 			Value: banner,
 		},
 	}, nil
+}
+
+func (b *Banner) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (b *Banner) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/bgp/bgp.go
+++ b/internal/provider/cisco/nxos/bgp/bgp.go
@@ -144,6 +144,14 @@ func (b *BGP) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 	}, nil
 }
 
+func (b *BGP) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (b *BGP) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 var (
 	_ AddressFamily = (*L2EVPN)(nil)
 	_ AddressFamily = (*IPv4Unicast)(nil)
@@ -322,6 +330,14 @@ func (p *BGPPeer) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, 
 			XPath: "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=" + p.Addr.String() + "]",
 		},
 	}, nil
+}
+
+func (b *BGPPeer) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (b *BGPPeer) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }
 
 var (

--- a/internal/provider/cisco/nxos/copp/copp.go
+++ b/internal/provider/cisco/nxos/copp/copp.go
@@ -10,6 +10,7 @@ package copp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
@@ -73,4 +74,12 @@ func (v *COPP) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 			Value: x,
 		},
 	}, nil
+}
+
+func (c *COPP) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (c *COPP) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/crypto/trustpoint.go
+++ b/internal/provider/cisco/nxos/crypto/trustpoint.go
@@ -52,3 +52,11 @@ func (t *Trustpoint) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Updat
 		},
 	}, nil
 }
+
+func (t *Trustpoint) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (t *Trustpoint) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/dns/dns.go
+++ b/internal/provider/cisco/nxos/dns/dns.go
@@ -20,6 +20,7 @@ package dns
 
 import (
 	"context"
+	"errors"
 
 	"github.com/openconfig/ygot/ygot"
 
@@ -99,4 +100,12 @@ func (v *DNS) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 			Value: dns,
 		},
 	}, nil
+}
+
+func (d *DNS) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (d *DNS) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/feat/feat.go
+++ b/internal/provider/cisco/nxos/feat/feat.go
@@ -14,17 +14,19 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
 )
 
-var _ gnmiext.DeviceConf = Features{}
+var _ gnmiext.DeviceConf = (*Features)(nil)
 
 // Features the list of enabled features on the device.
 // All features not listed here are considered disabled.
-type Features []string
+type Features struct {
+	List []string
+}
 
 func (feat Features) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	fm := &nxos.Cisco_NX_OSDevice_System_FmItems{}
 	fm.PopulateDefaults()
 	rv := reflect.ValueOf(fm).Elem()
-	for _, f := range feat {
+	for _, f := range feat.List {
 		name := strings.ToUpper(f[:1]) + strings.ToLower(f[1:])
 		name = strings.TrimSuffix(name, "-items") + "Items"
 		field := rv.FieldByName(name)
@@ -53,6 +55,14 @@ func (feat Features) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Upda
 }
 
 // do not support resetting features
-func (v Features) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+func (f Features) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	return []gnmiext.Update{}, errors.New("feat: resetting features is not supported")
+}
+
+func (f *Features) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (f *Features) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/feat/feat_test.go
+++ b/internal/provider/cisco/nxos/feat/feat_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_Features(t *testing.T) {
-	f := Features{"restconf"}
+	f := Features{List: []string{"restconf"}}
 
 	got, err := f.ToYGOT(t.Context(), &gnmiext.ClientMock{})
 	if err != nil {

--- a/internal/provider/cisco/nxos/gnmiext/client_test.go
+++ b/internal/provider/cisco/nxos/gnmiext/client_test.go
@@ -134,7 +134,7 @@ func Test_NewClient_Version(t *testing.T) {
 }
 
 func TestClient_Exists(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	path := "System/time-items/srcIf-items"
 
 	t.Run("exists with value", func(t *testing.T) {
@@ -511,7 +511,7 @@ func TestClient_Get_WithStdJSONUnmarshal_NonRFC7951(t *testing.T) {
 							{
 								Path: &gpb.Path{Elem: []*gpb.PathElem{{Name: "System/time-items/srcIf-items/srcIf"}}},
 								Val: func() *gpb.TypedValue {
-									val, _ := json.Marshal(map[string]interface{}{
+									val, _ := json.Marshal(map[string]any{ //nolint:errcheck
 										"name":  "eth1/1",
 										"value": 42,
 									})
@@ -691,6 +691,14 @@ func (*Dummy) Reset(_ context.Context, _ Client) ([]Update, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (*Dummy) Equals(_ DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (*Dummy) FromYGOT(_ context.Context, _ Client) error {
+	return errors.New("not implemented")
+}
+
 type DummyWithError struct{}
 
 func (*DummyWithError) ToYGOT(_ context.Context, _ Client) ([]Update, error) {
@@ -699,6 +707,14 @@ func (*DummyWithError) ToYGOT(_ context.Context, _ Client) ([]Update, error) {
 
 func (*DummyWithError) Reset(_ context.Context, _ Client) ([]Update, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (*DummyWithError) Equals(_ DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (*DummyWithError) FromYGOT(_ context.Context, _ Client) error {
+	return errors.New("not implemented")
 }
 
 func Test_Update(t *testing.T) {
@@ -790,6 +806,14 @@ func (*DummyWithValidationError) ToYGOT(_ context.Context, _ Client) ([]Update, 
 
 func (*DummyWithValidationError) Reset(_ context.Context, _ Client) ([]Update, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (*DummyWithValidationError) Equals(_ DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (*DummyWithValidationError) FromYGOT(_ context.Context, _ Client) error {
+	return errors.New("not implemented")
 }
 
 func Test_Update_ValidationFails(t *testing.T) {

--- a/internal/provider/cisco/nxos/iface/getter_test.go
+++ b/internal/provider/cisco/nxos/iface/getter_test.go
@@ -203,7 +203,7 @@ func TestExists(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mock := &gnmiext.ClientMock{ExistsFunc: test.fn}
-			exists, err := Exists(context.Background(), mock, test.interfaceName)
+			exists, err := Exists(t.Context(), mock, test.interfaceName)
 			if exists != test.wantExists {
 				t.Errorf("Exists(%q) = %v, want %v", test.interfaceName, exists, test.wantExists)
 			}

--- a/internal/provider/cisco/nxos/iface/loopback.go
+++ b/internal/provider/cisco/nxos/iface/loopback.go
@@ -119,3 +119,11 @@ func (l *Loopback) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update,
 		},
 	}, nil
 }
+
+func (l *Loopback) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (l *Loopback) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/iface/loopback_test.go
+++ b/internal/provider/cisco/nxos/iface/loopback_test.go
@@ -4,7 +4,6 @@
 package iface
 
 import (
-	"context"
 	"testing"
 
 	"github.com/openconfig/ygot/ygot"
@@ -93,7 +92,7 @@ func Test_Loopback_ToYGOT_BaseConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create loopback interface: %v", err)
 			}
-			got, err := p.ToYGOT(context.Background(), &gnmiext.ClientMock{})
+			got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -103,7 +102,6 @@ func Test_Loopback_ToYGOT_BaseConfig(t *testing.T) {
 }
 
 func Test_Loopback_ToYGOT_WithL3Config(t *testing.T) {
-
 	testAddressingL3Cfg, err := NewL3Config(
 		WithNumberedAddressingIPv4([]string{"10.0.0.1/24"}),
 	)
@@ -158,7 +156,7 @@ func Test_Loopback_ToYGOT_WithL3Config(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create loopback interface: %v", err)
 			}
-			got, err := p.ToYGOT(context.Background(), &gnmiext.ClientMock{})
+			got, err := p.ToYGOT(t.Context(), &gnmiext.ClientMock{})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -248,7 +246,7 @@ func Test_Loopback_Reset(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create loopback interface: %v", err)
 			}
-			updates, err := p.Reset(context.Background(), nil)
+			updates, err := p.Reset(t.Context(), nil)
 			if err != nil {
 				t.Errorf("unexpected error during reset: %v", err)
 			}

--- a/internal/provider/cisco/nxos/iface/physif_test.go
+++ b/internal/provider/cisco/nxos/iface/physif_test.go
@@ -5,6 +5,8 @@ package iface
 
 import (
 	"context"
+	"errors"
+	"net/netip"
 	"testing"
 
 	"github.com/openconfig/ygot/ygot"
@@ -501,12 +503,310 @@ func Test_PhysIf_Reset(t *testing.T) {
 
 			m := &gnmiext.ClientMock{ExistsFunc: tt.exists}
 
-			updates, err := p.Reset(context.Background(), m)
+			updates, err := p.Reset(t.Context(), m)
 			if err != nil {
 				t.Errorf("unexpected error during reset: %v", err)
 			}
 
 			testutils.AssertEqual(t, updates, tt.expectedUpdates)
+		})
+	}
+}
+
+func Test_PhysIf_FromYGOT(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       PhysIf
+		expected    PhysIf
+		clientMock  *gnmiext.ClientMock
+		expectError bool
+	}{
+		{
+			name:     "valid input without VRF",
+			input:    PhysIf{name: "eth1/1"},
+			expected: PhysIf{name: "eth1/1", description: "test interface", adminSt: false},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					i := dest.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+					i.Id = ygot.String("eth1/1")
+					i.Descr = ygot.String("test interface")
+					i.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_down
+					return nil
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:     "valid input with VRF",
+			input:    PhysIf{name: "eth1/1"},
+			expected: PhysIf{name: "eth1/1", description: "test interface", adminSt: true, vrf: "management"},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					i := dest.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+					i.Id = ygot.String("eth1/1")
+					i.Descr = ygot.String("test interface")
+					i.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_up
+					i.RtvrfMbrItems = &nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList_RtvrfMbrItems{
+						TDn: ygot.String("System/inst-items/Inst-list[name=management]"),
+					}
+					return nil
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid input with L2 config",
+			input: PhysIf{name: "eth1/1"},
+			expected: PhysIf{
+				name:        "eth1/1",
+				description: "L2 interface",
+				adminSt:     true,
+				l2: &L2Config{
+					switchPort:   SwitchPortModeAccess,
+					spanningTree: SpanningTreeModeEdge,
+				},
+			},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					switch xpath {
+					case "System/intf-items/phys-items/PhysIf-list[id=eth1/1]":
+						i := dest.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+						i.Id = ygot.String("eth1/1")
+						i.Descr = ygot.String("L2 interface")
+						i.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_up
+						i.Layer = nxos.Cisco_NX_OSDevice_L1_Layer_Layer2
+						i.Mode = nxos.Cisco_NX_OSDevice_L1_Mode_access
+						return nil
+					case "System/stp-items/inst-items/if-items/If-list[id=eth1/1]":
+						s := dest.(*nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList)
+						s.Id = ygot.String("eth1/1")
+						s.Mode = nxos.Cisco_NX_OSDevice_Stp_IfMode_edge
+						return nil
+					default:
+						return errors.New("unexpected xpath: " + xpath)
+					}
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid: L2 config with VLAN list in non ascending format",
+			input: PhysIf{name: "eth1/1"},
+			expected: PhysIf{
+				name:        "eth1/1",
+				description: "L2 interface",
+				adminSt:     true,
+				l2: &L2Config{
+					switchPort:   SwitchPortModeTrunk,
+					spanningTree: SpanningTreeModeTrunk,
+					accessVlan:   0,
+					nativeVlan:   100,
+					allowedVlans: []uint16{10, 11, 12, 13, 14, 15, 20, 30, 31},
+				},
+			},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					switch xpath {
+					case "System/intf-items/phys-items/PhysIf-list[id=eth1/1]":
+						i := dest.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+						i.Id = ygot.String("eth1/1")
+						i.Descr = ygot.String("L2 interface")
+						i.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_up
+						i.Layer = nxos.Cisco_NX_OSDevice_L1_Layer_Layer2
+						i.Mode = nxos.Cisco_NX_OSDevice_L1_Mode_trunk
+						i.AccessVlan = ygot.String("vlan-0")
+						i.NativeVlan = ygot.String("vlan-100")
+						i.TrunkVlans = ygot.String("30-31,20,10-15")
+						return nil
+					case "System/stp-items/inst-items/if-items/If-list[id=eth1/1]":
+						s := dest.(*nxos.Cisco_NX_OSDevice_System_StpItems_InstItems_IfItems_IfList)
+						s.Id = ygot.String("eth1/1")
+						s.Mode = nxos.Cisco_NX_OSDevice_Stp_IfMode_trunk
+						return nil
+					default:
+						return errors.New("unexpected xpath: " + xpath)
+					}
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid input with L3 config (unnumbered)",
+			input: PhysIf{name: "eth1/1"},
+			expected: PhysIf{
+				name:        "eth1/1",
+				description: "L3 interface",
+				adminSt:     false,
+				l3: &L3Config{
+					medium:             L3MediumTypeP2P,
+					addressingMode:     AddressingModeUnnumbered,
+					unnumberedLoopback: "lo0",
+				},
+			},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					switch xpath {
+					case "System/intf-items/phys-items/PhysIf-list[id=eth1/1]":
+						i := dest.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+						i.Id = ygot.String("eth1/1")
+						i.Descr = ygot.String("L3 interface")
+						i.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_down
+						i.Layer = nxos.Cisco_NX_OSDevice_L1_Layer_Layer3
+						i.Medium = nxos.Cisco_NX_OSDevice_L1_Medium_p2p
+						return nil
+					case "System/ipv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=eth1/1]":
+						s := dest.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
+						s.Id = ygot.String("eth1/1")
+						s.Unnumbered = ygot.String("lo0")
+						return nil
+					default:
+						return errors.New("unexpected xpath: " + xpath)
+					}
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid input with L3 config (with addresses sorted differently)",
+			input: PhysIf{name: "eth1/1"},
+			expected: PhysIf{
+				name:        "eth1/1",
+				description: "L3 interface",
+				adminSt:     true,
+				l3: &L3Config{
+					medium:         L3MediumTypeBroadcast,
+					addressingMode: AddressingModeNumbered,
+					prefixesIPv4: []netip.Prefix{
+						netip.MustParsePrefix("10.0.0.1/24"),
+						netip.MustParsePrefix("192.168.1.1/24"),
+					},
+					prefixesIPv6: []netip.Prefix{
+						netip.MustParsePrefix("2001:db8::1/64"),
+					},
+				},
+			},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(ctx context.Context, xpath string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					switch xpath {
+					case "System/intf-items/phys-items/PhysIf-list[id=eth1/1]":
+						i := dest.(*nxos.Cisco_NX_OSDevice_System_IntfItems_PhysItems_PhysIfList)
+						i.Id = ygot.String("eth1/1")
+						i.Descr = ygot.String("L3 interface")
+						i.AdminSt = nxos.Cisco_NX_OSDevice_L1_AdminSt_up
+						i.Layer = nxos.Cisco_NX_OSDevice_L1_Layer_Layer3
+						i.Medium = nxos.Cisco_NX_OSDevice_L1_Medium_broadcast
+					case "System/ipv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=eth1/1]":
+						s := dest.(*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList)
+						s.Id = ygot.String("eth1/1")
+						s.AddrItems = &nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems{
+							AddrList: map[string]*nxos.Cisco_NX_OSDevice_System_Ipv4Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems_AddrList{
+								"192.168.1.1/24": {
+									Addr: ygot.String("192.168.1.1/24"),
+								},
+								"10.0.0.0/24": {
+									Addr: ygot.String("10.0.0.1/24"),
+								},
+							},
+						}
+					case "System/ipv6-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=eth1/1]":
+						s := dest.(*nxos.Cisco_NX_OSDevice_System_Ipv6Items_InstItems_DomItems_DomList_IfItems_IfList)
+						s.Id = ygot.String("eth1/1")
+						s.AddrItems = &nxos.Cisco_NX_OSDevice_System_Ipv6Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems{
+							AddrList: map[string]*nxos.Cisco_NX_OSDevice_System_Ipv6Items_InstItems_DomItems_DomList_IfItems_IfList_AddrItems_AddrList{
+								"2001:db8::/64": {
+									Addr: ygot.String("2001:db8::1/64"),
+								},
+							},
+						}
+					default:
+						return errors.New("unexpected xpath: " + xpath)
+					}
+					return nil
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Example: Call FromYGOT and check error (replace with actual logic)
+			err := tt.input.FromYGOT(t.Context(), tt.clientMock)
+			if err != nil && !tt.expectError {
+				t.Errorf("unexpected error: %v", err)
+			}
+			equals, err := tt.input.Equals(&tt.expected)
+			if err != nil {
+				t.Errorf("error during equality check: %v", err)
+			}
+			if !equals {
+				t.Errorf("expected output %+v, got %+v", tt.expected.String(), tt.input.String())
+			}
+		})
+	}
+}
+
+func Test_PhysIf_Equal(t *testing.T) {
+	tests := []struct {
+		name          string
+		a             *PhysIf
+		b             gnmiext.DeviceConf
+		expectedError bool
+		expectedEqual bool
+	}{
+		{
+			name:          "equal: identical interfaces",
+			a:             &PhysIf{name: "eth1/1", description: "desc", adminSt: true, mtu: 1500, vrf: "vrf1"},
+			b:             &PhysIf{name: "eth1/1", description: "desc", adminSt: true, mtu: 1500, vrf: "vrf1"},
+			expectedError: false,
+			expectedEqual: true,
+		},
+		{
+			name:          "not-equal: different interface values (description)",
+			a:             &PhysIf{name: "eth1/1", description: "A", adminSt: true, mtu: 1500, vrf: "vrf1"},
+			b:             &PhysIf{name: "eth1/1", description: "B", adminSt: true, mtu: 1500, vrf: "vrf1"},
+			expectedError: false,
+			expectedEqual: false,
+		},
+		{
+			name:          "not-equal: different interface values (missing description)",
+			a:             &PhysIf{name: "eth1/1", description: "A"},
+			b:             &PhysIf{name: "eth1/1"},
+			expectedError: false,
+			expectedEqual: false,
+		},
+		{
+			name:          "error: different type",
+			a:             &PhysIf{name: "eth1/1", description: "desc", adminSt: true},
+			b:             &Loopback{name: "lo1", description: ygot.String("desc"), adminSt: true},
+			expectedError: true,
+			expectedEqual: false,
+		},
+		{
+			name:          "equal: L2 with VLANs in different order",
+			a:             &PhysIf{name: "eth1/1", l2: &L2Config{switchPort: SwitchPortModeAccess, spanningTree: SpanningTreeModeEdge, accessVlan: 10, nativeVlan: 40, allowedVlans: []uint16{20, 30, 40}}},
+			b:             &PhysIf{name: "eth1/1", l2: &L2Config{switchPort: SwitchPortModeAccess, spanningTree: SpanningTreeModeEdge, accessVlan: 10, nativeVlan: 40, allowedVlans: []uint16{30, 40, 20}}},
+			expectedError: false,
+			expectedEqual: true,
+		},
+		{
+			name:          "equal: L3 with IPs in different order",
+			a:             &PhysIf{name: "eth1/1", l3: &L3Config{addressingMode: AddressingModeNumbered, prefixesIPv4: []netip.Prefix{netip.MustParsePrefix("192.168.1.1/24"), netip.MustParsePrefix("10.0.0.1/24")}}},
+			b:             &PhysIf{name: "eth1/1", l3: &L3Config{addressingMode: AddressingModeNumbered, prefixesIPv4: []netip.Prefix{netip.MustParsePrefix("10.0.0.1/24"), netip.MustParsePrefix("192.168.1.1/24")}}},
+			expectedError: false,
+			expectedEqual: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, err := tt.a.Equals(tt.b)
+			if err != nil && tt.expectedError == false {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if equal != tt.expectedEqual {
+				t.Errorf("Equal() = %v, want %v", equal, tt.expectedEqual)
+			}
 		})
 	}
 }

--- a/internal/provider/cisco/nxos/iface/portchannel.go
+++ b/internal/provider/cisco/nxos/iface/portchannel.go
@@ -195,3 +195,11 @@ func (p *PortChannel) createL2(a *nxos.Cisco_NX_OSDevice_System_IntfItems_AggrIt
 	}
 	return nil
 }
+
+func (p *PortChannel) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (p *PortChannel) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/isis/interface.go
+++ b/internal/provider/cisco/nxos/isis/interface.go
@@ -83,7 +83,7 @@ func WithBFD() IfOption {
 	}
 }
 
-var ErrInterfaceNotFound = fmt.Errorf("interface not found on device")
+var ErrInterfaceNotFound = errors.New("interface not found on device")
 
 func (i *Interface) toYGOT(ctx context.Context, client gnmiext.Client) (*nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList_DomItems_DomList_IfItems_IfList, error) {
 	exists, err := iface.Exists(ctx, client, i.name)

--- a/internal/provider/cisco/nxos/isis/interface_test.go
+++ b/internal/provider/cisco/nxos/isis/interface_test.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/openconfig/ygot/ygot"
+
 	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
-	"github.com/openconfig/ygot/ygot"
 )
 
 func Test_Interface_NewInterface(t *testing.T) {
@@ -101,7 +102,7 @@ func Test_Interface_toYGOT(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error from NewInterface: %v", err)
 			}
-			got, err := intf.toYGOT(context.Background(), &gnmiext.ClientMock{
+			got, err := intf.toYGOT(t.Context(), &gnmiext.ClientMock{
 				ExistsFunc: func(ctx context.Context, xpath string) (bool, error) {
 					if tc.expectErr {
 						return false, errors.New("error")

--- a/internal/provider/cisco/nxos/isis/isis.go
+++ b/internal/provider/cisco/nxos/isis/isis.go
@@ -99,7 +99,9 @@ func (i *ISIS) ToYGOT(ctx context.Context, c gnmiext.Client) ([]gnmiext.Update, 
 		if err != nil {
 			return nil, err
 		}
-		domList.GetOrCreateIfItems().AppendIfList(iflist)
+		if err = domList.GetOrCreateIfItems().AppendIfList(iflist); err != nil {
+			return nil, fmt.Errorf("isis: failed to append interface %q: %w", intf.name, err)
+		}
 	}
 
 	updates := []gnmiext.Update{
@@ -135,4 +137,12 @@ func (i *ISIS) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 			XPath: "System/isis-items/inst-items/Inst-list[name=" + i.Name + "]",
 		},
 	}, nil
+}
+
+func (i *ISIS) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (i *ISIS) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/isis/isis_test.go
+++ b/internal/provider/cisco/nxos/isis/isis_test.go
@@ -44,8 +44,8 @@ func Test_ISIS_ToYGOT(t *testing.T) {
 		t.Errorf("expected XPath 'System/isis-items/inst-items/Inst-list[name=UNDERLAY]', got %s", update.XPath)
 	}
 	instList, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList)
-	if !ok {
-		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList")
+	if !ok || instList == nil {
+		t.Fatalf("expected value to be non-nil *nxos.Cisco_NX_OSDevice_System_IsisItems_InstItems_InstList")
 	}
 	if instList.Name == nil || *instList.Name != "UNDERLAY" {
 		t.Errorf("expected instList.Name to be 'UNDERLAY', got %v", instList.Name)
@@ -55,16 +55,16 @@ func Test_ISIS_ToYGOT(t *testing.T) {
 		t.Fatalf("expected DomItems to be present")
 	}
 	domList := domItems.GetDomList("default")
-	if domList == nil {
+	if domList == nil { //nolint:staticcheck
 		t.Fatalf("expected domList for default to be present")
 	}
-	if domList.Net == nil {
+	if domList.Net == nil { //nolint:staticcheck
 		t.Fatalf("expected Net to be set")
 	}
-	if *domList.Net != isis.NET {
+	if *domList.Net != isis.NET { //nolint:staticcheck
 		t.Errorf("Net not set correctly")
 	}
-	if domList.IsType != nxos.Cisco_NX_OSDevice_Isis_IsT_l12 {
+	if domList.IsType != nxos.Cisco_NX_OSDevice_Isis_IsT_l12 { //nolint:staticcheck
 		t.Errorf("Level not set correctly")
 	}
 	if domList.GetOverloadItems().AdminSt != nxos.Cisco_NX_OSDevice_Isis_OverloadAdminSt_bootup {

--- a/internal/provider/cisco/nxos/logging/logging.go
+++ b/internal/provider/cisco/nxos/logging/logging.go
@@ -34,6 +34,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openconfig/ygot/ygot"
@@ -285,4 +286,12 @@ func toSeverityLevel(level SeverityLevel) (nxos.E_Cisco_NX_OSDevice_Syslog_Sever
 	default:
 		return nxos.Cisco_NX_OSDevice_Syslog_Severity_UNSET, fmt.Errorf("logging: unknown severity level %s", level)
 	}
+}
+
+func (l *Logging) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (l *Logging) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/ntp/ntp.go
+++ b/internal/provider/cisco/nxos/ntp/ntp.go
@@ -5,6 +5,7 @@ package ntp
 
 import (
 	"context"
+	"errors"
 
 	"github.com/openconfig/ygot/ygot"
 
@@ -77,4 +78,12 @@ func (n *NTP) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 			},
 		},
 	}, nil
+}
+
+func (n *NTP) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (n *NTP) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/nve/nve.go
+++ b/internal/provider/cisco/nxos/nve/nve.go
@@ -235,7 +235,6 @@ func (n *NVE) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 		val.McastGroupL2 = ygot.String(n.mcastL2.String())
 	}
 	if n.mcastL3 != nil {
-
 		updates = append(updates, gnmiext.EditingUpdate{
 			XPath: "/System/fm-items/ngmvpn-items",
 			Value: &nxos.Cisco_NX_OSDevice_System_FmItems_NgmvpnItems{
@@ -281,4 +280,12 @@ func (n *NVE) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 			},
 		},
 	}, nil
+}
+
+func (n *NVE) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (n *NVE) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/nve/nve_test.go
+++ b/internal/provider/cisco/nxos/nve/nve_test.go
@@ -252,7 +252,7 @@ func Test_NVE_ToYGOT(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error during NewNVE: %v", err)
 			}
-			updates, err := nve.ToYGOT(context.TODO(), &gnmiext.ClientMock{
+			updates, err := nve.ToYGOT(t.Context(), &gnmiext.ClientMock{
 				ExistsFunc: func(_ context.Context, _ string) (bool, error) { return true, nil },
 			})
 			if err != nil {
@@ -322,7 +322,7 @@ func Test_NVE_Reset(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error during NewNVE: %v", err)
 			}
-			updates, err := nve.Reset(context.TODO(), &gnmiext.ClientMock{
+			updates, err := nve.Reset(t.Context(), &gnmiext.ClientMock{
 				ExistsFunc: func(_ context.Context, _ string) (bool, error) { return true, nil },
 			})
 			if err != nil {

--- a/internal/provider/cisco/nxos/ospf/interface.go
+++ b/internal/provider/cisco/nxos/ospf/interface.go
@@ -151,3 +151,11 @@ func (i *Interface) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update
 		},
 	}, nil
 }
+
+func (i *Interface) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (i *Interface) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/ospf/ospf.go
+++ b/internal/provider/cisco/nxos/ospf/ospf.go
@@ -255,3 +255,11 @@ func (o *OSPF) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 		},
 	}, nil
 }
+
+func (o *OSPF) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (o *OSPF) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/pim/pim.go
+++ b/internal/provider/cisco/nxos/pim/pim.go
@@ -133,6 +133,14 @@ func (p *RendezvousPoint) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.
 	}, nil
 }
 
+func (r *RendezvousPoint) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (r *RendezvousPoint) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 var _ gnmiext.DeviceConf = (*AnycastPeer)(nil)
 
 // AnycastPeer represents a PIM anycast rendezvous point peer configuration.
@@ -226,6 +234,14 @@ func (a *AnycastPeer) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Upda
 	}, nil
 }
 
+func (a *AnycastPeer) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (a *AnycastPeer) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 var _ gnmiext.DeviceConf = (*Interface)(nil)
 
 // Interface represents a PIM interface configuration. It is used to configure PIM on a specific interface.
@@ -314,4 +330,12 @@ func (i *Interface) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update
 			XPath: "System/pim-items/inst-items/dom-items/Dom-list[name=" + i.Vrf + "]/if-items/If-list[id=" + i.Name + "]",
 		},
 	}, nil
+}
+
+func (p *Interface) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (p *Interface) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -594,7 +594,8 @@ type Features struct{ Spec []string }
 func (step *Features) Name() string             { return "Features" }
 func (step *Features) Deps() []client.ObjectKey { return nil }
 func (step *Features) Exec(ctx context.Context, s *Scope) error {
-	return s.GNMI.Update(ctx, feat.Features(step.Spec))
+	f := &feat.Features{List: step.Spec}
+	return s.GNMI.Update(ctx, f)
 }
 
 type DNS struct{ Spec *v1alpha1.DNS }

--- a/internal/provider/cisco/nxos/smartlicensing/smartlicensing.go
+++ b/internal/provider/cisco/nxos/smartlicensing/smartlicensing.go
@@ -5,6 +5,7 @@ package smartlicensing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openconfig/ygot/ygot"
@@ -80,6 +81,14 @@ func (v *Licensing) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update
 			Value: x,
 		},
 	}, nil
+}
+
+func (l *Licensing) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (l *Licensing) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }
 
 type CallHome struct {
@@ -194,4 +203,12 @@ func (v *CallHome) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update,
 			Value: x,
 		},
 	}, nil
+}
+
+func (c *CallHome) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (c *CallHome) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/snmp/snmp.go
+++ b/internal/provider/cisco/nxos/snmp/snmp.go
@@ -300,3 +300,11 @@ func opt(s string) *string {
 	}
 	return ygot.String(s)
 }
+
+func (s *SNMP) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (s *SNMP) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/internal/provider/cisco/nxos/snmp/snmp_test.go
+++ b/internal/provider/cisco/nxos/snmp/snmp_test.go
@@ -284,7 +284,7 @@ func TestSNMP_ToYGOT(t *testing.T) {
 				GetFunc: test.mockGet,
 			}
 
-			updates, err := test.snmp.ToYGOT(context.Background(), mockClient)
+			updates, err := test.snmp.ToYGOT(t.Context(), mockClient)
 			if test.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -339,7 +339,7 @@ func TestSNMP_Reset(t *testing.T) {
 		},
 	}
 
-	updates, err := (&SNMP{}).Reset(context.Background(), mockClient)
+	updates, err := (&SNMP{}).Reset(t.Context(), mockClient)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return

--- a/internal/provider/cisco/nxos/term/term.go
+++ b/internal/provider/cisco/nxos/term/term.go
@@ -4,6 +4,7 @@ package term
 
 import (
 	"context"
+	"errors"
 
 	"github.com/openconfig/ygot/ygot"
 
@@ -34,7 +35,7 @@ func (c *Console) ToYGOT(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update,
 	}, nil
 }
 
-func (v *Console) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
+func (c *Console) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, error) {
 	cons := &nxos.Cisco_NX_OSDevice_System_TermlItems_LnItems_ConsItems{}
 	cons.PopulateDefaults()
 	return []gnmiext.Update{
@@ -43,6 +44,14 @@ func (v *Console) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, 
 			Value: cons,
 		},
 	}, nil
+}
+
+func (c *Console) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (c *Console) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }
 
 // VTY represents the virtual terminal line configuration.
@@ -96,4 +105,12 @@ func (v *VTY) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 			Value: acls,
 		},
 	}, nil
+}
+
+func (v *VTY) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (v *VTY) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/user/user.go
+++ b/internal/provider/cisco/nxos/user/user.go
@@ -115,6 +115,14 @@ func (u *User) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, err
 	}, nil
 }
 
+func (u *User) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (u *User) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 type Role struct {
 	Name string
 }

--- a/internal/provider/cisco/nxos/vlan/settings.go
+++ b/internal/provider/cisco/nxos/vlan/settings.go
@@ -5,6 +5,7 @@ package vlan
 
 import (
 	"context"
+	"errors"
 
 	"github.com/openconfig/ygot/ygot"
 
@@ -35,4 +36,12 @@ func (s *Settings) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update,
 			XPath: "System/vlanmgr-items/inst-items",
 		},
 	}, nil
+}
+
+func (s *Settings) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (s *Settings) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }

--- a/internal/provider/cisco/nxos/vrf/vrf.go
+++ b/internal/provider/cisco/nxos/vrf/vrf.go
@@ -4,6 +4,7 @@ package vrf
 
 import (
 	"context"
+	"errors"
 	"strconv"
 
 	"github.com/openconfig/ygot/ygot"
@@ -179,4 +180,12 @@ func (v *VRF) Reset(_ context.Context, _ gnmiext.Client) ([]gnmiext.Update, erro
 			XPath: "System/inst-items/Inst-list[name=" + v.name + "]/",
 		},
 	}, nil
+}
+
+func (v *VRF) FromYGOT(_ context.Context, _ gnmiext.Client) error {
+	return errors.New("not implemented")
+}
+
+func (v *VRF) Equals(_ gnmiext.DeviceConf) (bool, error) {
+	return false, errors.New("not implemented")
 }


### PR DESCRIPTION
* We want to avoid pushing new updates to the switch if its config has not
changed. This happens quite often, everytime a new reconcile is
triggered. Thus, we introduce methods for a user to retrieve the state
from the remote switch and populate our structs.
* We add a `FromYGOT` method to the DeviceConf interface. This method
  takes a gnmiext.Client as parameter. The `FromYGOT` function uses this
client to request various parts of the yang tree and populate the
DeviceConf implementation directly.
* Notice that an object is represented by multiple xpaths and the values
  therein, and that these xpaths often include lists with key values in
the middle of the path. For example a VRF name is often inserted in the
middle of an XPath. As such, it is not trivial create a list of Updates
to be requested with the client. Instead, we need to issue requests that
depend on the values returned by previous requests.
* We also add an `Equals` method to the DeviceConf interface. This
  method implements a comparison that can be utilized within a reconcile
iteration to check the differences between two objects. For example:
```
// declare an object and pre-set relevant key values, i.e., interface name
rConfig, _ := iface.NewPhysicalInterface("Ethernet1/1")
... // do error handling

// update rConfig with data from remote switch
err = c.Pull(context.Background(), rConfig)
... // add err handling

// lConfig is the object populated with CRD values
areEqual, err = rConfig.Equals(lConfig)

// reconcile or skip
```
* We implement an example for `PhysIf` and leave all other methods
  unimplemented for future work.
* Refactor pkg `Features`. Features is now a struct that incudes a List
  of features (a slice of strings). This change is done for convenience
after the introduction of the Equals method.
* Addressed several linting and static check errors