### PR TITLE
[NX-OS] Define UserCfgdFlags as Bitmask

### DIFF
--- a/internal/provider/cisco/nxos/intf_test.go
+++ b/internal/provider/cisco/nxos/intf_test.go
@@ -22,7 +22,7 @@ func init() {
 		AccessVlan:    DefaultVLAN,
 		NativeVlan:    DefaultVLAN,
 		TrunkVlans:    DefaultVLANRange,
-		UserCfgdFlags: "admin_layer,admin_mtu,admin_state",
+		UserCfgdFlags: UserFlagAdminState | UserFlagAdminLayer | UserFlagAdminMTU,
 	})
 
 	Register("physif_switchport", &PhysIf{
@@ -35,7 +35,7 @@ func init() {
 		AccessVlan:    DefaultVLAN,
 		NativeVlan:    DefaultVLAN,
 		TrunkVlans:    "10",
-		UserCfgdFlags: "admin_state",
+		UserCfgdFlags: UserFlagAdminState,
 	})
 
 	intfAddr4 := &AddrItem{ID: "lo0", Vrf: DefaultVRFName}
@@ -57,7 +57,7 @@ func init() {
 		PcMode:        PortChannelModeActive,
 		NativeVlan:    DefaultVLAN,
 		TrunkVlans:    "10",
-		UserCfgdFlags: "admin_state",
+		UserCfgdFlags: UserFlagAdminState,
 	}
 	pc.RsmbrIfsItems.RsMbrIfsList.Set(NewPortChannelMember("eth1/10"))
 	Register("pc", pc)

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -641,15 +641,15 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		if req.Interface.Spec.AdminState == v1alpha1.AdminStateUp {
 			p.AdminSt = AdminStUp
 		}
+		p.UserCfgdFlags = UserFlagAdminState | UserFlagAdminLayer
 		// TODO: If the interface is a member of a port-channel, do the following:
 		// 1) If the mtu has been explicitly configured on the port-channel and matches the mtu on the physical interface, adopt the "admin_mtu" flag.
 		// 2) If the mtu on the port-channel differs from the mtu on the physical interface, return an error.
 		// 3) If the mtu has not been explicitly configured on the port-channel, do not adopt the "admin_mtu" flag.
 		if req.Interface.Spec.MTU != 0 {
 			p.MTU = req.Interface.Spec.MTU
-			p.UserCfgdFlags = "admin_mtu," + p.UserCfgdFlags
+			p.UserCfgdFlags |= UserFlagAdminMTU
 		}
-		p.UserCfgdFlags = "admin_layer," + p.UserCfgdFlags
 		if req.IPv4 != nil {
 			p.Layer = Layer3
 		}
@@ -723,15 +723,13 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		pc.AccessVlan = DefaultVLAN
 		pc.NativeVlan = DefaultVLAN
 		pc.TrunkVlans = DefaultVLANRange
-		pc.UserCfgdFlags = "admin_state"
+		pc.UserCfgdFlags = UserFlagAdminState | UserFlagAdminLayer
 
 		pc.MTU = DefaultMTU
 		if req.Interface.Spec.MTU != 0 {
 			pc.MTU = req.Interface.Spec.MTU
-			pc.UserCfgdFlags = "admin_mtu," + pc.UserCfgdFlags
+			pc.UserCfgdFlags |= UserFlagAdminMTU
 		}
-
-		pc.UserCfgdFlags = "admin_layer," + pc.UserCfgdFlags
 
 		pc.PcMode = PortChannelModeActive
 		switch m := req.Interface.Spec.Aggregation.ControlProtocol.Mode; m {


### PR DESCRIPTION
This change introduces a formal type for the `UserCfgdFlags` used on interface configuration which corresponds to the Bitmask that is used internally to represent this value. Possible options and it's structure can be obtained from: https://pubhub.devnetcloud.com/media/dme-docs-10-4-3/docs/System/l1:PhysIf/