### PR TITLE
cisco-nxos-provider: allow to configure client certificate trustpoint

### DIFF
--- a/internal/provider/cisco/nxos/api/grpc_test.go
+++ b/internal/provider/cisco/nxos/api/grpc_test.go
@@ -4,103 +4,136 @@
 package api
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/openconfig/ygot/ygot"
 
 	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/testutils"
 )
 
-func Test_GRPC(t *testing.T) {
-	grpc := &GRPC{
-		Enable:     true,
-		Vrf:        "CC-MGMT",
-		Trustpoint: "mytrustpoint",
-	}
-
-	got, err := grpc.ToYGOT(t.Context(), &gnmiext.ClientMock{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(got) != 2 {
-		t.Errorf("expected 2 keys, got %d", len(got))
-	}
-
-	update, ok := got[0].(gnmiext.EditingUpdate)
-	if !ok {
-		t.Errorf("expected value to be of type EditingUpdate")
-	}
-
-	if update.XPath != "System/fm-items/grpc-items" {
-		t.Errorf("expected key 'System/fm-items/grpc-items' to be present")
-	}
-
-	i, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems)
-	if !ok {
-		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems")
-	}
-	if i.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled {
-		t.Errorf("expected value for 'System/fm-items/grpc-items/adminSt' to be enabled")
-	}
-
-	update, ok = got[1].(gnmiext.EditingUpdate)
-	if !ok {
-		t.Errorf("expected value to be of type EditingUpdate")
-	}
-
-	if update.XPath != "System/grpc-items" {
-		t.Errorf("expected key 'System/grpc-items' to be present")
-	}
-
-	g, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_GrpcItems)
-	if !ok {
-		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems")
-	}
-
-	want := &nxos.Cisco_NX_OSDevice_System_GrpcItems{
-		Cert: ygot.String("mytrustpoint"),
-		GnmiItems: &nxos.Cisco_NX_OSDevice_System_GrpcItems_GnmiItems{
-			MinSampleInterval: ygot.Uint32(10),
-			KeepAliveTimeout:  ygot.Uint32(600),
-			MaxCalls:          ygot.Uint16(8),
+func Test_GRPC_ToYGOT(t *testing.T) {
+	tests := []struct {
+		name     string
+		grpc     *GRPC
+		expected []gnmiext.Update
+	}{
+		{
+			name: "disabled",
+			grpc: &GRPC{Enable: false},
+			expected: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "System/fm-items/grpc-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled,
+					},
+				},
+			},
 		},
-		Port:   ygot.Uint32(50051),
-		UseVrf: ygot.String("CC-MGMT"),
+		{
+			name: "enabled with defaults",
+			grpc: &GRPC{
+				Enable:     true,
+				Vrf:        "CC-MGMT",
+				Trustpoint: "mytrustpoint",
+			},
+			expected: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "System/fm-items/grpc-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+					},
+				},
+				gnmiext.EditingUpdate{
+					XPath: "System/grpc-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_GrpcItems{
+						Cert:           ygot.String("mytrustpoint"),
+						Port:           ygot.Uint32(50051),
+						UseVrf:         ygot.String("CC-MGMT"),
+						CertClientRoot: nil,
+						GnmiItems: &nxos.Cisco_NX_OSDevice_System_GrpcItems_GnmiItems{
+							MaxCalls:          ygot.Uint16(8),
+							KeepAliveTimeout:  ygot.Uint32(600),
+							MinSampleInterval: ygot.Uint32(10),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enabled with custom values",
+			grpc: &GRPC{
+				Enable:         true,
+				Port:           9000,
+				Vrf:            "production",
+				Trustpoint:     "custom-trustpoint",
+				CertClientRoot: "root-cert",
+				GNMI: &GNMI{
+					MaxConcurrentCall: 12,
+					KeepAliveTimeout:  900,
+					MinSampleInterval: 5,
+				},
+			},
+			expected: []gnmiext.Update{
+				gnmiext.EditingUpdate{
+					XPath: "System/fm-items/grpc-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems{
+						AdminSt: nxos.Cisco_NX_OSDevice_Fm_AdminState_enabled,
+					},
+				},
+				gnmiext.EditingUpdate{
+					XPath: "System/grpc-items",
+					Value: &nxos.Cisco_NX_OSDevice_System_GrpcItems{
+						Cert:           ygot.String("custom-trustpoint"),
+						Port:           ygot.Uint32(9000),
+						UseVrf:         ygot.String("production"),
+						CertClientRoot: ygot.String("root-cert"),
+						GnmiItems: &nxos.Cisco_NX_OSDevice_System_GrpcItems_GnmiItems{
+							MaxCalls:          ygot.Uint16(12),
+							KeepAliveTimeout:  ygot.Uint32(900),
+							MinSampleInterval: ygot.Uint32(5),
+						},
+					},
+				},
+			},
+		},
 	}
-	if !reflect.DeepEqual(g, want) {
-		t.Errorf("unexpected value for 'System/grpc-items': got=%+v, want=%+v", g, want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.grpc.ToYGOT(t.Context(), &gnmiext.ClientMock{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			testutils.AssertEqual(t, got, tt.expected)
+		})
 	}
 }
 
-func Test_GRPC_Disabled(t *testing.T) {
-	grpc := &GRPC{Enable: false}
+func Test_GRPC_Reset(t *testing.T) {
+	grpc := &GRPC{} // Any configuration should be ignored for Reset
 
-	got, err := grpc.ToYGOT(t.Context(), &gnmiext.ClientMock{})
+	got, err := grpc.Reset(t.Context(), &gnmiext.ClientMock{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(got) != 1 {
-		t.Errorf("expected 1 key, got %d", len(got))
+	expected := []gnmiext.Update{
+		gnmiext.ReplacingUpdate{
+			XPath: "System/grpc-items",
+			Value: &nxos.Cisco_NX_OSDevice_System_GrpcItems{
+				Port:   ygot.Uint32(50051),
+				UseVrf: ygot.String("default"),
+				GnmiItems: &nxos.Cisco_NX_OSDevice_System_GrpcItems_GnmiItems{
+					MaxCalls:          ygot.Uint16(8),
+					KeepAliveTimeout:  ygot.Uint32(600),
+					MinSampleInterval: ygot.Uint32(10),
+				},
+			},
+		},
 	}
 
-	update, ok := got[0].(gnmiext.EditingUpdate)
-	if !ok {
-		t.Errorf("expected value to be of type EditingUpdate")
-	}
-
-	if update.XPath != "System/fm-items/grpc-items" {
-		t.Errorf("expected key 'System/fm-items/grpc-items' to be present")
-	}
-
-	i, ok := update.Value.(*nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems)
-	if !ok {
-		t.Errorf("expected value to be of type *nxos.Cisco_NX_OSDevice_System_FmItems_GrpcItems")
-	}
-	if i.AdminSt != nxos.Cisco_NX_OSDevice_Fm_AdminState_disabled {
-		t.Errorf("expected value for 'System/fm-items/grpc-items/adminSt' to be disabled")
-	}
+	testutils.AssertEqual(t, got, expected)
 }


### PR DESCRIPTION
This patch adjusts the implementation for configuring the grpc server process on the Cisco NX-OS Device to set a client certificate trustpoint that is used for mTLS to verify the client certificate presented by the callers. This corresponds to the cli configuration of:

```
grpc client root certificate <trustpoint-id>
```

Additionally, this patch implements the `Reset` func of the grpc configuration. It will not disable the grpc server but just reset some of it's properties to their default value.