### PR TITLE
Do not wait for interfaces to become ready to configure ospf

### DIFF
--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -70,6 +70,19 @@ func IsReady(target Getter) bool {
 	return condition.Status == metav1.ConditionTrue
 }
 
+// IsConfigured looks at the [v1alpha1.ConfiguredCondition] condition type and returns true
+// if that condition is set to true and the observed generation matches the object's generation.
+func IsConfigured(target Getter) bool {
+	condition := meta.FindStatusCondition(target.GetConditions(), v1alpha1.ConfiguredCondition)
+	if condition == nil {
+		return false
+	}
+	if m, ok := target.(metav1.Object); ok && condition.ObservedGeneration != m.GetGeneration() {
+		return false
+	}
+	return condition.Status == metav1.ConditionTrue
+}
+
 // GetTopLevelCondition finds and returns the top level condition (Ready Condition).
 func GetTopLevelCondition(target Getter) *metav1.Condition {
 	return meta.FindStatusCondition(target.GetConditions(), v1alpha1.ReadyCondition)

--- a/internal/controller/core/ospf_controller.go
+++ b/internal/controller/core/ospf_controller.go
@@ -252,12 +252,12 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 			return ctrl.Result{}, err
 		}
 
-		if !conditions.IsReady(intf) {
+		if !conditions.IsConfigured(intf) {
 			conditions.Set(s.OSPF, metav1.Condition{
 				Type:    v1alpha1.ReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1alpha1.WaitingForDependenciesReason,
-				Message: "Waiting for referenced interfaces to become ready",
+				Message: "Waiting for referenced interfaces to be configured",
 			})
 			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
 		}


### PR DESCRIPTION
OSPF would never be configured if only one member interface is down.
Hence, only wait for configuration.
