### PR TITLE
[NX-OS] Add defaults for `VPCDomain` resource

### DIFF
--- a/api/cisco/nx/v1alpha1/vpcdomain_types.go
+++ b/api/cisco/nx/v1alpha1/vpcdomain_types.go
@@ -36,6 +36,7 @@ type VPCDomainSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:default=32667
 	RolePriority int32 `json:"rolePriority"`
 
 	// SystemPriority is the system priority for this vPC domain (1-65535).
@@ -43,6 +44,7 @@ type VPCDomainSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:default=32667
 	SystemPriority int32 `json:"systemPriority"`
 
 	// DelayRestoreSVI is the delay in seconds (1-3600) before bringing up interface-vlan (SVI) after peer-link comes up.
@@ -50,17 +52,20 @@ type VPCDomainSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3600
+	// +kubebuilder:default=10
 	DelayRestoreSVI int16 `json:"delayRestoreSVI"`
 
 	// DelayRestoreVPC is the delay in seconds (1-3600) before bringing up the member ports after the peer-link is restored.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3600
+	// +kubebuilder:default=30
 	DelayRestoreVPC int16 `json:"delayRestoreVPC"`
 
 	// FastConvergence ensures that both SVIs and member ports are shut down simultaneously when the peer-link goes down.
 	// This synchronization helps prevent traffic loss.
 	// +optional
+	// +kubebuilder:default={enabled:false}
 	FastConvergence Enabled `json:"fastConvergence"`
 
 	// Peer contains the vPC's domain peer configuration including peer-link, keepalive.
@@ -86,7 +91,7 @@ type Peer struct {
 	// This interface carries control and data traffic between the two vPC domain peers.
 	// It is usually dedicated port-channel, but it can also be a single physical interface.
 	// +required
-	InterfaceRef v1alpha1.LocalObjectReference `json:"interfaceRef,omitempty"`
+	InterfaceRef v1alpha1.LocalObjectReference `json:"interfaceRef"`
 
 	// KeepAlive defines the out-of-band keepalive configuration.
 	// +required
@@ -94,7 +99,7 @@ type Peer struct {
 
 	// AutoRecovery defines auto-recovery settings for restoring vPC domain after peer failure.
 	// +optional
-	AutoRecovery *AutoRecovery `json:"autoRecovery,omitempty"`
+	AutoRecovery *AutoRecovery `json:"autoRecovery"`
 
 	// Switch enables peer-switch functionality on this peer.
 	// When enabled, both vPC domain peers use the same spanning-tree bridge ID, allowing both
@@ -147,14 +152,15 @@ type AutoRecovery struct {
 	// When enabled, the switch will wait for ReloadDelay seconds after peer failure
 	// before assuming the peer is dead and restoring the vPC's domain functionality.
 	// +required
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 
 	// ReloadDelay is the time in seconds (60-3600) to wait before assuming the peer is dead
 	// and automatically attempting to restore the communication with the peer.
 	// +optional
 	// +kubebuilder:validation:Minimum=60
 	// +kubebuilder:validation:Maximum=3600
-	ReloadDelay int16 `json:"reloadDelay,omitempty"`
+	// +kubebuilder:default=240
+	ReloadDelay int16 `json:"reloadDelay"`
 }
 
 // VPCDomainStatus defines the observed state of VPCDomain.
@@ -178,10 +184,6 @@ type VPCDomainStatus struct {
 	//+patchMergeKey=type
 	//+optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-
-	// DomainID is the vPC domain ID as reported by the device.
-	// +optional
-	DomainID uint16 `json:"domainId,omitempty"`
 
 	// Role indicates the current operational role of this vPC domain peer.
 	// +optional
@@ -207,7 +209,7 @@ type VPCDomainStatus struct {
 
 	// PeerUptime indicates how long the vPC domain peer has been up and reachable via keepalive.
 	// +optional
-	PeerUptime metav1.Duration `json:"peerUptime,omitempty"`
+	PeerUptime metav1.Duration `json:"peerUptime,omitempty,omitzero"`
 
 	// PeerLinkIf is the name of the interface used as the vPC domain peer-link.
 	// +optional

--- a/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -105,6 +105,7 @@ spec:
                 - Down
                 type: string
               delayRestoreSVI:
+                default: 10
                 description: |-
                   DelayRestoreSVI is the delay in seconds (1-3600) before bringing up interface-vlan (SVI) after peer-link comes up.
                   This prevents traffic blackholing during convergence.
@@ -112,6 +113,7 @@ spec:
                 minimum: 1
                 type: integer
               delayRestoreVPC:
+                default: 30
                 description: DelayRestoreVPC is the delay in seconds (1-3600) before
                   bringing up the member ports after the peer-link is restored.
                 maximum: 3600
@@ -145,6 +147,8 @@ spec:
                 minimum: 1
                 type: integer
               fastConvergence:
+                default:
+                  enabled: false
                 description: |-
                   FastConvergence ensures that both SVIs and member ports are shut down simultaneously when the peer-link goes down.
                   This synchronization helps prevent traffic loss.
@@ -179,6 +183,7 @@ spec:
                           before assuming the peer is dead and restoring the vPC's domain functionality.
                         type: boolean
                       reloadDelay:
+                        default: 240
                         description: |-
                           ReloadDelay is the time in seconds (60-3600) to wait before assuming the peer is dead
                           and automatically attempting to restore the communication with the peer.
@@ -293,6 +298,7 @@ spec:
                 - keepalive
                 type: object
               rolePriority:
+                default: 32667
                 description: |-
                   RolePriority is the role priority for this vPC domain (1-65535).
                   The switch with the lower role priority becomes the operational primary.
@@ -301,6 +307,7 @@ spec:
                 minimum: 1
                 type: integer
               systemPriority:
+                default: 32667
                 description: |-
                   SystemPriority is the system priority for this vPC domain (1-65535).
                   Used to ensure that the vPC domain devices are primary devices on LACP. Must match on both peers.
@@ -388,9 +395,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              domainId:
-                description: DomainID is the vPC domain ID as reported by the device.
-                type: integer
               keepaliveStatus:
                 description: KeepAliveStatus indicates the status of the peer via
                   the keepalive link.

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -99,6 +99,7 @@ spec:
                 - Down
                 type: string
               delayRestoreSVI:
+                default: 10
                 description: |-
                   DelayRestoreSVI is the delay in seconds (1-3600) before bringing up interface-vlan (SVI) after peer-link comes up.
                   This prevents traffic blackholing during convergence.
@@ -106,6 +107,7 @@ spec:
                 minimum: 1
                 type: integer
               delayRestoreVPC:
+                default: 30
                 description: DelayRestoreVPC is the delay in seconds (1-3600) before
                   bringing up the member ports after the peer-link is restored.
                 maximum: 3600
@@ -139,6 +141,8 @@ spec:
                 minimum: 1
                 type: integer
               fastConvergence:
+                default:
+                  enabled: false
                 description: |-
                   FastConvergence ensures that both SVIs and member ports are shut down simultaneously when the peer-link goes down.
                   This synchronization helps prevent traffic loss.
@@ -173,6 +177,7 @@ spec:
                           before assuming the peer is dead and restoring the vPC's domain functionality.
                         type: boolean
                       reloadDelay:
+                        default: 240
                         description: |-
                           ReloadDelay is the time in seconds (60-3600) to wait before assuming the peer is dead
                           and automatically attempting to restore the communication with the peer.
@@ -287,6 +292,7 @@ spec:
                 - keepalive
                 type: object
               rolePriority:
+                default: 32667
                 description: |-
                   RolePriority is the role priority for this vPC domain (1-65535).
                   The switch with the lower role priority becomes the operational primary.
@@ -295,6 +301,7 @@ spec:
                 minimum: 1
                 type: integer
               systemPriority:
+                default: 32667
                 description: |-
                   SystemPriority is the system priority for this vPC domain (1-65535).
                   Used to ensure that the vPC domain devices are primary devices on LACP. Must match on both peers.
@@ -382,9 +389,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              domainId:
-                description: DomainID is the vPC domain ID as reported by the device.
-                type: integer
               keepaliveStatus:
                 description: KeepAliveStatus indicates the status of the peer via
                   the keepalive link.

--- a/config/samples/cisco/nx/v1alpha1_vpcdomain.yaml
+++ b/config/samples/cisco/nx/v1alpha1_vpcdomain.yaml
@@ -124,7 +124,6 @@ spec:
   delayRestoreSVI: 140
   delayRestoreVPC: 150
   peer:
-    vpcId: 1
     adminState: Up
     interfaceRef:
       name: po1

--- a/internal/provider/cisco/nxos/vpc.go
+++ b/internal/provider/cisco/nxos/vpc.go
@@ -21,18 +21,18 @@ var (
 
 // VPCDomain represents the domain of a virtual Port Channel (vPC)
 type VPCDomain struct {
-	AdminSt                 AdminSt         `json:"adminSt"`
-	AutoRecovery            Option[AdminSt] `json:"autoRecovery"`
-	AutoRecoveryReloadDelay Option[uint16]  `json:"autoRecoveryIntvl"`
-	DelayRestoreSVI         Option[uint16]  `json:"delayRestoreSVI"`
-	DelayRestoreVPC         Option[uint16]  `json:"delayRestoreVPC"`
-	FastConvergence         Option[AdminSt] `json:"fastConvergence"`
-	Id                      uint16          `json:"id"`
-	L3PeerRouter            AdminSt         `json:"l3PeerRouter"`
-	PeerGateway             AdminSt         `json:"peerGw"`
-	PeerSwitch              AdminSt         `json:"peerSwitch"`
-	RolePrio                Option[uint16]  `json:"rolePrio"`
-	SysPrio                 Option[uint16]  `json:"sysPrio"`
+	AdminSt                 AdminSt `json:"adminSt"`
+	AutoRecovery            AdminSt `json:"autoRecovery"`
+	AutoRecoveryReloadDelay int16   `json:"autoRecoveryIntvl"`
+	DelayRestoreSVI         int16   `json:"delayRestoreSVI"`
+	DelayRestoreVPC         int16   `json:"delayRestoreVPC"`
+	FastConvergence         AdminSt `json:"fastConvergence"`
+	ID                      int16   `json:"id"`
+	L3PeerRouter            AdminSt `json:"l3PeerRouter"`
+	PeerGateway             AdminSt `json:"peerGw"`
+	PeerSwitch              AdminSt `json:"peerSwitch"`
+	RolePrio                int32   `json:"rolePrio"`
+	SysPrio                 int32   `json:"sysPrio"`
 	KeepAliveItems          struct {
 		DestIP        string `json:"destIp"`
 		SrcIP         string `json:"srcIp"`

--- a/internal/provider/cisco/nxos/vpc_test.go
+++ b/internal/provider/cisco/nxos/vpc_test.go
@@ -6,17 +6,17 @@ package nxos
 func init() {
 	vd := &VPCDomain{
 		AdminSt:                 AdminStEnabled,
-		AutoRecovery:            NewOption(AdminStEnabled),
-		AutoRecoveryReloadDelay: NewOption[uint16](360),
-		DelayRestoreSVI:         NewOption[uint16](45),
-		DelayRestoreVPC:         NewOption[uint16](150),
-		FastConvergence:         NewOption(AdminStEnabled),
-		Id:                      2,
+		AutoRecovery:            AdminStEnabled,
+		AutoRecoveryReloadDelay: 360,
+		DelayRestoreSVI:         45,
+		DelayRestoreVPC:         150,
+		FastConvergence:         AdminStEnabled,
+		ID:                      2,
 		L3PeerRouter:            AdminStEnabled,
 		PeerGateway:             AdminStEnabled,
 		PeerSwitch:              AdminStEnabled,
-		RolePrio:                NewOption[uint16](100),
-		SysPrio:                 NewOption[uint16](10),
+		RolePrio:                100,
+		SysPrio:                 10,
 	}
 	vd.KeepAliveItems.DestIP = "10.114.235.156"
 	vd.KeepAliveItems.SrcIP = "10.114.235.155"


### PR DESCRIPTION
The default values are taken from the DME reference. See https://pubhub.devnetcloud.com/media/dme-docs-10-4-3/docs/System/vpc:Dom/