### PR TITLE
Add peer interface annotation for physical interfaces

### DIFF
--- a/api/core/v1alpha1/groupversion_info.go
+++ b/api/core/v1alpha1/groupversion_info.go
@@ -63,6 +63,22 @@ const VRFLabel = "networking.metal.ironcore.dev/vrf-name"
 // to trigger certain disruptive operations, such as reboots or firmware upgrades.
 const DeviceMaintenanceAnnotation = "networking.metal.ironcore.dev/maintenance"
 
+// PhysicalInterfaceNeighborLabel identifies the peer Interface resource on the other end of a physical link.
+// The value must be the name of another Interface resource in the same namespace.
+// This label is only valid for interfaces of type Physical.
+// For peers that are not managed as Interface resources, use PhysicalInterfaceNeighborRawAnnotation instead.
+const PhysicalInterfaceNeighborLabel = "networking.metal.ironcore.dev/interface-neighbor"
+
+// PhysicalInterfaceNeighborRawAnnotation stores raw neighbor identification for interfaces
+// connected to unmanaged devices (devices without an Interface resource).
+// The value format is "chassisID::portID" where:
+//   - chassisID: The LLDP chassis identifier (MAC address or system name)
+//   - portID: The LLDP port identifier (interface name, alias, or MAC address)
+//
+// Example: "00:1a:2b:3c:4d:5e::Ethernet1/1" or "spine-switch-01::Ethernet48"
+// This annotation is only valid for interfaces of type Physical.
+const PhysicalInterfaceNeighborRawAnnotation = "networking.metal.ironcore.dev/interface-neighbor-raw"
+
 // Device maintenance actions that can be requested via the DeviceMaintenanceAnnotation.
 const (
 	// DeviceMaintenanceReboot requests a device reboot.

--- a/internal/webhook/core/v1alpha1/interface_webhook.go
+++ b/internal/webhook/core/v1alpha1/interface_webhook.go
@@ -67,11 +67,65 @@ func (v *InterfaceCustomValidator) ValidateDelete(ctx context.Context, obj runti
 
 // validateInterfaceSpec performs validation on the Interface spec.
 func validateInterfaceSpec(intf *v1alpha1.Interface) error {
-	if intf.Spec.IPv4 == nil {
+	var errAgg []error
+
+	if err := validatePhysicalInterfaceNeighborLabel(intf); err != nil {
+		errAgg = append(errAgg, err)
+	}
+
+	if err := validatePhysicalInterfaceNeighborRawAnnotation(intf); err != nil {
+		errAgg = append(errAgg, err)
+	}
+
+	if err := validatePhysicalInterfaceNeighborMutualExclusion(intf); err != nil {
+		errAgg = append(errAgg, err)
+	}
+
+	if intf.Spec.IPv4 != nil {
+		if err := validateInterfaceIPv4(intf.Spec.IPv4); err != nil {
+			errAgg = append(errAgg, err)
+		}
+	}
+
+	return errors.Join(errAgg...)
+}
+
+// validatePhysicalInterfaceNeighborLabel validates that the PhysicalInterfaceNeighborLabel is only used on Physical interfaces.
+func validatePhysicalInterfaceNeighborLabel(intf *v1alpha1.Interface) error {
+	if _, ok := intf.Labels[v1alpha1.PhysicalInterfaceNeighborLabel]; !ok {
 		return nil
 	}
 
-	return validateInterfaceIPv4(intf.Spec.IPv4)
+	if intf.Spec.Type != v1alpha1.InterfaceTypePhysical {
+		return fmt.Errorf("label %q is only valid for interfaces of type %s, but interface has type %s", v1alpha1.PhysicalInterfaceNeighborLabel, v1alpha1.InterfaceTypePhysical, intf.Spec.Type)
+	}
+
+	return nil
+}
+
+// validatePhysicalInterfaceNeighborRawAnnotation validates that the PhysicalInterfaceNeighborRawAnnotation is only used on Physical interfaces.
+func validatePhysicalInterfaceNeighborRawAnnotation(intf *v1alpha1.Interface) error {
+	if _, ok := intf.Annotations[v1alpha1.PhysicalInterfaceNeighborRawAnnotation]; !ok {
+		return nil
+	}
+
+	if intf.Spec.Type != v1alpha1.InterfaceTypePhysical {
+		return fmt.Errorf("annotation %q is only valid for interfaces of type %s, but interface has type %s", v1alpha1.PhysicalInterfaceNeighborRawAnnotation, v1alpha1.InterfaceTypePhysical, intf.Spec.Type)
+	}
+
+	return nil
+}
+
+// validatePhysicalInterfaceNeighborMutualExclusion validates that only one of the neighbor label or raw annotation is set.
+func validatePhysicalInterfaceNeighborMutualExclusion(intf *v1alpha1.Interface) error {
+	_, hasLabel := intf.Labels[v1alpha1.PhysicalInterfaceNeighborLabel]
+	_, hasRawAnnotation := intf.Annotations[v1alpha1.PhysicalInterfaceNeighborRawAnnotation]
+
+	if hasLabel && hasRawAnnotation {
+		return fmt.Errorf("cannot set both %q label and %q annotation on the same interface", v1alpha1.PhysicalInterfaceNeighborLabel, v1alpha1.PhysicalInterfaceNeighborRawAnnotation)
+	}
+
+	return nil
 }
 
 // validateInterfaceIPv4 performs validation on the InterfaceIPv4 spec.

--- a/internal/webhook/core/v1alpha1/interface_webhook_test.go
+++ b/internal/webhook/core/v1alpha1/interface_webhook_test.go
@@ -90,5 +90,81 @@ var _ = Describe("Interface Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("overlaps with"))
 		})
+
+		It("Should allow interface-neighbor label on Physical interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Labels = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborLabel: "peer-interface",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should reject interface-neighbor label on Loopback interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypeLoopback
+			obj.Labels = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborLabel: "peer-interface",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should reject interface-neighbor label on Aggregate interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypeAggregate
+			obj.Labels = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborLabel: "peer-interface",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should reject interface-neighbor label on RoutedVLAN interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypeRoutedVLAN
+			obj.Labels = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborLabel: "peer-interface",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should allow interface-neighbor-raw annotation on Physical interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Annotations = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborRawAnnotation: "spine-switch-01::Ethernet48",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should reject interface-neighbor-raw annotation on Loopback interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypeLoopback
+			obj.Annotations = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborRawAnnotation: "spine-switch-01::Ethernet48",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should reject interface-neighbor-raw annotation on Aggregate interfaces", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypeAggregate
+			obj.Annotations = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborRawAnnotation: "spine-switch-01::Ethernet48",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should reject setting both interface-neighbor label and interface-neighbor-raw annotation", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Labels = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborLabel: "peer-interface",
+			}
+			obj.Annotations = map[string]string{
+				v1alpha1.PhysicalInterfaceNeighborRawAnnotation: "spine-switch-01::Ethernet48",
+			}
+			_, err := validator.ValidateCreate(context.Background(), obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot set both"))
+		})
 	})
 })


### PR DESCRIPTION
This patch introduces the `PhysicalInterfaceNeighborLabel` label which
references the peer Interface resource on the other end of a physical
link. The label can be used by users to declare expected cabling, or
by controllers to reflect actual cabling discovered via neighbor
discovery protocols (e.g., LLDP).

The label value must be the name of another Interface resource in the
same namespace. It is only valid for interfaces of type Physical.

Additionally, a `PhysicalInterfaceNeighborRawAnnotation` annotation is
introduced for interfaces connected to unmanaged devices (devices
without an Interface resource). The annotation value format is
"chassisID::portID" where chassisID is the LLDP chassis identifier
and portID is the LLDP port identifier.

Both the label and annotation are mutually exclusive - an interface
cannot have both set at the same time.