### PR TITLE
cisco-nxos-provider: `VLAN`

### DIFF
--- a/internal/provider/cisco/nxos/vlan/vlan.go
+++ b/internal/provider/cisco/nxos/vlan/vlan.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package vlan provides functionality to manage VLANs on Cisco NX-OS devices. This implementation assumes that the
+//
+// [Cisco-VLAN] https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/104x/configuration/layer-2-switching/cisco-nexus-9000-series-nx-os-layer-2-switching-configuration-guide-104x/m-configuring-vlans.html
+package vlan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+	"github.com/openconfig/ygot/ygot"
+)
+
+var _ gnmiext.DeviceConf = (*VLAN)(nil)
+
+type VLAN struct {
+	ID         uint16
+	Name       string
+	AdminState bool
+}
+
+func (v *VLAN) validate(ctx context.Context, c gnmiext.Client) error {
+	if v.ID < 1 || v.ID > 4095 {
+		return errors.New("vlan: ID must be in the range 1-4095")
+	}
+	// always reserved VLAN IDs: 1, 4093, 4094, and 4095
+	if v.ID == 1 || v.ID >= 4093 {
+		return fmt.Errorf("vlan: ID %d is reserved and cannot be configured", v.ID)
+	}
+	// the reserved ID range for internal use can be configured by the user and needs to be thus fetched from the device
+	rv := &nxos.Cisco_NX_OSDevice_System_BdItems_ResvlanItems{}
+	err := c.Get(ctx, "System/bd-items/resvlan-items", rv)
+	if err != nil {
+		return fmt.Errorf("vlan: failed to retrieve reserved VLAN range from device: %w", err)
+	}
+	if rv.SysVlan == nil || *rv.SysVlan == 0 {
+		return fmt.Errorf("vlan: failed to retrieve reserved VLAN range from device, sysVlan is nil or zero")
+	}
+	if v.ID >= *rv.SysVlan && v.ID <= *rv.SysVlan+128 {
+		return fmt.Errorf("vlan: ID %d is in the range reserved for internal use, min: %d, max %d", v.ID, *rv.SysVlan, *rv.SysVlan+128)
+	}
+
+	if v.ID >= 1006 && v.ID <= 3967 && !v.AdminState {
+		return errors.New("vlan: IDs 1006-3967 are reserved for extended range and cannot be shut down or deleted")
+	}
+	return nil
+}
+
+// ToYGOT converts the VLAN configuration to a list of gnmiext.Updates that can be applied to the device.
+// Returns an error if the VLAN ID is out of range or reserved (see [Cisco-VLAN] for applicable ranges)
+func (v *VLAN) ToYGOT(ctx context.Context, c gnmiext.Client) ([]gnmiext.Update, error) {
+	if err := v.validate(ctx, c); err != nil {
+		return nil, err
+	}
+
+	yv := &nxos.Cisco_NX_OSDevice_System_BdItems_BdItems_BDList{
+		Id:      ygot.Uint32(uint32(v.ID)),
+		AdminSt: nxos.Cisco_NX_OSDevice_L2_DomAdminSt_active,
+	}
+
+	if v.Name != "" {
+		yv.Name = ygot.String(v.Name)
+	}
+	if !v.AdminState {
+		yv.AdminSt = nxos.Cisco_NX_OSDevice_L2_DomAdminSt_suspend
+	}
+
+	return []gnmiext.Update{
+		gnmiext.ReplacingUpdate{
+			XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-" + strconv.FormatUint(uint64(v.ID), 10) + "]",
+			Value: yv,
+		},
+	}, nil
+}
+
+// Reset resets or deletes the VLAN depending on VLAN's ID value (see [Cisco-VLAN] for applicable ranges):
+func (v *VLAN) Reset(ctx context.Context, c gnmiext.Client) ([]gnmiext.Update, error) {
+	if err := v.validate(ctx, c); err != nil {
+		return nil, err
+	}
+	// normal VLANs can be deleted
+	if v.ID >= 2 && v.ID <= 1005 {
+		return []gnmiext.Update{
+			gnmiext.DeletingUpdate{
+				XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-" + strconv.FormatUint(uint64(v.ID), 10) + "]",
+			},
+		}, nil
+	}
+	// extended range VLANs can only be reset to default values
+	yv := &nxos.Cisco_NX_OSDevice_System_BdItems_BdItems_BDList{}
+	yv.PopulateDefaults()
+	yv.Id = ygot.Uint32(uint32(v.ID))
+	return []gnmiext.Update{
+		gnmiext.DeletingUpdate{
+			XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-" + strconv.FormatUint(uint64(v.ID), 10) + "]",
+		},
+	}, nil
+}

--- a/internal/provider/cisco/nxos/vlan/vlan_test.go
+++ b/internal/provider/cisco/nxos/vlan/vlan_test.go
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package vlan
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	nxos "github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/genyang"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/gnmiext"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos/testutils"
+	"github.com/openconfig/ygot/ygot"
+)
+
+var clientMock = &gnmiext.ClientMock{
+	GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+		destVal, ok := dest.(*nxos.Cisco_NX_OSDevice_System_BdItems_ResvlanItems)
+		if !ok {
+			return errors.New("unexpected type in GetFunc mock")
+		}
+		destVal.SysVlan = ygot.Uint16(3968)
+		return nil
+	},
+}
+
+func TestVLAN_ToYGOT(t *testing.T) {
+	tests := []struct {
+		name            string
+		v               VLAN
+		clientMock      gnmiext.Client
+		expectErr       bool
+		expectedUpdates []gnmiext.Update
+	}{
+		{
+			name:       "valid VLAN",
+			v:          VLAN{ID: 10, Name: "test", AdminState: true},
+			clientMock: clientMock,
+			expectErr:  false,
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.ReplacingUpdate{
+					XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-10]",
+					Value: &nxos.Cisco_NX_OSDevice_System_BdItems_BdItems_BDList{
+						Id:      ygot.Uint32(10),
+						Name:    ygot.String("test"),
+						AdminSt: nxos.Cisco_NX_OSDevice_L2_DomAdminSt_active,
+					},
+				},
+			},
+		},
+		{
+			name:       "valid VLAN, no name, default state is admin down",
+			v:          VLAN{ID: 20},
+			clientMock: clientMock,
+			expectErr:  false,
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.ReplacingUpdate{
+					XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-20]",
+					Value: &nxos.Cisco_NX_OSDevice_System_BdItems_BdItems_BDList{
+						Id:      ygot.Uint32(20),
+						AdminSt: nxos.Cisco_NX_OSDevice_L2_DomAdminSt_suspend,
+					},
+				},
+			},
+		},
+		{
+			name:       "invalid: VLAN 0",
+			v:          VLAN{ID: 0},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: VLAN 4096",
+			v:          VLAN{ID: 4096},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to modify system VLAN 1",
+			v:          VLAN{ID: 1},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to modify system VLAN 4093",
+			v:          VLAN{ID: 4093},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to modify system VLAN 4094",
+			v:          VLAN{ID: 4094},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to modify system VLAN 4095",
+			v:          VLAN{ID: 4096},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: in system reserved range 3968-4095",
+			v:          VLAN{ID: 4000},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to shutdown VLAN 1006 in extended range 1006-3967",
+			v:          VLAN{ID: 1006},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to shutdown VLAN 3967 in extended range 1006-3967",
+			v:          VLAN{ID: 3967},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name: "invalid: in system reserved range 100-268",
+			v:    VLAN{ID: 200},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					destVal, ok := dest.(*nxos.Cisco_NX_OSDevice_System_BdItems_ResvlanItems)
+					if !ok {
+						return errors.New("unexpected type in GetFunc mock")
+					}
+					destVal.SysVlan = ygot.Uint16(100)
+					return nil
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid: failed to get reserved VLANs from device",
+			v:    VLAN{ID: 200},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					return errors.New("gNMI error")
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid: no values returned for reserved VLANs from device",
+			v:    VLAN{ID: 200},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					destVal, ok := dest.(*nxos.Cisco_NX_OSDevice_System_BdItems_ResvlanItems)
+					if !ok {
+						return errors.New("unexpected type in GetFunc mock")
+					}
+					destVal.SysVlan = ygot.Uint16(0)
+					return nil
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates, err := tt.v.ToYGOT(t.Context(), tt.clientMock)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			testutils.AssertEqual(t, updates, tt.expectedUpdates)
+		})
+	}
+}
+
+func TestVLAN_Reset(t *testing.T) {
+	tests := []struct {
+		name            string
+		v               VLAN
+		clientMock      gnmiext.Client
+		expectErr       bool
+		expectedUpdates []gnmiext.Update
+	}{
+		{
+			name:       "valid VLAN reset in normal range",
+			v:          VLAN{ID: 10, Name: "test", AdminState: true},
+			clientMock: clientMock,
+			expectErr:  false,
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.DeletingUpdate{
+					XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-10]",
+				},
+			},
+		},
+		{
+			name:       "valid VLAN reset in extended range",
+			v:          VLAN{ID: 2000, Name: "test", AdminState: true},
+			clientMock: clientMock,
+			expectErr:  false,
+			expectedUpdates: []gnmiext.Update{
+				gnmiext.DeletingUpdate{
+					XPath: "System/bd-items/bd-items/BD-list[fabEncap=vlan-2000]",
+				},
+			},
+		},
+		{
+			name:       "invalid: VLAN 0",
+			v:          VLAN{ID: 0},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: VLAN 4096",
+			v:          VLAN{ID: 4096},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to reset system VLAN 1",
+			v:          VLAN{ID: 1},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to reset system VLAN 4093",
+			v:          VLAN{ID: 4093},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to reset system VLAN 4094",
+			v:          VLAN{ID: 4094},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: attempt to reset system VLAN 4095",
+			v:          VLAN{ID: 4095},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid: in system reserved range 3968-4095",
+			v:          VLAN{ID: 4000},
+			clientMock: clientMock,
+			expectErr:  true,
+		},
+		{
+			name: "invalid: in custom reserved range 100-268",
+			v:    VLAN{ID: 200},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					destVal, ok := dest.(*nxos.Cisco_NX_OSDevice_System_BdItems_ResvlanItems)
+					if !ok {
+						return errors.New("unexpected type in GetFunc mock")
+					}
+					destVal.SysVlan = ygot.Uint16(100)
+					return nil
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid: failed to get reserved VLANs from device",
+			v:    VLAN{ID: 200},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					return errors.New("gNMI error")
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid: no values returned for reserved VLANs from device",
+			v:    VLAN{ID: 200},
+			clientMock: &gnmiext.ClientMock{
+				GetFunc: func(_ context.Context, _ string, dest ygot.GoStruct, opts ...gnmiext.GetOption) error {
+					destVal, ok := dest.(*nxos.Cisco_NX_OSDevice_System_BdItems_ResvlanItems)
+					if !ok {
+						return errors.New("unexpected type in GetFunc mock")
+					}
+					destVal.SysVlan = ygot.Uint16(0)
+					return nil
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates, err := tt.v.Reset(t.Context(), tt.clientMock)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			testutils.AssertEqual(t, updates, tt.expectedUpdates)
+		})
+	}
+}


### PR DESCRIPTION
This PR is not to be merged as per decision to move away from `YGOT`. It can be used as reference for new implementations. 


* Implement the configuration of VLANs on the cisco-nxos-provider. It supports the following CLI configuration:

```
vlan 100
name "test"
no shutdown
```