### PR TITLE
Add build platform specification to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.26-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 AS builder
 
 RUN apk add --no-cache --no-progress git make
 
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN --mount=type=bind,target=.,readwrite \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOTOOLCHAIN=local make install
+    GO_BUILDENV="GOOS=${TARGETOS} GOARCH=${TARGETARCH}" GOTOOLCHAIN=local make install
 
 FROM gcr.io/distroless/static:nonroot
 


### PR DESCRIPTION
This patch adds the specification for the build platform to the Dockerfile to effectively make use of the cross compilation capabilities of Go in the build stage. See https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/ for a detailed explanation.

This reduces the workflow execution from ~30min[^1] to ~4min[^2].

[^1]: https://github.com/ironcore-dev/network-operator/actions/runs/22599079048/job/65476427191
[^2]: https://github.com/ironcore-dev/network-operator/actions/runs/22623850875/job/65555278544