### PR TITLE
Upgrade to Go 1.25

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
   ],
   "commitMessageAction": "Renovate: Update",
   "constraints": {
-    "go": "1.24"
+    "go": "1.25"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,
@@ -24,7 +24,7 @@
       "matchPackageNames": [
         "golang"
       ],
-      "allowedVersions": "1.24.x"
+      "allowedVersions": "1.25.x"
     },
     {
       "matchPackageNames": [

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.5
+          go-version: 1.25.1
       - name: Cache golangci-lint analysis
         uses: actions/cache@v4
         with:
@@ -43,7 +43,7 @@ jobs:
         run: |
           # FIXME: Exclude cisco nx-os provider from golangci-lint as it includes
           # a lot of generated code that will exceed the runners's constraints.
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
           go list -f '{{.Dir}}' ./... | grep -v nxos/ | xargs $(go env GOPATH)/bin/golangci-lint run
       - name: Run shellcheck
         uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.5
+          go-version: 1.25.1
       - name: Run prepare make target
         run: make generate
       - name: Build all binaries
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.5
+          go-version: 1.25.1
       - name: Run prepare make target
         run: make generate
       - name: Run tests and generate coverage report

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.5
+          go-version: 1.25.1
       - name: Run prepare make target
         run: make generate
       - name: Generate release info

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.4
+          go-version: 1.25.1
       - name: Fetch latest kubectl version
         id: kubectl
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.24.4
+          go-version: 1.25.1
       - name: Fetch latest kubectl version
         id: kubectl
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.24-alpine3.22 AS builder
+FROM golang:1.25-alpine3.22 AS builder
 
 RUN apk add --no-cache --no-progress git make
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 -->
 
 # network-operator
+
 [![REUSE status](https://api.reuse.software/badge/github.com/ironcore-dev/network-operator)](https://api.reuse.software/info/github.com/ironcore-dev/network-operator)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ironcore-dev/network-operator)](https://goreportcard.com/report/github.com/ironcore-dev/network-operator)
 [![GitHub License](https://img.shields.io/static/v1?label=License&message=Apache-2.0&color=blue)](LICENSE)
@@ -18,12 +19,14 @@ Network-operator is a project built using Kubebuilder and controller-runtime to 
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+
+- go version v1.25.0+
 - docker version 28+.
 - kubectl version v1.33.1+.
 - Access to a Kubernetes v1.33.0+ cluster.
 
 ### To Deploy on the cluster
+
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
@@ -53,9 +56,10 @@ You can apply the samples (examples) from the config/sample:
 kubectl apply -k config/samples/
 ```
 
->**NOTE**: Ensure that the samples have default values to test it out.
+> **NOTE**: Ensure that the samples have default values to test it out.
 
 ### To Uninstall
+
 **Delete the instances (CRs) from the cluster:**
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/ironcore-dev/network-operator
 
-go 1.24
+go 1.25
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/google/go-cmp v0.7.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.3
@@ -23,6 +24,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.3
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -51,7 +53,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -106,7 +107,6 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace github.com/openconfig/ygnmi => github.com/felix-kaestner/ygnmi v0.0.0-20250709083711-68dcb70888a5

--- a/test/gnmi/Dockerfile
+++ b/test/gnmi/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 ARG ALPINE_VERSION=3.22
 
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build

--- a/test/gnmi/go.mod
+++ b/test/gnmi/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/gnmi-test-server
 
-go 1.24
+go 1.25
 
 require (
 	github.com/openconfig/gnmi v0.14.1


### PR DESCRIPTION
This fixes CVE-2025-47906. 

See https://pkg.go.dev/vuln/GO-2025-3956