### PR TITLE
Remove finalizer for device credential secret

### DIFF
--- a/api/v1alpha1/device_types.go
+++ b/api/v1alpha1/device_types.go
@@ -30,9 +30,7 @@ type Endpoint struct {
 
 	// SecretRef is name of the authentication secret for the device containing the username and password.
 	// The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
-	// Immutable after creation.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SecretRef is immutable"
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 
 	// Transport credentials for grpc connection to the switch.

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -67,7 +67,4 @@ const (
 
 	// ProvisioningReason indicates that the resource is being provisioned.
 	ProvisioningReason = "Provisioning"
-
-	// AllResourcesReadyReason indicates that all resources owned by the resource are ready.
-	AllResourcesReadyReason = "AllResourcesReady"
 )

--- a/config/crd/bases/networking.cloud.sap_devices.yaml
+++ b/config/crd/bases/networking.cloud.sap_devices.yaml
@@ -151,7 +151,6 @@ spec:
                     description: |-
                       SecretRef is name of the authentication secret for the device containing the username and password.
                       The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
-                      Immutable after creation.
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -163,9 +162,6 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                    x-kubernetes-validations:
-                    - message: SecretRef is immutable
-                      rule: self == oldSelf
                   tls:
                     description: Transport credentials for grpc connection to the
                       switch.


### PR DESCRIPTION
Previously the `Device` reconciler added a finalizer on the credentials secret to it's deletion. This had a number of undesired side-effects.
1. This meant that the secret had to be immutable, as changing the secret reference on the device would leave previously referenced secrets with a finalizer, preventing their deletion.
2. This restriction and handling felt unlogical and inconsistent, as we didn't handle other secret references, such as the references used to refer to the tls credentials, in the same way.

With this PR we are removing the logic of adding finalizer logic on the referenced credentials secret. If a referenced secret gets deleted, while it's still being referred to by a `Device` resource, we let the reconcilation fail and return an error. It will then be an administrators responsibility to ensure that the referenced resource exists, such that the `Device` (and child resources) can successfully be reconciled. This is also inline with the overall consensus of handling such situations within the wider ecosystem and what is done in other projects.