### PR TITLE
Add `gnmiext/v2` package providing utilities for using gNMI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ironcore-dev/network-operator
 go 1.25
 
 require (
+	github.com/felix-kaestner/copy v0.0.0-20240226161622-4773371af039
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
+github.com/felix-kaestner/copy v0.0.0-20240226161622-4773371af039 h1:jkrAuR/4HxUAEAPr5ibxidQTJBxLY1SUPF2WDpUx0dE=
+github.com/felix-kaestner/copy v0.0.0-20240226161622-4773371af039/go.mod h1:CBCoJwqwLnXKmE+Oo/m1Wli4mbYI3ROGqRCiTtbOE2c=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
@@ -113,10 +115,6 @@ github.com/openconfig/goyang v1.6.2 h1:LVwwlVIIt4nmwacW67yBsxzP5DhDM94SOEMWod1hE
 github.com/openconfig/goyang v1.6.2/go.mod h1:jzlGg+yjRpOcq1Kg6q6cSiLGQK5hrNNMsUx0fFxm4U0=
 github.com/openconfig/grpctunnel v0.1.0 h1:EN99qtlExZczgQgp5ANnHRC/Rs62cAG+Tz2BQ5m/maM=
 github.com/openconfig/grpctunnel v0.1.0/go.mod h1:G04Pdu0pml98tdvXrvLaU+EBo3PxYfI9MYqpvdaEHLo=
-github.com/openconfig/ygnmi v0.12.0 h1:tHQvwAtOK59P9o0yLYT9VcVFG90jPFebaKJTFk1M8V0=
-github.com/openconfig/ygnmi v0.12.0/go.mod h1:tgmeZPVofJnH0zUIPmoO0ZyBX3Ami1asv86k7cbahVA=
-github.com/openconfig/ygnmi v0.13.0 h1:l/oxs5QMpZhMYoFYLoUCjXOOEFCxVrxgz3Fdj7ot+BM=
-github.com/openconfig/ygnmi v0.13.0/go.mod h1:PdM5tOI2aCWSqfci5OagAyKJUNJ1IhYIGmSeRlMBVCI=
 github.com/openconfig/ygnmi v0.13.1-0.20250924235719-646562b5d0c3 h1:y9Wj152WN0UadK5v0iZGB5qs36FxO2x/CyX73GtKR+4=
 github.com/openconfig/ygnmi v0.13.1-0.20250924235719-646562b5d0c3/go.mod h1:PdM5tOI2aCWSqfci5OagAyKJUNJ1IhYIGmSeRlMBVCI=
 github.com/openconfig/ygot v0.32.0 h1:zGYVk/T7hgcMuxhxH5bN5tFxy3VhHlLN6ZabSeTATtk=

--- a/internal/provider/cisco/gnmiext/v2/client.go
+++ b/internal/provider/cisco/gnmiext/v2/client.go
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package gnmiext
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+
+	cp "github.com/felix-kaestner/copy"
+	"github.com/go-logr/logr"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+	"google.golang.org/grpc"
+)
+
+// Configurable represents a configuration item with a YANG path.
+type Configurable interface {
+	// XPath returns the YANG path for this configuration item.
+	// It may include an origin prefix (e.g., "openconfig:system/config/hostname").
+	XPath() string
+}
+
+// Defaultable represents a configuration item that resets to a default
+// value instead of being deleted.
+type Defaultable interface {
+	// Default sets the receiver to its default value in-place.
+	Default()
+}
+
+// Marshaler provides device-specific marshaling based on capabilities.
+type Marshaler interface {
+	// MarshalYANG serializes the receiver using device capabilities.
+	MarshalYANG(*Capabilities) ([]byte, error)
+
+	// UnmarshalYANG deserializes data into the receiver using device
+	// capabilities.
+	UnmarshalYANG(*Capabilities, []byte) error
+}
+
+// Model represents a YANG data model supported by a device.
+type Model struct {
+	Name         string
+	Organization string
+	Version      string
+}
+
+// Capabilities represents device capabilities including supported YANG models.
+type Capabilities struct {
+	SupportedModels []Model
+}
+
+// Client is a gNMI client offering convenience methods for device configuration
+// using gNMI.
+type Client struct {
+	gnmi         gpb.GNMIClient
+	encoding     gpb.Encoding
+	capabilities *Capabilities
+	logger       logr.Logger
+}
+
+// New creates a new Client by negotiating capabilities with the gNMI server by
+// carrying out a Capabilities RPC.
+// Returns an error if the device doesn't support JSON encoding.
+// By default, the client uses [slog.Default] for logging.
+// Use [WithLogger] to provide a custom logger.
+func New(ctx context.Context, conn grpc.ClientConnInterface, opts ...Option) (*Client, error) {
+	gnmi := gpb.NewGNMIClient(conn)
+	res, err := gnmi.Capabilities(ctx, &gpb.CapabilityRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("gnmiext: failed to retrieve capabilities: %w", err)
+	}
+	encoding := gpb.Encoding(-1)
+	for _, e := range res.SupportedEncodings {
+		switch e {
+		case gpb.Encoding_JSON, gpb.Encoding_JSON_IETF:
+			encoding = e
+		default:
+			// Ignore unsupported encodings.
+		}
+	}
+	if encoding == -1 {
+		return nil, fmt.Errorf("gnmiext: unsupported encoding: %v", res.SupportedEncodings)
+	}
+	capabilities := &Capabilities{SupportedModels: make([]Model, len(res.GetSupportedModels()))}
+	for i, model := range res.GetSupportedModels() {
+		capabilities.SupportedModels[i] = Model{
+			Name:         model.Name,
+			Organization: model.Organization,
+			Version:      model.Version,
+		}
+	}
+	logger := logr.FromSlogHandler(slog.Default().Handler())
+	client := &Client{gnmi, encoding, capabilities, logger}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client, nil
+}
+
+type Option func(*Client)
+
+// WithLogger sets a custom logger for the client.
+func WithLogger(logger logr.Logger) Option {
+	return func(c *Client) {
+		c.logger = logger
+	}
+}
+
+// ErrNil indicates that the value for a xpath is not defined.
+var ErrNil = errors.New("gnmiext: nil")
+
+// GetConfig retrieves config and unmarshals it into the provided targets.
+// If some of the values for the given xpaths are not defined, [ErrNil] is returned.
+func (c *Client) GetConfig(ctx context.Context, conf ...Configurable) error {
+	return c.get(ctx, gpb.GetRequest_CONFIG, conf...)
+}
+
+// GetState retrieves state and unmarshals it into the provided targets.
+// If some of the values for the given xpaths are not defined, [ErrNil] is returned.
+func (c *Client) GetState(ctx context.Context, conf ...Configurable) error {
+	return c.get(ctx, gpb.GetRequest_STATE, conf...)
+}
+
+// Update replaces the configuration for the given set of items.
+// If the current configuration equals the desired configuration, the operation is skipped.
+// For partial updates that merge changes, use [Client.Patch] instead.
+func (c *Client) Update(ctx context.Context, conf ...Configurable) error {
+	return c.set(ctx, false, conf...)
+}
+
+// Patch merges the configuration for the given set of items.
+// If the current configuration equals the desired configuration, the operation is skipped.
+// For full replacement of configuration, use [Client.Update] instead.
+func (c *Client) Patch(ctx context.Context, conf ...Configurable) error {
+	return c.set(ctx, true, conf...)
+}
+
+// Delete resets the configuration for the given set of items.
+// If an item implements [Defaultable], it's reset to default value.
+// Otherwise, the configuration is deleted.
+func (c *Client) Delete(ctx context.Context, conf ...Configurable) error {
+	if len(conf) == 0 {
+		return nil
+	}
+	r := new(gpb.SetRequest)
+	for _, cf := range conf {
+		path, err := StringToStructuredPath(cf.XPath())
+		if err != nil {
+			return err
+		}
+		if d, ok := cf.(Defaultable); ok {
+			d.Default()
+			b, err := c.Marshal(cf)
+			if err != nil {
+				return err
+			}
+			c.logger.V(1).Info("Resetting to default", "path", cf.XPath(), "payload", string(b))
+			r.Replace = append(r.Replace, &gpb.Update{
+				Path: path,
+				Val:  c.Encode(b),
+			})
+			continue
+		}
+		c.logger.V(1).Info("Deleting", "path", cf.XPath())
+		r.Delete = append(r.Delete, path)
+	}
+	if _, err := c.gnmi.Set(ctx, r); err != nil {
+		return fmt.Errorf("gnmiext: failed to perform set rpc: %w", err)
+	}
+	return nil
+}
+
+// get retrieves data of the specified type (CONFIG or STATE) and unmarshals it
+// into the provided targets. If some of the values for the given xpaths are not
+// defined, [ErrNil] is returned.
+func (c *Client) get(ctx context.Context, dt gpb.GetRequest_DataType, conf ...Configurable) error {
+	if len(conf) == 0 {
+		return nil
+	}
+	r := &gpb.GetRequest{
+		Type:     dt,
+		Encoding: c.encoding,
+	}
+	for _, cf := range conf {
+		path, err := StringToStructuredPath(cf.XPath())
+		if err != nil {
+			return err
+		}
+		r.Path = append(r.Path, path)
+	}
+	res, err := c.gnmi.Get(ctx, r)
+	if err != nil {
+		return fmt.Errorf("gnmiext: failed to perform get rpc: %w", err)
+	}
+	// As per [gNMI spec] the response MUST contain one notification
+	// for each path in the request.
+	//
+	// [gNMI spec]: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#332-the-getresponse-message
+	if len(res.Notification) != len(conf) {
+		// This should never happen. If it does, it indicates a bug in the
+		// gNMI server.
+		return fmt.Errorf("gnmiext: unexpected number of notifications: got %d, want %d", len(res.Notification), len(conf))
+	}
+	// prevent bounds check in for the range loop below
+	// [Bounds Check Elimination]: https://go101.org/optimizations/5-bce.html
+	_ = res.Notification[len(conf)-1]
+	for i, cf := range conf {
+		n := res.Notification[i]
+		switch len(n.Update) {
+		case 0:
+			return ErrNil
+		case 1:
+			b, err := c.Decode(n.Update[0].Val)
+			if err != nil {
+				return err
+			}
+			// Some target devices (e.g., Cisco NX-OS) have an incorrect
+			// implementation of the [gNMI spec] and return an empty [gpb.TypedValue]
+			// instead of a NotFound status error when the requested path is
+			// syntactically correct but does not exist on the device.
+			//
+			// [gNMI spec]: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#334-getresponse-behavior-table
+			if len(b) == 0 {
+				return ErrNil
+			}
+			if err := c.Unmarshal(b, cf); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("gnmiext: unexpected number of updates: %d", len(n.Update))
+		}
+	}
+	return nil
+}
+
+// set applies the provided configuration items. If patch is true, a
+// partial update is performed by merging the changes into the existing
+// configuration. Otherwise, a full replacement is done.
+// If the current configuration equals the desired configuration, the operation
+// is skipped.
+func (c *Client) set(ctx context.Context, patch bool, conf ...Configurable) (err error) {
+	if len(conf) == 0 {
+		return nil
+	}
+	r := new(gpb.SetRequest)
+	for _, cf := range conf {
+		path, err := StringToStructuredPath(cf.XPath())
+		if err != nil {
+			return err
+		}
+		got := cp.Deep(cf)
+		if err := c.GetConfig(ctx, got); err != nil && !errors.Is(err, ErrNil) {
+			return fmt.Errorf("gnmiext: failed to retrieve current config for %s: %w", cf.XPath(), err)
+		}
+		// If the current configuration is equal to the desired configuration, skip the update.
+		// This avoids unnecessary updates and potential disruptions.
+		if reflect.DeepEqual(cf, got) {
+			c.logger.V(1).Info("Configuration is already up-to-date", "path", cf.XPath())
+			continue
+		}
+		b, err := c.Marshal(cf)
+		if err != nil {
+			return err
+		}
+		c.logger.V(1).Info("Updating", "path", cf.XPath(), "payload", string(b), "patch", patch)
+		u := &gpb.Update{
+			Path: path,
+			Val:  c.Encode(b),
+		}
+		if patch {
+			r.Update = append(r.Update, u)
+			continue
+		}
+		r.Replace = append(r.Replace, u)
+	}
+	if len(r.Update) == 0 && len(r.Replace) == 0 {
+		// All configurations are already up-to-date.
+		return nil
+	}
+	if _, err := c.gnmi.Set(ctx, r); err != nil {
+		return fmt.Errorf("gnmiext: failed to perform set rpc: %w", err)
+	}
+	return nil
+}
+
+// Marshal marshals the provided value into a byte slice using the client's encoding.
+// If the value implements the [Marshaler] interface, it will be marshaled using that.
+// Otherwise, [json.Marshal] is used.
+func (c *Client) Marshal(v any) (b []byte, err error) {
+	if m, ok := v.(Marshaler); ok {
+		b, err = m.MarshalYANG(c.capabilities)
+		if err != nil {
+			return nil, fmt.Errorf("gnmiext: failed to marshal value: %w", err)
+		}
+		return b, nil
+	}
+	b, err = json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("gnmiext: failed to marshal value: %w", err)
+	}
+	return b, nil
+}
+
+// Unmarshal unmarshals the provided byte slice into the provided destination.
+// If the destination implements the [Marshaler] interface, it will be unmarshaled using that.
+// Otherwise, [json.Unmarshal] is used.
+func (c *Client) Unmarshal(b []byte, dst any) (err error) {
+	if um, ok := dst.(Marshaler); ok {
+		if err := um.UnmarshalYANG(c.capabilities, b); err != nil {
+			return fmt.Errorf("gnmiext: failed to unmarshal value: %w", err)
+		}
+		return nil
+	}
+	if err := json.Unmarshal(b, dst); err != nil {
+		return fmt.Errorf("gnmiext: failed to unmarshal value: %w", err)
+	}
+	return nil
+}
+
+// Encode encodes the provided byte slice into a [gpb.TypedValue] using the client's encoding.
+func (c *Client) Encode(b []byte) *gpb.TypedValue {
+	switch c.encoding {
+	case gpb.Encoding_JSON:
+		return &gpb.TypedValue{
+			Value: &gpb.TypedValue_JsonVal{
+				JsonVal: b,
+			},
+		}
+	case gpb.Encoding_JSON_IETF:
+		return &gpb.TypedValue{
+			Value: &gpb.TypedValue_JsonIetfVal{
+				JsonIetfVal: b,
+			},
+		}
+	default:
+		panic("gnmiext: unsupported encoding")
+	}
+}
+
+// Decode decodes the provided [gpb.TypedValue] into the provided destination using the client's encoding.
+func (c *Client) Decode(val *gpb.TypedValue) ([]byte, error) {
+	switch c.encoding {
+	case gpb.Encoding_JSON:
+		v, ok := val.Value.(*gpb.TypedValue_JsonVal)
+		if !ok {
+			return nil, fmt.Errorf("gnmiext: unexpected value type: expected JsonVal, got %T", val.Value)
+		}
+		return v.JsonVal, nil
+	case gpb.Encoding_JSON_IETF:
+		v, ok := val.Value.(*gpb.TypedValue_JsonIetfVal)
+		if !ok {
+			return nil, fmt.Errorf("gnmiext: unexpected value type: expected JsonIetfVal, got %T", val.Value)
+		}
+		return v.JsonIetfVal, nil
+	default:
+		panic("gnmiext: unsupported encoding")
+	}
+}
+
+// StringToStructuredPath converts a string xpath to a structured path.
+//
+// It is a wrapper around [ygot.StringToStructuredPath] that additionally supports
+// origin prefixes, such as "openconfig-interfaces:interfaces/interface[name=eth1/1]".
+func StringToStructuredPath(xpath string) (*gpb.Path, error) {
+	var model string
+	if idx := strings.Index(xpath, ":"); idx > 0 {
+		model = xpath[:idx]
+		xpath = xpath[idx+1:]
+	}
+	path, err := ygot.StringToStructuredPath(xpath)
+	if err != nil {
+		return nil, fmt.Errorf("gnmiext: failed to convert xpath '%s' to path: %w", xpath, err)
+	}
+	path.Origin = model
+	return path, nil
+}

--- a/internal/provider/cisco/gnmiext/v2/client_test.go
+++ b/internal/provider/cisco/gnmiext/v2/client_test.go
@@ -1,0 +1,1460 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package gnmiext
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/utils/ptr"
+)
+
+func TestClient_New(t *testing.T) {
+	tests := []struct {
+		name    string
+		conn    grpc.ClientConnInterface
+		wantErr bool
+	}{
+		{
+			name: "Capabilities error",
+			conn: &MockClientConn{
+				CapabilitiesFunc: func(ctx context.Context, req *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
+					return nil, errors.New("test error")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Unsupported Encoding",
+			conn: &MockClientConn{
+				CapabilitiesFunc: func(ctx context.Context, req *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
+					return &gpb.CapabilityResponse{
+						SupportedEncodings: []gpb.Encoding{gpb.Encoding_ASCII},
+					}, nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "JSON Encoding",
+			conn: &MockClientConn{
+				CapabilitiesFunc: func(ctx context.Context, req *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
+					return &gpb.CapabilityResponse{
+						SupportedEncodings: []gpb.Encoding{gpb.Encoding_JSON},
+					}, nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "JSON_IETF Encoding",
+			conn: &MockClientConn{
+				CapabilitiesFunc: func(ctx context.Context, req *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
+					return &gpb.CapabilityResponse{
+						SupportedEncodings: []gpb.Encoding{gpb.Encoding_JSON_IETF},
+					}, nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Supported Models",
+			conn: &MockClientConn{
+				CapabilitiesFunc: func(ctx context.Context, req *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
+					return &gpb.CapabilityResponse{
+						SupportedModels: []*gpb.ModelData{
+							{
+								Name:         "openconfig-system",
+								Organization: "OpenConfig working group",
+								Version:      "0.17.0",
+							},
+						},
+						SupportedEncodings: []gpb.Encoding{gpb.Encoding_JSON, gpb.Encoding_JSON_IETF},
+					}, nil
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := New(t.Context(), test.conn)
+			if (err != nil) != test.wantErr {
+				t.Errorf("NewClient() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if got == nil && !test.wantErr {
+				t.Errorf("NewClient() = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestClient_GetConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		conn    grpc.ClientConnInterface
+		conf    []Configurable
+		wantErr bool
+	}{
+		{
+			name: "Single",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: false,
+		},
+		{
+			name: "Multiple",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 2 {
+						t.Errorf("Expected two paths in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname), new(Hostname)},
+			wantErr: false,
+		},
+		{
+			name:    "Empty list",
+			conf:    []Configurable{},
+			wantErr: false,
+		},
+		{
+			name: "Get RPC Error",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return nil, errors.New("get rpc failed")
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+		{
+			name: "Empty Notifications",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+		{
+			name: "Empty Updates",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+		{
+			name: "Empty Value",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(""),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+		{
+			name: "Multiple Updates",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+		{
+			name: "Unexpected Encoding",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonIetfVal{
+												JsonIetfVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				encoding: gpb.Encoding_JSON,
+				gnmi:     gpb.NewGNMIClient(test.conn),
+			}
+
+			err := client.GetConfig(t.Context(), test.conf...)
+			if (err != nil) != test.wantErr {
+				t.Errorf("GetConfig() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestClient_GetState(t *testing.T) {
+	tests := []struct {
+		name    string
+		conn    grpc.ClientConnInterface
+		conf    []Configurable
+		wantErr bool
+	}{
+		{
+			name: "Single",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_STATE {
+						t.Errorf("Expected GetRequest_STATE, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "state"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "state"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(HostnameState)},
+			wantErr: false,
+		},
+		{
+			name:    "Empty list",
+			conf:    []Configurable{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				encoding: gpb.Encoding_JSON,
+				gnmi:     gpb.NewGNMIClient(test.conn),
+			}
+
+			err := client.GetState(t.Context(), test.conf...)
+			if (err != nil) != test.wantErr {
+				t.Errorf("GetState() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestClient_Update(t *testing.T) {
+	tests := []struct {
+		name    string
+		conn    grpc.ClientConnInterface
+		conf    []Configurable
+		wantErr bool
+	}{
+		{
+			name: "Replace",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+				SetFunc: func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+					if len(req.Replace) != 1 {
+						t.Errorf("Expected single Replace operation, got %d", len(req.Replace))
+					}
+					if len(req.Update) != 0 {
+						t.Errorf("Expected no Update operations, got %d", len(req.Update))
+					}
+					if len(req.Delete) != 0 {
+						t.Errorf("Expected no Delete operations, got %d", len(req.Delete))
+					}
+					if !proto.Equal(req.Replace[0], &gpb.Update{
+						Path: &gpb.Path{
+							Origin: "openconfig",
+							Elem: []*gpb.PathElem{
+								{Name: "system"},
+								{Name: "config"},
+								{Name: "hostname"},
+							},
+						},
+						Val: &gpb.TypedValue{
+							Value: &gpb.TypedValue_JsonVal{
+								JsonVal: []byte(`"new-hostname"`),
+							},
+						},
+					}) {
+						t.Errorf("Unexpected Replace operation: %v", req.Replace[0])
+					}
+					return &gpb.SetResponse{
+						Timestamp: time.Now().UnixNano(),
+					}, nil
+				},
+			},
+			conf:    []Configurable{ptr.To(Hostname("new-hostname"))},
+			wantErr: false,
+		},
+		{
+			name: "Unchanged",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{ptr.To(Hostname("test-hostname"))},
+			wantErr: false,
+		},
+		{
+			name: "Get RPC Error",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return nil, errors.New("get rpc failed")
+				},
+			},
+			conf:    []Configurable{ptr.To(Hostname("test-hostname"))},
+			wantErr: true,
+		},
+		{
+			name: "Set RPC Error",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON {
+						t.Errorf("Expected Encoding_JSON, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonVal{
+												JsonVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+				SetFunc: func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+					if len(req.Replace) != 1 {
+						t.Errorf("Expected single Replace operation, got %d", len(req.Replace))
+					}
+					if len(req.Update) != 0 {
+						t.Errorf("Expected no Update operations, got %d", len(req.Update))
+					}
+					if len(req.Delete) != 0 {
+						t.Errorf("Expected no Delete operations, got %d", len(req.Delete))
+					}
+					if !proto.Equal(req.Replace[0], &gpb.Update{
+						Path: &gpb.Path{
+							Origin: "openconfig",
+							Elem: []*gpb.PathElem{
+								{Name: "system"},
+								{Name: "config"},
+								{Name: "hostname"},
+							},
+						},
+						Val: &gpb.TypedValue{
+							Value: &gpb.TypedValue_JsonVal{
+								JsonVal: []byte(`"new-hostname"`),
+							},
+						},
+					}) {
+						t.Errorf("Unexpected Replace operation: %v", req.Replace[0])
+					}
+					return nil, errors.New("set rpc failed")
+				},
+			},
+			conf:    []Configurable{ptr.To(Hostname("new-hostname"))},
+			wantErr: true,
+		},
+		{
+			name:    "Empty list",
+			conf:    []Configurable{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				encoding: gpb.Encoding_JSON,
+				gnmi:     gpb.NewGNMIClient(test.conn),
+			}
+
+			err := client.Update(t.Context(), test.conf...)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Update() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestClient_Patch(t *testing.T) {
+	tests := []struct {
+		name    string
+		conn    grpc.ClientConnInterface
+		conf    []Configurable
+		wantErr bool
+	}{
+		{
+			name: "Merge",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON_IETF {
+						t.Errorf("Expected Encoding_JSON_IETF, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonIetfVal{
+												JsonIetfVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+				SetFunc: func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+					if len(req.Update) != 1 {
+						t.Errorf("Expected single Update operation, got %d", len(req.Update))
+					}
+					if len(req.Replace) != 0 {
+						t.Errorf("Expected no Replace operations, got %d", len(req.Replace))
+					}
+					if len(req.Delete) != 0 {
+						t.Errorf("Expected no Delete operations, got %d", len(req.Delete))
+					}
+					if !proto.Equal(req.Update[0], &gpb.Update{
+						Path: &gpb.Path{
+							Origin: "openconfig",
+							Elem: []*gpb.PathElem{
+								{Name: "system"},
+								{Name: "config"},
+								{Name: "hostname"},
+							},
+						},
+						Val: &gpb.TypedValue{
+							Value: &gpb.TypedValue_JsonIetfVal{
+								JsonIetfVal: []byte(`"new-hostname"`),
+							},
+						},
+					}) {
+						t.Errorf("Unexpected Update operation: %v", req.Replace[0])
+					}
+					return &gpb.SetResponse{
+						Timestamp: time.Now().UnixNano(),
+					}, nil
+				},
+			},
+			conf:    []Configurable{ptr.To(Hostname("new-hostname"))},
+			wantErr: false,
+		},
+		{
+			name: "Unchanged",
+			conn: &MockClientConn{
+				GetFunc: func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+					if req.Type != gpb.GetRequest_CONFIG {
+						t.Errorf("Expected GetRequest_CONFIG, got %v", req.Type)
+					}
+					if req.Encoding != gpb.Encoding_JSON_IETF {
+						t.Errorf("Expected Encoding_JSON_IETF, got %v", req.Encoding)
+					}
+					if len(req.Path) != 1 {
+						t.Errorf("Expected single path in GetRequest, got %d", len(req.Path))
+					}
+					if !proto.Equal(req.Path[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected path in GetRequest: %v", req.Path[0])
+					}
+					return &gpb.GetResponse{
+						Notification: []*gpb.Notification{
+							{
+								Update: []*gpb.Update{
+									{
+										Path: &gpb.Path{
+											Origin: "openconfig",
+											Elem: []*gpb.PathElem{
+												{Name: "system"},
+												{Name: "config"},
+												{Name: "hostname"},
+											},
+										},
+										Val: &gpb.TypedValue{
+											Value: &gpb.TypedValue_JsonIetfVal{
+												JsonIetfVal: []byte(`"test-hostname"`),
+											},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			conf:    []Configurable{ptr.To(Hostname("test-hostname"))},
+			wantErr: false,
+		},
+		{
+			name:    "Empty list",
+			conf:    []Configurable{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				encoding: gpb.Encoding_JSON_IETF,
+				gnmi:     gpb.NewGNMIClient(test.conn),
+			}
+
+			err := client.Patch(t.Context(), test.conf...)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Update() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestClient_Delete(t *testing.T) {
+	tests := []struct {
+		name    string
+		conn    grpc.ClientConnInterface
+		conf    []Configurable
+		wantErr bool
+	}{
+		{
+			name: "Regular Delete",
+			conn: &MockClientConn{
+				SetFunc: func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+					if len(req.Delete) == 0 {
+						t.Error("Expected Delete operation for regular Configurable")
+					}
+					if len(req.Replace) > 0 {
+						t.Error("Expected no Replace operations for regular Configurable")
+					}
+					if !proto.Equal(req.Delete[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected Delete operation: %v", req.Delete[0])
+					}
+					return &gpb.SetResponse{
+						Timestamp: time.Now().UnixNano(),
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: false,
+		},
+		{
+			name: "Defaultable Replace",
+			conn: &MockClientConn{
+				SetFunc: func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+					if len(req.Replace) == 0 {
+						t.Error("Expected Replace operation for Defaultable")
+					}
+					if len(req.Delete) > 0 {
+						t.Error("Expected no Delete operations for Defaultable")
+					}
+					if !proto.Equal(req.Replace[0], &gpb.Update{
+						Path: &gpb.Path{
+							Origin: "openconfig",
+							Elem: []*gpb.PathElem{
+								{Name: "system"},
+								{Name: "config"},
+								{Name: "hostname"},
+							},
+						},
+						Val: &gpb.TypedValue{
+							Value: &gpb.TypedValue_JsonVal{
+								JsonVal: []byte(`"default-hostname"`),
+							},
+						},
+					}) {
+						t.Errorf("Unexpected Replace operation: %v", req.Replace[0])
+					}
+					return &gpb.SetResponse{
+						Timestamp: time.Now().UnixNano(),
+					}, nil
+				},
+			},
+			conf:    []Configurable{new(DefaultableHostname)},
+			wantErr: false,
+		},
+		{
+			name: "Set RPC Error",
+			conn: &MockClientConn{
+				SetFunc: func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+					if len(req.Delete) == 0 {
+						t.Error("Expected Delete operation for regular Configurable")
+					}
+					if len(req.Replace) > 0 {
+						t.Error("Expected no Replace operations for regular Configurable")
+					}
+					if !proto.Equal(req.Delete[0], &gpb.Path{
+						Origin: "openconfig",
+						Elem: []*gpb.PathElem{
+							{Name: "system"},
+							{Name: "config"},
+							{Name: "hostname"},
+						},
+					}) {
+						t.Errorf("Unexpected Delete operation: %v", req.Delete[0])
+					}
+					return nil, errors.New("set rpc failed")
+				},
+			},
+			conf:    []Configurable{new(Hostname)},
+			wantErr: true,
+		},
+		{
+			name:    "Empty list",
+			conf:    []Configurable{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				encoding: gpb.Encoding_JSON,
+				gnmi:     gpb.NewGNMIClient(test.conn),
+			}
+
+			err := client.Delete(context.Background(), test.conf...)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestStringToStructuredPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		xpath   string
+		want    *gpb.Path
+		wantErr bool
+	}{
+		{
+			name:  "Simple",
+			xpath: "System/name",
+			want: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{Name: "System"},
+					{Name: "name"},
+				},
+			},
+		},
+		{
+			name:  "Model",
+			xpath: "openconfig:system/config/hostname",
+			want: &gpb.Path{
+				Origin: "openconfig",
+				Elem: []*gpb.PathElem{
+					{Name: "system"},
+					{Name: "config"},
+					{Name: "hostname"},
+				},
+			},
+		},
+		{
+			name:    "Invalid",
+			xpath:   "[",
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := StringToStructuredPath(test.xpath)
+			if (err != nil) != test.wantErr {
+				t.Errorf("StringToStructuredPath() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !proto.Equal(got, test.want) {
+				t.Errorf("StringToStructuredPath() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestClient_Marshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "JSON string",
+			value:   "test-hostname",
+			want:    []byte(`"test-hostname"`),
+			wantErr: false,
+		},
+		{
+			name: "JSON struct",
+			value: struct {
+				Name string `json:"name"`
+			}{Name: "test"},
+			want:    []byte(`{"name":"test"}`),
+			wantErr: false,
+		},
+		{
+			name:    "Custom Marshaller",
+			value:   &Interface{Name: "eth1/1"},
+			want:    []byte(`{"config":{"name":"eth1/1"},"name":"eth1/1"}`),
+			wantErr: false,
+		},
+		{
+			name:    "Error",
+			value:   func() {},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				capabilities: &Capabilities{
+					SupportedModels: []Model{
+						{Name: "openconfig-interfaces", Organization: "OpenConfig working group", Version: "2.5.0"},
+					},
+				},
+			}
+
+			got, err := client.Marshal(test.value)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Marshal() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !test.wantErr && string(got) != string(test.want) {
+				t.Errorf("Marshal() = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestClient_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    any
+		value   []byte
+		wantErr bool
+	}{
+		{
+			name:    "JSON string",
+			want:    "test-hostname",
+			value:   []byte(`"test-hostname"`),
+			wantErr: false,
+		},
+		{
+			name: "JSON struct",
+			want: struct {
+				Name string `json:"name"`
+			}{Name: "test"},
+			value:   []byte(`{"name":"test"}`),
+			wantErr: false,
+		},
+		{
+			name:    "Custom Marshaller",
+			want:    &Interface{Name: "eth1/1"},
+			value:   []byte(`{"config":{"name":"eth1/1"},"name":"eth1/1"}`),
+			wantErr: false,
+		},
+		{
+			name:    "Error",
+			want:    "",
+			value:   []byte(`{}`),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{
+				capabilities: &Capabilities{
+					SupportedModels: []Model{
+						{Name: "openconfig-interfaces", Organization: "OpenConfig working group", Version: "2.5.0"},
+					},
+				},
+			}
+
+			rt := reflect.TypeOf(test.want)
+			for rt.Kind() == reflect.Pointer {
+				rt = rt.Elem()
+			}
+
+			got := reflect.New(rt).Interface()
+			if err := client.Unmarshal(test.value, got); (err != nil) != test.wantErr {
+				t.Errorf("Marshal() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+
+			if !test.wantErr {
+				rv := reflect.ValueOf(test.want)
+				if rv.Kind() != reflect.Pointer {
+					p := reflect.New(rv.Type())
+					p.Elem().Set(rv)
+					rv = p
+				}
+
+				want := rv.Interface()
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("Unmarshal() = %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+// -- Config --
+
+type Hostname string
+
+var _ Configurable = (*Hostname)(nil)
+
+func (*Hostname) XPath() string { return "openconfig:system/config/hostname" }
+
+// -- State --
+
+type HostnameState string
+
+var _ Configurable = (*HostnameState)(nil)
+
+func (*HostnameState) XPath() string { return "openconfig:system/state/hostname" }
+
+// -- Defaultable --
+
+type DefaultableHostname string
+
+var (
+	_ Configurable = (*DefaultableHostname)(nil)
+	_ Defaultable  = (*DefaultableHostname)(nil)
+)
+
+func (*DefaultableHostname) XPath() string { return "openconfig:system/config/hostname" }
+func (h *DefaultableHostname) Default()    { *h = "default-hostname" }
+
+var _ grpc.ClientConnInterface = (*MockClientConn)(nil)
+
+// MockClientConn provides a mock implementation of [grpc.ClientConnInterface] for testing gNMI clients.
+// It includes configurable mock responses for gNMI RPC methods.
+type MockClientConn struct {
+	// CapabilitiesFunc allows mocking of the Capabilities RPC response.
+	CapabilitiesFunc func(ctx context.Context, req *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error)
+
+	// GetFunc allows mocking of the Get RPC response.
+	GetFunc func(ctx context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error)
+
+	// SetFunc allows mocking of the Set RPC response.
+	SetFunc func(ctx context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error)
+}
+
+func (m *MockClientConn) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
+	switch method {
+	case "/gnmi.gNMI/Capabilities":
+		if m.CapabilitiesFunc == nil {
+			return status.Error(codes.Unimplemented, "Capabilities RPC not mocked")
+		}
+		req := args.(*gpb.CapabilityRequest)
+		res, err := m.CapabilitiesFunc(ctx, req)
+		if err != nil {
+			return err
+		}
+		proto.Merge(reply.(*gpb.CapabilityResponse), res)
+		return nil
+
+	case "/gnmi.gNMI/Get":
+		if m.GetFunc == nil {
+			return status.Error(codes.Unimplemented, "Get RPC not mocked")
+		}
+		req := args.(*gpb.GetRequest)
+		res, err := m.GetFunc(ctx, req)
+		if err != nil {
+			return err
+		}
+		proto.Merge(reply.(*gpb.GetResponse), res)
+		return nil
+
+	case "/gnmi.gNMI/Set":
+		if m.SetFunc == nil {
+			return status.Error(codes.Unimplemented, "Set RPC not mocked")
+		}
+		req := args.(*gpb.SetRequest)
+		res, err := m.SetFunc(ctx, req)
+		if err != nil {
+			return err
+		}
+		proto.Merge(reply.(*gpb.SetResponse), res)
+		return nil
+
+	default:
+		return status.Errorf(codes.Unimplemented, "method %s not mocked", method)
+	}
+}
+
+func (m *MockClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, status.Errorf(codes.Unimplemented, "streaming method %s not mocked", method)
+}
+
+// Interface implements the [Marshaler] interface.
+// It marshals to different YANG models based on the client's capabilities.
+type Interface struct {
+	Name string
+}
+
+var _ Marshaler = (*Interface)(nil)
+
+func (i *Interface) MarshalYANG(caps *Capabilities) ([]byte, error) {
+	if slices.ContainsFunc(caps.SupportedModels, func(m Model) bool {
+		return m.Name == "openconfig-interfaces"
+	}) {
+		// Openconfig Interfaces model
+		return fmt.Appendf(nil, `{"config":{"name":"%s"},"name":"%s"}`, i.Name, i.Name), nil
+	}
+	// Cisco NX-OS Device model
+	return fmt.Appendf(nil, `{"id":"%s"}`, i.Name), nil
+}
+
+func (i *Interface) UnmarshalYANG(caps *Capabilities, data []byte) error {
+	if slices.ContainsFunc(caps.SupportedModels, func(m Model) bool {
+		return m.Name == "openconfig-interfaces"
+	}) {
+		var res struct {
+			Name   string `json:"name"`
+			Config struct {
+				Name string `json:"name"`
+			} `json:"config"`
+		}
+		if err := json.Unmarshal(data, &res); err != nil {
+			return err
+		}
+		i.Name = res.Config.Name
+		return nil
+	}
+	var res struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+	i.Name = res.ID
+	return nil
+}

--- a/internal/provider/cisco/gnmiext/v2/doc.go
+++ b/internal/provider/cisco/gnmiext/v2/doc.go
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gnmiext provides a gNMI client with device capability awareness
+// and configuration management utilities.
+package gnmiext

--- a/internal/provider/cisco/gnmiext/v2/empty.go
+++ b/internal/provider/cisco/gnmiext/v2/empty.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package gnmiext
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// NOTE: Use json.Marshaler and json.Unmarshaler interfaces instead of the
+// Marshaler interface for types that only need to customize their JSON
+// representation and do not need to consider the capabilities of the target
+// device. The Empty type is defined in RFC 7951 and has a specific JSON
+// representation that is consistent across all devices and versions.
+var (
+	_ json.Marshaler   = (*Empty)(nil)
+	_ json.Unmarshaler = (*Empty)(nil)
+)
+
+// Empty represents the built-in "empty" type as defined in RFC 7951.
+// It differentiates between an existing empty value ([null]) and a
+// non-existing value (null).
+//
+// RFC 7951: https://datatracker.ietf.org/doc/html/rfc7951#section-6.9
+type Empty bool
+
+// MarshalJSON implements json.Marshaler for Empty.
+func (e Empty) MarshalJSON() ([]byte, error) {
+	if !e {
+		return []byte("null"), nil
+	}
+	return []byte("[null]"), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Empty.
+func (e *Empty) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		*e = false
+		return nil
+	}
+	if string(b) != "[null]" {
+		return fmt.Errorf("gnmiext: invalid empty value: %s", string(b))
+	}
+	*e = true
+	return nil
+}

--- a/internal/provider/cisco/gnmiext/v2/empty_test.go
+++ b/internal/provider/cisco/gnmiext/v2/empty_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package gnmiext
+
+import "testing"
+
+func TestEmpty_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		empty Empty
+		want  string
+	}{
+		{
+			name:  "valid empty (exists)",
+			empty: Empty(true),
+			want:  "[null]",
+		},
+		{
+			name:  "invalid empty (does not exist)",
+			empty: Empty(false),
+			want:  "null",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.empty.MarshalJSON()
+			if err != nil {
+				t.Errorf("MarshalJSON() error = %v", err)
+				return
+			}
+			if string(got) != test.want {
+				t.Errorf("MarshalJSON() = %s, want %s", string(got), test.want)
+			}
+		})
+	}
+}
+
+func TestEmpty_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Empty
+		wantErr bool
+	}{
+		{
+			name:    "valid [null] (exists)",
+			input:   "[null]",
+			want:    Empty(true),
+			wantErr: false,
+		},
+		{
+			name:    "valid null (does not exist)",
+			input:   "null",
+			want:    Empty(false),
+			wantErr: false,
+		},
+		{
+			name:    "empty input (does not exist)",
+			input:   "",
+			want:    Empty(false),
+			wantErr: false,
+		},
+		{
+			name:    "invalid json array",
+			input:   "[1]",
+			want:    Empty(false),
+			wantErr: true,
+		},
+		{
+			name:    "invalid json string",
+			input:   `"test"`,
+			want:    Empty(false),
+			wantErr: true,
+		},
+		{
+			name:    "invalid json object",
+			input:   "{}",
+			want:    Empty(false),
+			wantErr: true,
+		},
+		{
+			name:    "invalid json number",
+			input:   "42",
+			want:    Empty(false),
+			wantErr: true,
+		},
+		{
+			name:    "invalid array with multiple elements",
+			input:   "[null, null]",
+			want:    Empty(false),
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var empty Empty
+			err := empty.UnmarshalJSON([]byte(test.input))
+			if (err != nil) != test.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !test.wantErr && empty != test.want {
+				t.Errorf("UnmarshalJSON() got = %+v, want %+v", empty, test.want)
+			}
+		})
+	}
+}

--- a/internal/provider/cisco/nxos/version.go
+++ b/internal/provider/cisco/nxos/version.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package nxos
+
+import "github.com/ironcore-dev/network-operator/internal/provider/cisco/gnmiext/v2"
+
+// Version represents the operating system version of the target device.
+type Version string
+
+const (
+	VersionUnknown  Version = "Unknown"
+	VersionNX10_4_3 Version = "10.4(3)"
+	VersionNX10_4_4 Version = "10.4(4)"
+	VersionNX10_4_5 Version = "10.4(5)"
+	VersionNX10_4_6 Version = "10.4(6)"
+	VersionNX10_5_1 Version = "10.5(1)"
+	VersionNX10_5_2 Version = "10.5(2)"
+	VersionNX10_5_3 Version = "10.5(3)"
+	VersionNX10_6_1 Version = "10.6(1)"
+)
+
+// nxosVersions maps the revision date of the Cisco-NX-OS-device yang model to the corresponding [Version].
+// It is used to determine the version of the target device based on the capabilities returned by the device.
+var nxosVersions = map[string]Version{
+	"2024-03-26": VersionNX10_4_3,
+	"2024-10-17": VersionNX10_4_4,
+	"2025-03-01": VersionNX10_4_5,
+	"2025-08-30": VersionNX10_4_6,
+	"2024-07-25": VersionNX10_5_1,
+	"2024-11-26": VersionNX10_5_2,
+	"2025-04-23": VersionNX10_5_3,
+	"2025-08-12": VersionNX10_6_1,
+}
+
+// NXVersion returns the NX-OS operating system version of the target device based on the supported models.
+// If the version cannot be determined, [VersionUnknown] is returned.
+func NXVersion(c *gnmiext.Capabilities) Version {
+	version := VersionUnknown
+	for _, m := range c.SupportedModels {
+		if m.Name == "Cisco-NX-OS-device" && m.Organization == "Cisco Systems, Inc." {
+			if v, ok := nxosVersions[m.Version]; ok {
+				version = v
+			}
+			break
+		}
+	}
+	return version
+}


### PR DESCRIPTION
The newly added `gnmiext/v2` package builds on the existing `gnmiext` package previously maintained under the Cisco NX-OS provider.

Most notably it adds the following features:
- No dependency on a specific YANG model or openconfig/ygot code generation (lays foundation for moving away from ygot, see #9)
- Support multiple target devices and platforms at the same time, configuration items override their marshaling/unmarshaling based on the target capabilities
- Support for JSON_IETF encoded payloads, used e.g. on Cisco IOS-XR
- Allow multple updates to be carried out in a single gNMI request
- Support for specifying the target YANG models via a origin prefix in the xpaths
- Improved diff functionality, checking for equality in Go types, which unmarshal only a subset of fields, allowing to skip unrelated fields