### PR TITLE
Make SecretRef in Device Immutable after creation

### DIFF
--- a/api/v1alpha1/device_types.go
+++ b/api/v1alpha1/device_types.go
@@ -20,6 +20,8 @@ type DeviceSpec struct {
 	Bootstrap *Bootstrap `json:"bootstrap,omitempty"`
 }
 
+// Endpoint contains the connection information for the device.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.secretRef) || has(self.secretRef)", message="SecretRef is required once set"
 type Endpoint struct {
 	// Address is the management address of the device provided as <ip:port>.
 	// +kubebuilder:validation:Pattern=`^(\d{1,3}\.){3}\d{1,3}:\d{1,5}$`
@@ -28,7 +30,9 @@ type Endpoint struct {
 
 	// SecretRef is name of the authentication secret for the device containing the username and password.
 	// The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
+	// Immutable after creation.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecretRef is immutable"
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 
 	// Transport credentials for grpc connection to the switch.

--- a/charts/network-operator/templates/crd/networking.cloud.sap_devices.yaml
+++ b/charts/network-operator/templates/crd/networking.cloud.sap_devices.yaml
@@ -141,6 +141,7 @@ spec:
                     description: |-
                       SecretRef is name of the authentication secret for the device containing the username and password.
                       The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
+                      Immutable after creation.
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -152,6 +153,9 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: SecretRef is immutable
+                      rule: self == oldSelf
                   tls:
                     description: Transport credentials for grpc connection to the
                       switch.
@@ -209,6 +213,9 @@ spec:
                 required:
                 - address
                 type: object
+                x-kubernetes-validations:
+                - message: SecretRef is required once set
+                  rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
             required:
             - endpoint
             type: object

--- a/config/crd/bases/networking.cloud.sap_devices.yaml
+++ b/config/crd/bases/networking.cloud.sap_devices.yaml
@@ -135,6 +135,7 @@ spec:
                     description: |-
                       SecretRef is name of the authentication secret for the device containing the username and password.
                       The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
+                      Immutable after creation.
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -146,6 +147,9 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: SecretRef is immutable
+                      rule: self == oldSelf
                   tls:
                     description: Transport credentials for grpc connection to the
                       switch.
@@ -203,6 +207,9 @@ spec:
                 required:
                 - address
                 type: object
+                x-kubernetes-validations:
+                - message: SecretRef is required once set
+                  rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
             required:
             - endpoint
             type: object

--- a/internal/controller/device_controller.go
+++ b/internal/controller/device_controller.go
@@ -250,7 +250,7 @@ func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Devic
 
 	if ref := device.Spec.Endpoint.SecretRef; ref != nil {
 		secret := new(corev1.Secret)
-		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, secret); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: device.Namespace}, secret); err != nil {
 			log.Error(err, "Failed to get endpoint secret for device")
 			return err
 		}
@@ -284,7 +284,7 @@ func (r *DeviceReconciler) finalize(ctx context.Context, device *v1alpha1.Device
 
 	if ref := device.Spec.Endpoint.SecretRef; ref != nil {
 		secret := new(corev1.Secret)
-		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, secret); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: device.Namespace}, secret); err != nil {
 			log.Error(err, "Failed to get endpoint secret for device")
 			return err
 		}


### PR DESCRIPTION
The DeviceReconciler will add a finalizer to the referenced secret to make sure that it's not deleted while still used from the device. Additionally, it's now also validated that the secret reference, once set on the device, can not be changed. This prevents the user from changing the secretRef on a device, leaving the old referenced secret with the finalizer.