### PR TITLE
fix(isis,pim): Do not wait for interfaces to become ready

### DIFF
--- a/internal/controller/core/isis_controller.go
+++ b/internal/controller/core/isis_controller.go
@@ -248,12 +248,12 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 			return ctrl.Result{}, err
 		}
 
-		if !conditions.IsReady(intf) {
+		if !conditions.IsConfigured(intf) {
 			conditions.Set(s.ISIS, metav1.Condition{
 				Type:    v1alpha1.ReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1alpha1.WaitingForDependenciesReason,
-				Message: "Waiting for referenced interfaces to become ready",
+				Message: "Waiting for referenced interfaces to become configured",
 			})
 			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
 		}

--- a/internal/controller/core/pim_controller.go
+++ b/internal/controller/core/pim_controller.go
@@ -248,12 +248,12 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Resu
 			return ctrl.Result{}, err
 		}
 
-		if !conditions.IsReady(res) {
+		if !conditions.IsConfigured(res) {
 			conditions.Set(s.PIM, metav1.Condition{
 				Type:    v1alpha1.ReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1alpha1.WaitingForDependenciesReason,
-				Message: "Waiting for referenced interfaces to become ready",
+				Message: "Waiting for referenced interfaces to become configured",
 			})
 			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
 		}


### PR DESCRIPTION
ISIS/PIM would never be configured if only one member interface is down.
Hence, only wait for configuration.
