### PR TITLE
Default list of allowed vlans switchport interfaces to all VLANs

### DIFF
--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -117,7 +117,6 @@ const (
 // Switchport defines the switchport configuration for an interface.
 // +kubebuilder:validation:XValidation:rule="self.mode != 'Access' || has(self.accessVlan)", message="accessVlan must be specified when mode is Access"
 // +kubebuilder:validation:XValidation:rule="self.mode != 'Trunk' || has(self.nativeVlan)", message="nativeVlan must be specified when mode is Trunk"
-// +kubebuilder:validation:XValidation:rule="self.mode != 'Trunk' || has(self.allowedVlans)", message="allowedVlans must be specified when mode is Trunk"
 type Switchport struct {
 	// Mode defines the switchport mode, such as access or trunk.
 	// +required
@@ -138,6 +137,7 @@ type Switchport struct {
 	NativeVlan int32 `json:"nativeVlan,omitempty"`
 
 	// AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+	// If not specified, all VLANs (1-4094) are allowed.
 	// Only applicable when Mode is set to "Trunk".
 	// +optional
 	// +kubebuilder:validation:MinItems=1

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_interfaces.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_interfaces.yaml
@@ -294,6 +294,7 @@ spec:
                   allowedVlans:
                     description: |-
                       AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+                      If not specified, all VLANs (1-4094) are allowed.
                       Only applicable when Mode is set to "Trunk".
                     items:
                       format: int32
@@ -325,8 +326,6 @@ spec:
                   rule: self.mode != 'Access' || has(self.accessVlan)
                 - message: nativeVlan must be specified when mode is Trunk
                   rule: self.mode != 'Trunk' || has(self.nativeVlan)
-                - message: allowedVlans must be specified when mode is Trunk
-                  rule: self.mode != 'Trunk' || has(self.allowedVlans)
               type:
                 description: Type indicates the type of the interface.
                 enum:

--- a/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
@@ -288,6 +288,7 @@ spec:
                   allowedVlans:
                     description: |-
                       AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+                      If not specified, all VLANs (1-4094) are allowed.
                       Only applicable when Mode is set to "Trunk".
                     items:
                       format: int32
@@ -319,8 +320,6 @@ spec:
                   rule: self.mode != 'Access' || has(self.accessVlan)
                 - message: nativeVlan must be specified when mode is Trunk
                   rule: self.mode != 'Trunk' || has(self.nativeVlan)
-                - message: allowedVlans must be specified when mode is Trunk
-                  rule: self.mode != 'Trunk' || has(self.allowedVlans)
               type:
                 description: Type indicates the type of the interface.
                 enum:


### PR DESCRIPTION
This change removes the requirement for `Interface` resources that are configured as switchports (L2) to specify their list of allowed vlans (trunk vlans). If unset, the configuration should default to allow all VLANs (1-4094) on the particular link.

Note: No changes were necessary on the provider implementation, as this was already handled in this way.