### PR TITLE
Set docker container image value to ghcr.io in Helm Chart

### DIFF
--- a/charts/network-operator/values.yaml
+++ b/charts/network-operator/values.yaml
@@ -3,7 +3,7 @@ controllerManager:
   replicas: 1
   container:
     image:
-      repository: controller
+      repository: ghcr.io/ironcore-dev/network-operator
       tag: latest
     imagePullPolicy: IfNotPresent
     args:


### PR DESCRIPTION
With the container image of this project now being published to ghcr.io we can set the default value for the manager container image in the values file of our helm chart to the container image published. Users can still overwrite the container image with a custom one, if required, this will just be the default.