### PR TITLE
Refactor GitHub Actions Workflows

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Kustomize
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  kustomize-validation:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Kustomize
+        run: |
+          make install-kustomize
+      - name: Validate Kustomize
+        run: |
+          ./hack/validate-kustomize.sh

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Container Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push-image:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            # https://github.com/docker/metadata-action#typeedge
+            type=edge
+            # https://github.com/docker/metadata-action#latest-tag
+            type=raw,value=latest,enable={{is_default_branch}}
+            # https://github.com/docker/metadata-action#typesemver
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # https://github.com/docker/metadata-action#typeref
+            type=ref,event=branch
+            type=ref,event=pr
+            # https://github.com/docker/metadata-action#typesha
+            type=sha,format=long
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: setup-buildx
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Go Cache for Docker
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            go-pkg-mod
+            go-build-cache
+          key: cache-mount-${{ hashFiles('go.sum') }}
+      - name: Restore Docker Cache Mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        with:
+          cache-map: |
+            {
+              "go-pkg-mod": "/go/pkg/mod",
+              "go-build-cache": "/root/.cache/go-build"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+          builder: ${{ steps.setup-buildx.outputs.name }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=max
+          cache-from: type=gha

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -68,13 +68,7 @@ githubWorkflow:
   securityChecks:
     enabled: true
   pushContainerToGhcr:
-    enabled: true
-    platforms: "linux/amd64,linux/arm64"
-    tagStrategy:
-      - edge
-      - latest
-      - semver
-      - sha
+    enabled: false
 
 variables:
   GO_BUILDENV: 'CGO_ENABLED=0'

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,7 +1,7 @@
 ## Append samples of your project ##
 resources:
 - v1alpha1_device.yaml
-- v1alpha1-dhcprelay.yaml
+- v1alpha1_dhcprelay.yaml
 - v1alpha1_interface.yaml
 - v1alpha1_lldp.yaml
 - v1alpha1_banner.yaml

--- a/hack/validate-kustomize.sh
+++ b/hack/validate-kustomize.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+BASEDIR=$(cd -- "$(dirname -- "$0")" && pwd)
+
+for kustomization in $(find "$BASEDIR/../config" -name "kustomization.yaml"); do
+  dir=$(dirname "$kustomization")
+  name=${dir#"$BASEDIR/../"}
+  if kustomize build "$dir" >/dev/null 2>&1; then
+    echo "OK: $name"
+  else
+    echo "FAILED: $name"
+    exit 1
+  fi
+done


### PR DESCRIPTION
With this PR we stop using go-makefile-maker for GitHub Actions workflow generation. With recent additions of custom workflows, maintaining consistency between auto-generated and manually written pipelines became impractical. The effort to update all workflows already requires reviewing each one, so auto-generation provides diminishing value. Additionally, some generated workflows like CodeQL are redundant (enabled at repo level) while others like test-chart or publishing the docker image to `ghcr.io` required manual modifications anyway.

Going forward, all workflows will be manually maintained for this project, providing full control over CI/CD configuration.