### PR TITLE
Remove `provider.Result` Response type from provider integration

### DIFF
--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -205,7 +205,7 @@ func main() {
 	case "create":
 		switch resource := obj.(type) {
 		case *v1alpha1.Interface:
-			_, err = ip.EnsureInterface(ctx, &provider.InterfaceRequest{
+			err = ip.EnsureInterface(ctx, &provider.InterfaceRequest{
 				Interface:      resource,
 				ProviderConfig: nil,
 			})

--- a/internal/controller/acl_controller.go
+++ b/internal/controller/acl_controller.go
@@ -161,13 +161,12 @@ func (r *AccessControlListReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -198,7 +197,7 @@ type aclScope struct {
 	Provider       provider.ACLProvider
 }
 
-func (r *AccessControlListReconciler) reconcile(ctx context.Context, s *aclScope) (_ ctrl.Result, reterr error) {
+func (r *AccessControlListReconciler) reconcile(ctx context.Context, s *aclScope) (reterr error) {
 	if s.ACL.Labels == nil {
 		s.ACL.Labels = make(map[string]string)
 	}
@@ -208,12 +207,12 @@ func (r *AccessControlListReconciler) reconcile(ctx context.Context, s *aclScope
 	// Ensure the AccessControlList is owned by the Device.
 	if !controllerutil.HasControllerReference(s.ACL) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.ACL, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -222,7 +221,7 @@ func (r *AccessControlListReconciler) reconcile(ctx context.Context, s *aclScope
 	}()
 
 	// Ensure the AccessControlList is realized on the provider.
-	res, err := s.Provider.EnsureACL(ctx, &provider.EnsureACLRequest{
+	err := s.Provider.EnsureACL(ctx, &provider.EnsureACLRequest{
 		ACL:            s.ACL,
 		ProviderConfig: s.ProviderConfig,
 	})
@@ -232,11 +231,7 @@ func (r *AccessControlListReconciler) reconcile(ctx context.Context, s *aclScope
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.ACL, cond)
 
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{RequeueAfter: res.RequeueAfter}, nil
+	return err
 }
 
 func (r *AccessControlListReconciler) finalize(ctx context.Context, s *aclScope) (reterr error) {

--- a/internal/controller/dns_controller.go
+++ b/internal/controller/dns_controller.go
@@ -161,13 +161,12 @@ func (r *DNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -198,7 +197,7 @@ type dnsScope struct {
 	Provider       provider.DNSProvider
 }
 
-func (r *DNSReconciler) reconcile(ctx context.Context, s *dnsScope) (_ ctrl.Result, reterr error) {
+func (r *DNSReconciler) reconcile(ctx context.Context, s *dnsScope) (reterr error) {
 	if s.DNS.Labels == nil {
 		s.DNS.Labels = make(map[string]string)
 	}
@@ -208,12 +207,12 @@ func (r *DNSReconciler) reconcile(ctx context.Context, s *dnsScope) (_ ctrl.Resu
 	// Ensure the DNS is owned by the Device.
 	if !controllerutil.HasControllerReference(s.DNS) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.DNS, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -222,7 +221,7 @@ func (r *DNSReconciler) reconcile(ctx context.Context, s *dnsScope) (_ ctrl.Resu
 	}()
 
 	// Ensure the DNS is realized on the provider.
-	res, err := s.Provider.EnsureDNS(ctx, &provider.EnsureDNSRequest{
+	err := s.Provider.EnsureDNS(ctx, &provider.EnsureDNSRequest{
 		DNS:            s.DNS,
 		ProviderConfig: s.ProviderConfig,
 	})
@@ -232,11 +231,7 @@ func (r *DNSReconciler) reconcile(ctx context.Context, s *dnsScope) (_ ctrl.Resu
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.DNS, cond)
 
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{RequeueAfter: res.RequeueAfter}, nil
+	return err
 }
 
 func (r *DNSReconciler) finalize(ctx context.Context, s *dnsScope) (reterr error) {

--- a/internal/controller/interface_controller.go
+++ b/internal/controller/interface_controller.go
@@ -236,7 +236,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 	}()
 
 	// Ensure the Interface is realized on the provider.
-	res, err := s.Provider.EnsureInterface(ctx, &provider.InterfaceRequest{
+	err := s.Provider.EnsureInterface(ctx, &provider.InterfaceRequest{
 		Interface:      s.Interface,
 		ProviderConfig: s.ProviderConfig,
 	})
@@ -246,10 +246,6 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-
-	if res.RequeueAfter > 0 {
-		return ctrl.Result{RequeueAfter: res.RequeueAfter}, nil
 	}
 
 	status, err := s.Provider.GetInterfaceStatus(ctx, &provider.InterfaceRequest{

--- a/internal/controller/isis_controller.go
+++ b/internal/controller/isis_controller.go
@@ -258,7 +258,7 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 	}()
 
 	// Ensure the ISIS is realized on the provider.
-	res, err := s.Provider.EnsureISIS(ctx, &provider.EnsureISISRequest{
+	err := s.Provider.EnsureISIS(ctx, &provider.EnsureISISRequest{
 		ISIS:           s.ISIS,
 		Interfaces:     interfaces,
 		ProviderConfig: s.ProviderConfig,
@@ -269,11 +269,7 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.ISIS, cond)
 
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{RequeueAfter: res.RequeueAfter}, nil
+	return ctrl.Result{}, err
 }
 
 func (r *ISISReconciler) finalize(ctx context.Context, s *isisScope) (reterr error) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -303,11 +303,11 @@ func (p *Provider) GetDeviceInfo(context.Context) (*provider.DeviceInfo, error) 
 	}, nil
 }
 
-func (p *Provider) EnsureInterface(ctx context.Context, req *provider.InterfaceRequest) (provider.Result, error) {
+func (p *Provider) EnsureInterface(ctx context.Context, req *provider.InterfaceRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.Ports[req.Interface.Name] = req.Interface
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteInterface(_ context.Context, req *provider.InterfaceRequest) error {
@@ -323,11 +323,11 @@ func (p *Provider) GetInterfaceStatus(context.Context, *provider.InterfaceReques
 	}, nil
 }
 
-func (p *Provider) EnsureBanner(_ context.Context, req *provider.BannerRequest) (provider.Result, error) {
+func (p *Provider) EnsureBanner(_ context.Context, req *provider.BannerRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.Banner = &req.Message
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteBanner(context.Context) error {
@@ -337,11 +337,11 @@ func (p *Provider) DeleteBanner(context.Context) error {
 	return nil
 }
 
-func (p *Provider) EnsureUser(_ context.Context, req *provider.EnsureUserRequest) (provider.Result, error) {
+func (p *Provider) EnsureUser(_ context.Context, req *provider.EnsureUserRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.User[req.Username] = struct{}{}
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteUser(_ context.Context, req *provider.DeleteUserRequest) error {
@@ -351,11 +351,11 @@ func (p *Provider) DeleteUser(_ context.Context, req *provider.DeleteUserRequest
 	return nil
 }
 
-func (p *Provider) EnsureDNS(_ context.Context, req *provider.EnsureDNSRequest) (provider.Result, error) {
+func (p *Provider) EnsureDNS(_ context.Context, req *provider.EnsureDNSRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.DNS = req.DNS
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteDNS(_ context.Context) error {
@@ -365,11 +365,11 @@ func (p *Provider) DeleteDNS(_ context.Context) error {
 	return nil
 }
 
-func (p *Provider) EnsureNTP(_ context.Context, req *provider.EnsureNTPRequest) (provider.Result, error) {
+func (p *Provider) EnsureNTP(_ context.Context, req *provider.EnsureNTPRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.NTP = req.NTP
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteNTP(context.Context) error {
@@ -379,11 +379,11 @@ func (p *Provider) DeleteNTP(context.Context) error {
 	return nil
 }
 
-func (p *Provider) EnsureACL(_ context.Context, req *provider.EnsureACLRequest) (provider.Result, error) {
+func (p *Provider) EnsureACL(_ context.Context, req *provider.EnsureACLRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.ACLs[req.ACL.Spec.Name] = struct{}{}
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteACL(_ context.Context, req *provider.DeleteACLRequest) error {
@@ -393,11 +393,11 @@ func (p *Provider) DeleteACL(_ context.Context, req *provider.DeleteACLRequest) 
 	return nil
 }
 
-func (p *Provider) EnsureCertificate(_ context.Context, req *provider.EnsureCertificateRequest) (provider.Result, error) {
+func (p *Provider) EnsureCertificate(_ context.Context, req *provider.EnsureCertificateRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.Certs[req.ID] = struct{}{}
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteCertificate(_ context.Context, req *provider.DeleteCertificateRequest) error {
@@ -407,11 +407,11 @@ func (p *Provider) DeleteCertificate(_ context.Context, req *provider.DeleteCert
 	return nil
 }
 
-func (p *Provider) EnsureSNMP(_ context.Context, req *provider.EnsureSNMPRequest) (provider.Result, error) {
+func (p *Provider) EnsureSNMP(_ context.Context, req *provider.EnsureSNMPRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.SNMP = req.SNMP
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteSNMP(_ context.Context, req *provider.DeleteSNMPRequest) error {
@@ -421,11 +421,11 @@ func (p *Provider) DeleteSNMP(_ context.Context, req *provider.DeleteSNMPRequest
 	return nil
 }
 
-func (p *Provider) EnsureSyslog(_ context.Context, req *provider.EnsureSyslogRequest) (provider.Result, error) {
+func (p *Provider) EnsureSyslog(_ context.Context, req *provider.EnsureSyslogRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.Syslog = req.Syslog
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteSyslog(_ context.Context) error {
@@ -435,11 +435,11 @@ func (p *Provider) DeleteSyslog(_ context.Context) error {
 	return nil
 }
 
-func (p *Provider) EnsureManagementAccess(_ context.Context, req *provider.EnsureManagementAccessRequest) (provider.Result, error) {
+func (p *Provider) EnsureManagementAccess(_ context.Context, req *provider.EnsureManagementAccessRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.Access = req.ManagementAccess
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteManagementAccess(context.Context) error {
@@ -449,11 +449,11 @@ func (p *Provider) DeleteManagementAccess(context.Context) error {
 	return nil
 }
 
-func (p *Provider) EnsureISIS(_ context.Context, req *provider.EnsureISISRequest) (provider.Result, error) {
+func (p *Provider) EnsureISIS(_ context.Context, req *provider.EnsureISISRequest) error {
 	p.Lock()
 	defer p.Unlock()
 	p.ISIS[req.ISIS.Spec.Instance] = struct{}{}
-	return provider.Result{}, nil
+	return nil
 }
 
 func (p *Provider) DeleteISIS(_ context.Context, req *provider.DeleteISISRequest) error {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"slices"
 	"sync"
-	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,12 +22,6 @@ import (
 type Provider interface {
 	Connect(context.Context, *deviceutil.Connection) error
 	Disconnect(context.Context, *deviceutil.Connection) error
-}
-
-type Result struct {
-	// RequeueAfter if greater than 0, indicates that the caller should retry the request after the specified duration.
-	// This is useful for situations where the operation is pending and needs to be retried later.
-	RequeueAfter time.Duration
 }
 
 type DeviceProvider interface {
@@ -69,7 +62,7 @@ type InterfaceProvider interface {
 	Provider
 
 	// EnsureInterface call is responsible for Interface realization on the provider.
-	EnsureInterface(context.Context, *InterfaceRequest) (Result, error)
+	EnsureInterface(context.Context, *InterfaceRequest) error
 	// DeleteInterface call is responsible for Interface deletion on the provider.
 	DeleteInterface(context.Context, *InterfaceRequest) error
 	// GetInterfaceStatus call is responsible for retrieving the current status of the Interface from the provider.
@@ -91,7 +84,7 @@ type BannerProvider interface {
 	Provider
 
 	// EnsureBanner call is responsible for Banner realization on the provider.
-	EnsureBanner(context.Context, *BannerRequest) (Result, error)
+	EnsureBanner(context.Context, *BannerRequest) error
 	// DeleteBanner call is responsible for Banner deletion on the provider.
 	DeleteBanner(context.Context) error
 }
@@ -106,7 +99,7 @@ type UserProvider interface {
 	Provider
 
 	// EnsureUser call is responsible for User realization on the provider.
-	EnsureUser(context.Context, *EnsureUserRequest) (Result, error)
+	EnsureUser(context.Context, *EnsureUserRequest) error
 	// DeleteUser call is responsible for User deletion on the provider.
 	DeleteUser(context.Context, *DeleteUserRequest) error
 }
@@ -129,7 +122,7 @@ type DNSProvider interface {
 	Provider
 
 	// EnsureDNS call is responsible for DNS realization on the provider.
-	EnsureDNS(context.Context, *EnsureDNSRequest) (Result, error)
+	EnsureDNS(context.Context, *EnsureDNSRequest) error
 	// DeleteDNS call is responsible for DNS deletion on the provider.
 	DeleteDNS(context.Context) error
 }
@@ -144,7 +137,7 @@ type NTPProvider interface {
 	Provider
 
 	// EnsureNTP call is responsible for NTP realization on the provider.
-	EnsureNTP(context.Context, *EnsureNTPRequest) (Result, error)
+	EnsureNTP(context.Context, *EnsureNTPRequest) error
 	// DeleteNTP call is responsible for NTP deletion on the provider.
 	DeleteNTP(context.Context) error
 }
@@ -159,7 +152,7 @@ type ACLProvider interface {
 	Provider
 
 	// EnsureACL call is responsible for AccessControlList realization on the provider.
-	EnsureACL(context.Context, *EnsureACLRequest) (Result, error)
+	EnsureACL(context.Context, *EnsureACLRequest) error
 	// DeleteACL call is responsible for AccessControlList deletion on the provider.
 	DeleteACL(context.Context, *DeleteACLRequest) error
 }
@@ -179,7 +172,7 @@ type CertificateProvider interface {
 	Provider
 
 	// EnsureCertificate call is responsible for Certificate realization on the provider.
-	EnsureCertificate(context.Context, *EnsureCertificateRequest) (Result, error)
+	EnsureCertificate(context.Context, *EnsureCertificateRequest) error
 	// DeleteCertificate call is responsible for Certificate deletion on the provider.
 	DeleteCertificate(context.Context, *DeleteCertificateRequest) error
 }
@@ -200,7 +193,7 @@ type SNMPProvider interface {
 	Provider
 
 	// EnsureSNMP call is responsible for SNMP realization on the provider.
-	EnsureSNMP(context.Context, *EnsureSNMPRequest) (Result, error)
+	EnsureSNMP(context.Context, *EnsureSNMPRequest) error
 	// DeleteSNMP call is responsible for SNMP deletion on the provider.
 	DeleteSNMP(context.Context, *DeleteSNMPRequest) error
 }
@@ -219,7 +212,7 @@ type SyslogProvider interface {
 	Provider
 
 	// EnsureSyslog call is responsible for Syslog realization on the provider.
-	EnsureSyslog(context.Context, *EnsureSyslogRequest) (Result, error)
+	EnsureSyslog(context.Context, *EnsureSyslogRequest) error
 	// DeleteSyslog call is responsible for Syslog deletion on the provider.
 	DeleteSyslog(context.Context) error
 }
@@ -234,7 +227,7 @@ type ManagementAccessProvider interface {
 	Provider
 
 	// EnsureManagementAccess call is responsible for ManagementAccess realization on the provider.
-	EnsureManagementAccess(context.Context, *EnsureManagementAccessRequest) (Result, error)
+	EnsureManagementAccess(context.Context, *EnsureManagementAccessRequest) error
 	// DeleteManagementAccess call is responsible for ManagementAccess deletion on the provider.
 	DeleteManagementAccess(context.Context) error
 }
@@ -249,7 +242,7 @@ type ISISProvider interface {
 	Provider
 
 	// EnsureISIS call is responsible for ISIS realization on the provider.
-	EnsureISIS(context.Context, *EnsureISISRequest) (Result, error)
+	EnsureISIS(context.Context, *EnsureISISRequest) error
 	// DeleteISIS call is responsible for ISIS deletion on the provider.
 	DeleteISIS(context.Context, *DeleteISISRequest) error
 }


### PR DESCRIPTION
This changes removes the `provider.Result` return argument historically used on the "EnsureX" provider methods. This type contained a `RequeueAfter` field that mimicked the equally named field of the `ctrl.Result` returned from the reconciliation loop. The reason for this changes is that we decided to keep the orchestration flow, incl. the decision for and how requeuing should be done up to the controller and should avoid leaking such kubernetes specific logic into the provider code.