### PR TITLE
Standardize administrative state using AdminState enum across resources

### DIFF
--- a/api/cisco/nx/v1alpha1/bordergateway_types.go
+++ b/api/cisco/nx/v1alpha1/bordergateway_types.go
@@ -17,6 +17,11 @@ type BorderGatewaySpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="DeviceRef is immutable"
 	DeviceRef v1alpha1.LocalObjectReference `json:"deviceRef"`
 
+	// AdminState indicates whether the BorderGateway instance is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState v1alpha1.AdminState `json:"adminState,omitempty"`
+
 	// MultisiteID is the identifier for the multisite border gateway.
 	// +required
 	// +kubebuilder:validation:Minimum=1

--- a/api/cisco/nx/v1alpha1/vpcdomain_types.go
+++ b/api/cisco/nx/v1alpha1/vpcdomain_types.go
@@ -6,7 +6,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	corev1 "github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 )
 
 // VPCDomainSpec defines the desired state of a vPC domain (Virtual Port Channel Domain)
@@ -15,7 +15,7 @@ type VPCDomainSpec struct {
 	// Immutable.
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="DeviceRef is immutable"
-	DeviceRef corev1.LocalObjectReference `json:"deviceRef"`
+	DeviceRef v1alpha1.LocalObjectReference `json:"deviceRef"`
 
 	// DomainID is the vPC domain ID (1-1000).
 	// This uniquely identifies the vPC domain and must match on both peer switches.
@@ -27,8 +27,9 @@ type VPCDomainSpec struct {
 
 	// AdminState is the administrative state of the vPC domain (enabled/disabled).
 	// When disabled, the vPC domain is administratively shut down.
-	// +required
-	AdminState AdminState `json:"adminState"`
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState v1alpha1.AdminState `json:"adminState"`
 
 	// RolePriority is the role priority for this vPC domain (1-65535).
 	// The switch with the lower role priority becomes the operational primary.
@@ -67,17 +68,6 @@ type VPCDomainSpec struct {
 	Peer Peer `json:"peer"`
 }
 
-// AdminState represents the administrative state of the peer-link connection (Up/Down).
-// +kubebuilder:validation:Enum=Up;Down
-type AdminState string
-
-const (
-	// AdminStateUp indicates the connection to the peer is administratively enabled.
-	AdminStateUp AdminState = "Up"
-	// AdminStateDown indicates the connection to the peer is administratively disabled.
-	AdminStateDown AdminState = "Down"
-)
-
 // Enabled represents a simple enabled/disabled configuration.
 type Enabled struct {
 	// Enabled indicates whether a configuration property is administratively enabled (true) or disabled (false).
@@ -88,14 +78,15 @@ type Enabled struct {
 // Peer defines settings to configure peer settings
 type Peer struct {
 	// AdminState defines the administrative state of the peer-link.
-	// +required
-	AdminState AdminState `json:"adminState"`
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState v1alpha1.AdminState `json:"adminState"`
 
 	// InterfaceRef is a reference to an Interface resource and identifies the interface to be used as the vPC domain's peer-link.
 	// This interface carries control and data traffic between the two vPC domain peers.
 	// It is usually dedicated port-channel, but it can also be a single physical interface.
 	// +required
-	InterfaceRef corev1.LocalObjectReference `json:"interfaceRef,omitempty"`
+	InterfaceRef v1alpha1.LocalObjectReference `json:"interfaceRef,omitempty"`
 
 	// KeepAlive defines the out-of-band keepalive configuration.
 	// +required
@@ -145,7 +136,7 @@ type KeepAlive struct {
 	// If specified, the switch sends keepalive packets throughout this VRF.
 	// If omitted, the management VRF is used.
 	// +optional
-	VRFRef *corev1.LocalObjectReference `json:"vrfRef,omitempty"`
+	VRFRef *v1alpha1.LocalObjectReference `json:"vrfRef,omitempty"`
 }
 
 // AutoRecovery holds settings to automatically restore vPC domain's operation after detecting

--- a/api/core/v1alpha1/bgp_peer_types.go
+++ b/api/core/v1alpha1/bgp_peer_types.go
@@ -21,6 +21,12 @@ type BGPPeerSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether this BGP peer is administratively up or down.
+	// When Down, the BGP session with this peer is administratively shut down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// Address is the IPv4 address of the BGP peer.
 	// +required
 	// +kubebuilder:validation:Format=ipv4

--- a/api/core/v1alpha1/bgp_types.go
+++ b/api/core/v1alpha1/bgp_types.go
@@ -21,6 +21,11 @@ type BGPSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether this BGP router is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// ASNumber is the autonomous system number (ASN) for the BGP router.
 	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
 	// +required

--- a/api/core/v1alpha1/dns_types.go
+++ b/api/core/v1alpha1/dns_types.go
@@ -20,6 +20,11 @@ type DNSSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether DNS is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// Default domain name that the device uses to complete unqualified hostnames.
 	// +required
 	// +kubebuilder:validation:MinLength=1

--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -43,7 +43,8 @@ type InterfaceSpec struct {
 	Name string `json:"name"`
 
 	// AdminState indicates whether the interface is administratively up or down.
-	// +required
+	// +optional
+	// +kubebuilder:default=Up
 	AdminState AdminState `json:"adminState"`
 
 	// Description provides a human-readable description of the interface.
@@ -95,14 +96,16 @@ type InterfaceSpec struct {
 	BFD *BFD `json:"bfd,omitempty"`
 }
 
-// AdminState represents the administrative state of the interface.
+// AdminState represents the administrative state of a resource.
+// This type is used across multiple resources including interfaces, protocols (BGP, OSPF, ISIS, PIM),
+// and system services (NTP, DNS) to indicate whether these are administratively enabled or disabled.
 // +kubebuilder:validation:Enum=Up;Down
 type AdminState string
 
 const (
-	// AdminStateUp indicates that the interface is administratively set up.
+	// AdminStateUp indicates that the resource is administratively enabled.
 	AdminStateUp AdminState = "Up"
-	// AdminStateDown indicates that the interface is administratively set down.
+	// AdminStateDown indicates that the resource is administratively disabled.
 	AdminStateDown AdminState = "Down"
 )
 

--- a/api/core/v1alpha1/isis_types.go
+++ b/api/core/v1alpha1/isis_types.go
@@ -20,6 +20,11 @@ type ISISSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether the ISIS instance is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// Instance is the name of the ISIS instance.
 	// +required
 	// +kubebuilder:validation:MinLength=1

--- a/api/core/v1alpha1/ntp_types.go
+++ b/api/core/v1alpha1/ntp_types.go
@@ -20,6 +20,11 @@ type NTPSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether NTP is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// Source interface for all NTP traffic.
 	// +required
 	// +kubebuilder:validation:MinLength=1

--- a/api/core/v1alpha1/ospf_types.go
+++ b/api/core/v1alpha1/ospf_types.go
@@ -20,6 +20,11 @@ type OSPFSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether the OSPF instance is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// Instance is the process tag of the OSPF instance.
 	// +required
 	// +kubebuilder:validation:MinLength=1

--- a/api/core/v1alpha1/pim_types.go
+++ b/api/core/v1alpha1/pim_types.go
@@ -20,6 +20,11 @@ type PIMSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// AdminState indicates whether the PIM instance is administratively up or down.
+	// +optional
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
+
 	// RendezvousPoints defines the list of rendezvous points for sparse mode multicast.
 	// +optional
 	// +listType=map

--- a/api/core/v1alpha1/ref_types.go
+++ b/api/core/v1alpha1/ref_types.go
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 // LocalObjectReference contains enough information to locate a

--- a/api/core/v1alpha1/vlan_types.go
+++ b/api/core/v1alpha1/vlan_types.go
@@ -37,20 +37,9 @@ type VLANSpec struct {
 
 	// AdminState indicates whether the VLAN is administratively active or inactive/suspended.
 	// +optional
-	// +kubebuilder:default=Active
-	AdminState VLANState `json:"adminState"`
+	// +kubebuilder:default=Up
+	AdminState AdminState `json:"adminState,omitempty"`
 }
-
-// VLANState represents the administrative state of the VLAN.
-// +kubebuilder:validation:Enum=Active;Suspended
-type VLANState string
-
-const (
-	// VLANStateActive indicates that the VLAN is administratively active.
-	VLANStateActive VLANState = "Active"
-	// VLANStateSuspended indicates that the VLAN is administratively inactive/suspended.
-	VLANStateSuspended VLANState = "Suspended"
-)
 
 // VLANStatus defines the observed state of VLAN.
 type VLANStatus struct {

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_bgp.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_bgp.yaml
@@ -228,6 +228,14 @@ spec:
                         type: object
                     type: object
                 type: object
+              adminState:
+                default: Up
+                description: AdminState indicates whether this BGP router is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               asNumber:
                 anyOf:
                 - type: integer

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_bgppeers.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_bgppeers.yaml
@@ -165,6 +165,15 @@ spec:
                         type: string
                     type: object
                 type: object
+              adminState:
+                default: Up
+                description: |-
+                  AdminState indicates whether this BGP peer is administratively up or down.
+                  When Down, the BGP session with this peer is administratively shut down.
+                enum:
+                - Up
+                - Down
+                type: string
               asNumber:
                 anyOf:
                 - type: integer

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_devices.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_devices.yaml
@@ -184,7 +184,7 @@ spec:
                   rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
               provisioning:
                 description: |-
-                  Bootstrap is an optional configuration for the device bootstrap process.
+                  Provisioning is an optional configuration for the device provisioning process.
                   It can be used to provide initial configuration templates or scripts that are applied during the device provisioning.
                 properties:
                   bootScript:
@@ -372,7 +372,7 @@ spec:
                 enum:
                 - Pending
                 - Provisioning
-                - Active
+                - Running
                 - Failed
                 - Provisioned
                 type: string
@@ -431,12 +431,20 @@ spec:
                       type: string
                     error:
                       type: string
+                    phase:
+                      description: ProvisioningPhase represents the reason for the
+                        current provisioning status.
+                      type: string
+                    reboot:
+                      format: date-time
+                      type: string
                     startTime:
                       format: date-time
                       type: string
                     token:
                       type: string
                   required:
+                  - phase
                   - startTime
                   - token
                   type: object

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_dns.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_dns.yaml
@@ -57,6 +57,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether DNS is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_interfaces.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_interfaces.yaml
@@ -83,6 +83,7 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               adminState:
+                default: Up
                 description: AdminState indicates whether the interface is administratively
                   up or down.
                 enum:
@@ -407,7 +408,6 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - adminState
             - deviceRef
             - name
             - type

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_isis.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_isis.yaml
@@ -71,6 +71,14 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: set
+              adminState:
+                default: Up
+                description: AdminState indicates whether the ISIS instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_ntp.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_ntp.yaml
@@ -57,6 +57,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether NTP is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_ospf.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_ospf.yaml
@@ -75,6 +75,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the OSPF instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_pim.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_pim.yaml
@@ -57,6 +57,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the PIM instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/charts/network-operator/templates/crd/networking.metal.ironcore.dev_vlans.yaml
+++ b/charts/network-operator/templates/crd/networking.metal.ironcore.dev_vlans.yaml
@@ -72,12 +72,12 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               adminState:
-                default: Active
+                default: Up
                 description: AdminState indicates whether the VLAN is administratively
                   active or inactive/suspended.
                 enum:
-                - Active
-                - Suspended
+                - Up
+                - Down
                 type: string
               deviceRef:
                 description: |-

--- a/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_bordergateways.yaml
+++ b/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_bordergateways.yaml
@@ -59,6 +59,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the BorderGateway instance
+                  is administratively up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               bgpPeerRefs:
                 description: |-
                   BGPPeerRefs is a list of BGP peers that are part of the border gateway configuration.

--- a/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -96,6 +96,7 @@ spec:
             description: spec defines the desired state of VPCDomain resource
             properties:
               adminState:
+                default: Up
                 description: |-
                   AdminState is the administrative state of the vPC domain (enabled/disabled).
                   When disabled, the vPC domain is administratively shut down.
@@ -160,6 +161,7 @@ spec:
                   peer-link, keepalive.
                 properties:
                   adminState:
+                    default: Up
                     description: AdminState defines the administrative state of the
                       peer-link.
                     enum:
@@ -287,7 +289,6 @@ spec:
                     - enabled
                     type: object
                 required:
-                - adminState
                 - interfaceRef
                 - keepalive
                 type: object
@@ -308,7 +309,6 @@ spec:
                 minimum: 1
                 type: integer
             required:
-            - adminState
             - deviceRef
             - domainId
             - peer

--- a/config/crd/bases/networking.metal.ironcore.dev_bgp.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_bgp.yaml
@@ -222,6 +222,14 @@ spec:
                         type: object
                     type: object
                 type: object
+              adminState:
+                default: Up
+                description: AdminState indicates whether this BGP router is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               asNumber:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/networking.metal.ironcore.dev_bgppeers.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_bgppeers.yaml
@@ -159,6 +159,15 @@ spec:
                         type: string
                     type: object
                 type: object
+              adminState:
+                default: Up
+                description: |-
+                  AdminState indicates whether this BGP peer is administratively up or down.
+                  When Down, the BGP session with this peer is administratively shut down.
+                enum:
+                - Up
+                - Down
+                type: string
               asNumber:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/networking.metal.ironcore.dev_dns.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_dns.yaml
@@ -51,6 +51,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether DNS is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
@@ -77,6 +77,7 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               adminState:
+                default: Up
                 description: AdminState indicates whether the interface is administratively
                   up or down.
                 enum:
@@ -401,7 +402,6 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - adminState
             - deviceRef
             - name
             - type

--- a/config/crd/bases/networking.metal.ironcore.dev_isis.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_isis.yaml
@@ -65,6 +65,14 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: set
+              adminState:
+                default: Up
+                description: AdminState indicates whether the ISIS instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/config/crd/bases/networking.metal.ironcore.dev_ntp.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_ntp.yaml
@@ -51,6 +51,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether NTP is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/config/crd/bases/networking.metal.ironcore.dev_ospf.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_ospf.yaml
@@ -69,6 +69,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the OSPF instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/config/crd/bases/networking.metal.ironcore.dev_pim.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_pim.yaml
@@ -51,6 +51,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the PIM instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.

--- a/config/crd/bases/networking.metal.ironcore.dev_vlans.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_vlans.yaml
@@ -66,12 +66,12 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               adminState:
-                default: Active
+                default: Up
                 description: AdminState indicates whether the VLAN is administratively
                   active or inactive/suspended.
                 enum:
-                - Active
-                - Suspended
+                - Up
+                - Down
                 type: string
               deviceRef:
                 description: |-

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_bordergateways.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_bordergateways.yaml
@@ -53,6 +53,14 @@ spec:
               Specification of the desired state of the resource.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the BorderGateway instance
+                  is administratively up or down.
+                enum:
+                - Up
+                - Down
+                type: string
               bgpPeerRefs:
                 description: |-
                   BGPPeerRefs is a list of BGP peers that are part of the border gateway configuration.

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -90,6 +90,7 @@ spec:
             description: spec defines the desired state of VPCDomain resource
             properties:
               adminState:
+                default: Up
                 description: |-
                   AdminState is the administrative state of the vPC domain (enabled/disabled).
                   When disabled, the vPC domain is administratively shut down.
@@ -154,6 +155,7 @@ spec:
                   peer-link, keepalive.
                 properties:
                   adminState:
+                    default: Up
                     description: AdminState defines the administrative state of the
                       peer-link.
                     enum:
@@ -281,7 +283,6 @@ spec:
                     - enabled
                     type: object
                 required:
-                - adminState
                 - interfaceRef
                 - keepalive
                 type: object
@@ -302,7 +303,6 @@ spec:
                 minimum: 1
                 type: integer
             required:
-            - adminState
             - deviceRef
             - domainId
             - peer

--- a/config/samples/v1alpha1_vlan.yaml
+++ b/config/samples/v1alpha1_vlan.yaml
@@ -11,4 +11,3 @@ spec:
     name: leaf1
   id: 10
   name: MonteCarlo
-  adminState: Active

--- a/internal/controller/core/evpninstance_controller_test.go
+++ b/internal/controller/core/evpninstance_controller_test.go
@@ -73,7 +73,7 @@ var _ = Describe("EVPNInstance Controller", func() {
 					DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
 					ID:         10,
 					Name:       "vlan-10",
-					AdminState: v1alpha1.VLANStateActive,
+					AdminState: v1alpha1.AdminStateUp,
 				},
 			}
 			Expect(k8sClient.Create(ctx, vlan)).To(Succeed())
@@ -200,7 +200,7 @@ var _ = Describe("EVPNInstance Controller", func() {
 					DeviceRef:  v1alpha1.LocalObjectReference{Name: "different-device"},
 					ID:         10,
 					Name:       "vlan-10",
-					AdminState: v1alpha1.VLANStateActive,
+					AdminState: v1alpha1.AdminStateUp,
 				},
 			}
 			Expect(k8sClient.Create(ctx, vlan)).To(Succeed())

--- a/internal/controller/core/interface_controller_test.go
+++ b/internal/controller/core/interface_controller_test.go
@@ -642,7 +642,7 @@ var _ = Describe("Interface Controller", func() {
 					DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
 					ID:         100,
 					Name:       "test-vlan",
-					AdminState: v1alpha1.VLANStateActive,
+					AdminState: v1alpha1.AdminStateUp,
 				},
 			}
 			Expect(k8sClient.Create(ctx, vlan)).To(Succeed())
@@ -741,7 +741,7 @@ var _ = Describe("Interface Controller", func() {
 					DeviceRef:  v1alpha1.LocalObjectReference{Name: "different-device"},
 					ID:         100,
 					Name:       "test-vlan",
-					AdminState: v1alpha1.VLANStateActive,
+					AdminState: v1alpha1.AdminStateUp,
 				},
 			}
 			Expect(k8sClient.Create(ctx, vlan)).To(Succeed())

--- a/internal/controller/core/vlan_controller_test.go
+++ b/internal/controller/core/vlan_controller_test.go
@@ -50,7 +50,7 @@ var _ = Describe("VLAN Controller", func() {
 						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
 						ID:         id,
 						Name:       "Scrum",
-						AdminState: v1alpha1.VLANStateActive,
+						AdminState: v1alpha1.AdminStateUp,
 					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())

--- a/internal/provider/cisco/nxos/bgp.go
+++ b/internal/provider/cisco/nxos/bgp.go
@@ -115,6 +115,7 @@ func (af *BGPDomAfItem) SetMultipath(m *v1alpha1.BGPMultipath) error {
 
 type BGPPeer struct {
 	Addr                string      `json:"addr"`
+	AdminSt             AdminSt     `json:"adminSt"`
 	Asn                 string      `json:"asn"`
 	AsnType             PeerAsnType `json:"asnType"`
 	Name                string      `json:"name,omitempty"`

--- a/internal/provider/cisco/nxos/bgp_test.go
+++ b/internal/provider/cisco/nxos/bgp_test.go
@@ -20,6 +20,7 @@ func init() {
 
 	bgpPeer := &BGPPeer{
 		Addr:    "1.1.1.1",
+		AdminSt: AdminStEnabled,
 		Asn:     "65000",
 		AsnType: PeerAsnTypeNone,
 		Name:    "EVPN peering with spine",

--- a/internal/provider/cisco/nxos/ntp.go
+++ b/internal/provider/cisco/nxos/ntp.go
@@ -28,6 +28,7 @@ func (*NTP) XPath() string {
 
 func (n *NTP) Default() {
 	n.AdminSt = AdminStDisabled
+	n.Logging = AdminStDisabled
 }
 
 type NTPProvider struct {

--- a/internal/provider/cisco/nxos/pim.go
+++ b/internal/provider/cisco/nxos/pim.go
@@ -6,10 +6,34 @@ package nxos
 import "github.com/ironcore-dev/network-operator/internal/provider/cisco/gnmiext/v2"
 
 var (
+	_ gnmiext.Configurable = (*PIM)(nil)
+	_ gnmiext.Configurable = (*PIMDom)(nil)
 	_ gnmiext.Configurable = (*StaticRPItems)(nil)
 	_ gnmiext.Configurable = (*AnycastPeerItems)(nil)
 	_ gnmiext.Configurable = (*PIMIfItems)(nil)
 )
+
+type PIM struct {
+	AdminSt   AdminSt `json:"adminSt"`
+	InstItems struct {
+		AdminSt AdminSt `json:"adminSt"`
+	} `json:"inst-items"`
+}
+
+func (*PIM) XPath() string {
+	return "System/pim-items"
+}
+
+type PIMDom struct {
+	Name    string  `json:"name"`
+	AdminSt AdminSt `json:"adminSt"`
+}
+
+func (*PIMDom) IsListItem() {}
+
+func (p *PIMDom) XPath() string {
+	return "System/pim-items/inst-items/dom-items/Dom-list[name=" + p.Name + "]"
+}
 
 type StaticRPItems struct {
 	StaticRPList gnmiext.List[string, *StaticRP] `json:"StaticRP-list,omitzero"`

--- a/internal/provider/cisco/nxos/testdata/bgp_peer.json
+++ b/internal/provider/cisco/nxos/testdata/bgp_peer.json
@@ -9,6 +9,7 @@
               "Peer-list": [
                 {
                   "addr": "1.1.1.1",
+                  "adminSt": "enabled",
                   "asn": "65000",
                   "asnType": "none",
                   "name": "EVPN peering with spine",


### PR DESCRIPTION
This patch harmonizes the API for setting a administrative state on resources using the AdminState enumeration and introduces this field for protocols (BGP, OSPF, ISIS, PIM) and system level services (NTP, DNS).