### PR TITLE
fix: Tilt passes an IPv6 addr, which fails kubebuilder validation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -33,7 +33,7 @@ k8s_resource('network-operator-controller-manager', resource_deps=['controller-g
 # Sample resources with manual trigger mode
 def device_yaml():
     decoded = read_yaml_stream('./config/samples/v1alpha1_device.yaml')
-    ip = str(local("docker run --rm busybox:1.37.0 nslookup host.docker.internal 2>/dev/null | grep 'Address:' | tail -n 1 | awk '{print $2}' || echo ''", quiet=True)).rstrip('\n')
+    ip = str(local("docker run --rm busybox:1.37.0 nslookup -type=a host.docker.internal 2>/dev/null | grep 'Address:' | tail -n 1 | awk '{print $2}' || echo ''", quiet=True)).rstrip('\n')
     if len(ip) > 0:
         decoded[0]['spec']['endpoint']['address'] = ip+':9339'
     return encode_yaml_stream(decoded)


### PR DESCRIPTION
Tilt calls `nslookup`, which can return an IPv4 and/or an IPv6 address(es)  with no guarantees about the order. This causes Tilt to supply an IPv6 address to `DeviceSpec.Endpoint.Address`, which is then rejected by a kubebuilder validation pattern. This commit fixes this by querying for IPv4 addresses. The alternative approach of allowing IPv6 to connect to devices is not considered for now.