### PR TITLE
[NX-OS]: Use management vrf by default for `VPCDomain` if not specified

### DIFF
--- a/internal/provider/cisco/nxos/dns_test.go
+++ b/internal/provider/cisco/nxos/dns_test.go
@@ -4,7 +4,7 @@
 package nxos
 
 func init() {
-	vrf := &DNSVrf{Name: "management"}
+	vrf := &DNSVrf{Name: ManagementVRFName}
 	vrf.ProvItems.ProviderList.Set(&DNSProv{Addr: "10.10.10.10"})
 
 	prof := &DNSProf{Name: DefaultVRFName}

--- a/internal/provider/cisco/nxos/grpc.go
+++ b/internal/provider/cisco/nxos/grpc.go
@@ -37,7 +37,7 @@ func (g *GRPC) Validate() error {
 	if g.Port < 1024 || g.Port > 65535 {
 		return fmt.Errorf("grpc: invalid port %d: must be between 1024 and 65535", g.Port)
 	}
-	if g.UseVrf == "management" {
+	if g.UseVrf == ManagementVRFName {
 		return errors.New("grpc: cannot use vrf 'management'")
 	}
 	return nil

--- a/internal/provider/cisco/nxos/intf_test.go
+++ b/internal/provider/cisco/nxos/intf_test.go
@@ -8,7 +8,7 @@ func init() {
 		ID:            "lo0",
 		Descr:         "Test",
 		AdminSt:       AdminStUp,
-		RtvrfMbrItems: NewVrfMember("lo0", "management"),
+		RtvrfMbrItems: NewVrfMember("lo0", ManagementVRFName),
 	})
 
 	Register("physif_rtd", &PhysIf{

--- a/internal/provider/cisco/nxos/ntp_test.go
+++ b/internal/provider/cisco/nxos/ntp_test.go
@@ -12,7 +12,7 @@ func init() {
 		Name:      "de.pool.ntp.org",
 		Preferred: true,
 		ProvT:     "server",
-		Vrf:       "management",
+		Vrf:       ManagementVRFName,
 	})
 	ntp.SrcIfItems.SrcIf = "mgmt0"
 	Register("ntp", ntp)

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -2273,6 +2273,7 @@ func (p *Provider) EnsureVPCDomain(ctx context.Context, vpcdomain *nxv1alpha1.VP
 	v.KeepAliveItems.DestIP = vpcdomain.Spec.Peer.KeepAlive.Destination
 	v.KeepAliveItems.SrcIP = vpcdomain.Spec.Peer.KeepAlive.Source
 
+	v.KeepAliveItems.VRF = ManagementVRFName
 	if vrf != nil {
 		v.KeepAliveItems.VRF = vrf.Spec.Name
 	}
@@ -2282,7 +2283,7 @@ func (p *Provider) EnsureVPCDomain(ctx context.Context, vpcdomain *nxv1alpha1.VP
 		return fmt.Errorf("vpc: failed to get short name for the port-channel interface %q: %w", pc.Spec.Name, err)
 	}
 
-	v.KeepAliveItems.PeerLinkItems.Id = pcName
+	v.KeepAliveItems.PeerLinkItems.ID = pcName
 	v.KeepAliveItems.PeerLinkItems.AdminSt = AdminStEnabled
 	if vpcdomain.Spec.Peer.AdminState == v1alpha1.AdminStateDown {
 		v.KeepAliveItems.PeerLinkItems.AdminSt = AdminStDisabled

--- a/internal/provider/cisco/nxos/snmp_test.go
+++ b/internal/provider/cisco/nxos/snmp_test.go
@@ -12,7 +12,7 @@ func init() {
 		NotifType: "traps",
 		Version:   "v2c",
 	}
-	vrf := &SNMPHostVrf{Vrfname: "management"}
+	vrf := &SNMPHostVrf{Vrfname: ManagementVRFName}
 	host.UsevrfItems.UseVrfList.Set(vrf)
 
 	hosts := &SNMPHostItems{}

--- a/internal/provider/cisco/nxos/syslog_test.go
+++ b/internal/provider/cisco/nxos/syslog_test.go
@@ -15,7 +15,7 @@ func init() {
 		Port:               514,
 		Severity:           Informational,
 		Transport:          "udp",
-		VrfName:            "management",
+		VrfName:            ManagementVRFName,
 	})
 	Register("syslog_remote", reItems)
 

--- a/internal/provider/cisco/nxos/vpc.go
+++ b/internal/provider/cisco/nxos/vpc.go
@@ -39,7 +39,7 @@ type VPCDomain struct {
 		VRF           string `json:"vrf"`
 		PeerLinkItems struct {
 			AdminSt AdminSt `json:"adminSt"`
-			Id      string  `json:"id"`
+			ID      string  `json:"id"`
 		} `json:"peerlink-items,omitzero"`
 	} `json:"keepalive-items,omitzero"`
 }
@@ -62,7 +62,7 @@ func (*VPCDomainOper) XPath() string {
 	return "System/vpc-items/inst-items/dom-items"
 }
 
-// VPCRole represents the role of a vPC peer.
+// VPCDomainRole represents the role of a vPC peer.
 type VPCDomainRole string
 
 const (

--- a/internal/provider/cisco/nxos/vpc_test.go
+++ b/internal/provider/cisco/nxos/vpc_test.go
@@ -20,9 +20,9 @@ func init() {
 	}
 	vd.KeepAliveItems.DestIP = "10.114.235.156"
 	vd.KeepAliveItems.SrcIP = "10.114.235.155"
-	vd.KeepAliveItems.VRF = "management"
+	vd.KeepAliveItems.VRF = ManagementVRFName
 	vd.KeepAliveItems.PeerLinkItems.AdminSt = AdminStEnabled
-	vd.KeepAliveItems.PeerLinkItems.Id = "po1"
+	vd.KeepAliveItems.PeerLinkItems.ID = "po1"
 	Register("vpc_domain", vd)
 
 	vi := &VPCIf{ID: 10}

--- a/internal/provider/cisco/nxos/vrf.go
+++ b/internal/provider/cisco/nxos/vrf.go
@@ -6,7 +6,10 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/gnmiext/v2"
 )
 
-const DefaultVRFName = "default"
+const (
+	DefaultVRFName    = "default"
+	ManagementVRFName = "management"
+)
 
 var _ gnmiext.Configurable = (*VRF)(nil)
 


### PR DESCRIPTION
This patch defaults the vrf to use for the keepalive link of the `VPCDomain` in Cisco NX-OS to use the "management" vrf. This reflects the default used by the device[^1].

[^1]: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/106x/configuration/interfaces/cisco-nexus-9000-series-nx-os-interfaces-configuration-guide-release-106x/m_configuring_vpcs_9x.html#:~:text=the%20system%20uses%20the%20management%20VRF%20by%20default