### PR TITLE
Rename printcolumn on `VPCDomain` to `Admin State` to align with others

### DIFF
--- a/api/cisco/nx/v1alpha1/vpcdomain_types.go
+++ b/api/cisco/nx/v1alpha1/vpcdomain_types.go
@@ -246,7 +246,7 @@ const (
 // +kubebuilder:resource:shortName=vpcdomain
 // +kubebuilder:printcolumn:name="Device",type=string,JSONPath=`.spec.deviceRef.name`
 // +kubebuilder:printcolumn:name="Domain",type=string,JSONPath=`.spec.domainId`
-// +kubebuilder:printcolumn:name="Enabled",type=string,JSONPath=`.spec.adminState`
+// +kubebuilder:printcolumn:name="Admin State",type=string,JSONPath=`.spec.adminState`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Configured",type=string,JSONPath=`.status.conditions[?(@.type=="Configured")].status`,priority=1
 // +kubebuilder:printcolumn:name="Operational",type=string,JSONPath=`.status.conditions[?(@.type=="Operational")].status`,priority=1

--- a/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/charts/network-operator/templates/crd/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -30,7 +30,7 @@ spec:
       name: Domain
       type: string
     - jsonPath: .spec.adminState
-      name: Enabled
+      name: Admin State
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -24,7 +24,7 @@ spec:
       name: Domain
       type: string
     - jsonPath: .spec.adminState
-      name: Enabled
+      name: Admin State
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready


### PR DESCRIPTION
This patch adjusts the column name for the printcolumn to show the admin state of a `VPCDomain` to adhere to the same name as on other resources for consistency.