### PR TITLE
Use OpenAPI v3 pattern format `cidr` for `IPPrefix` api type

### DIFF
--- a/api/core/v1alpha1/prefix_types.go
+++ b/api/core/v1alpha1/prefix_types.go
@@ -11,7 +11,7 @@ import (
 // It is used to define a range of IP addresses in a network.
 //
 // +kubebuilder:validation:Type=string
-// +kubebuilder:validation:Pattern=`^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$`
+// +kubebuilder:validation:Format=cidr
 // +kubebuilder:validation:Example="192.168.1.0/24"
 // +kubebuilder:validation:Example="2001:db8::/32"
 // +kubebuilder:object:generate=false

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_accesscontrollists.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_accesscontrollists.yaml
@@ -101,7 +101,7 @@ spec:
                       description: |-
                         Destination IP address prefix. Can be IPv4 or IPv6.
                         Use 0.0.0.0/0 (::/0) to represent 'any'.
-                      pattern: ^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$
+                      format: cidr
                       type: string
                     protocol:
                       default: IP
@@ -125,7 +125,7 @@ spec:
                       description: |-
                         Source IP address prefix. Can be IPv4 or IPv6.
                         Use 0.0.0.0/0 (::/0) to represent 'any'.
-                      pattern: ^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$
+                      format: cidr
                       type: string
                   required:
                   - action

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_interfaces.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_interfaces.yaml
@@ -186,7 +186,7 @@ spec:
                       The first address in the list is considered the primary address,
                       and any additional addresses are considered secondary addresses.
                     items:
-                      pattern: ^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$
+                      format: cidr
                       type: string
                     minItems: 1
                     type: array

--- a/config/crd/bases/networking.metal.ironcore.dev_accesscontrollists.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_accesscontrollists.yaml
@@ -95,7 +95,7 @@ spec:
                       description: |-
                         Destination IP address prefix. Can be IPv4 or IPv6.
                         Use 0.0.0.0/0 (::/0) to represent 'any'.
-                      pattern: ^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$
+                      format: cidr
                       type: string
                     protocol:
                       default: IP
@@ -119,7 +119,7 @@ spec:
                       description: |-
                         Source IP address prefix. Can be IPv4 or IPv6.
                         Use 0.0.0.0/0 (::/0) to represent 'any'.
-                      pattern: ^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$
+                      format: cidr
                       type: string
                   required:
                   - action

--- a/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
@@ -180,7 +180,7 @@ spec:
                       The first address in the list is considered the primary address,
                       and any additional addresses are considered secondary addresses.
                     items:
-                      pattern: ^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$
+                      format: cidr
                       type: string
                     minItems: 1
                     type: array


### PR DESCRIPTION
Supported formats for OpenAPI v3 pattern validation can be found here: https://github.com/kubernetes/kubernetes/blob/5caeb4171d0e764ed54906413fe9f8a9e8c59b11/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go#L47-L72