### PR TITLE
[NXOS] Fix `vrf` address family entries

### DIFF
--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -2149,33 +2149,33 @@ func (p *Provider) EnsureVRF(ctx context.Context, req *provider.VRFRequest) erro
 	}
 
 	if len(req.VRF.Spec.RouteTargets) > 0 {
-		// Helper to add an AF with import/export entries
-		addAF := func(afType1, afType2 AddressFamily, importE, exportE *RttEntry) {
+		// Initialize address families
+		afIPv4 := &VRFDomAf{Type: AddressFamilyIPv4Unicast}
+		afIPv6 := &VRFDomAf{Type: AddressFamilyIPv6Unicast}
+
+		addAF := func(af *VRFDomAf, afType AddressFamily, importE, exportE *RttEntry) {
 			if importE.EntItems.RttEntryList.Len() == 0 && exportE.EntItems.RttEntryList.Len() == 0 {
 				return
 			}
 
-			af := new(VRFDomAf)
-			af.Type = afType1
-
-			ctrl := new(VRFDomAfCtrl)
-			ctrl.Type = afType2
-
+			ctrl := &VRFDomAfCtrl{Type: afType}
 			if importE.EntItems.RttEntryList.Len() > 0 {
 				ctrl.RttpItems.RttPList.Set(importE)
 			}
 			if exportE.EntItems.RttEntryList.Len() > 0 {
 				ctrl.RttpItems.RttPList.Set(exportE)
 			}
-
 			af.CtrlItems.AfCtrlList.Set(ctrl)
-			dom.AfItems.DomAfList.Set(af)
 		}
 
-		addAF(AddressFamilyIPv4Unicast, AddressFamilyIPv4Unicast, importEntryIPv4, exportEntryIPv4)
-		addAF(AddressFamilyIPv6Unicast, AddressFamilyIPv6Unicast, importEntryIPv6, exportEntryIPv6)
-		addAF(AddressFamilyIPv4Unicast, AddressFamilyL2EVPN, importEntryIPv4EVPN, exportEntryIPv4EVPN)
-		addAF(AddressFamilyIPv6Unicast, AddressFamilyL2EVPN, importEntryIPv6EVPN, exportEntryIPv6EVPN)
+		addAF(afIPv4, AddressFamilyIPv4Unicast, importEntryIPv4, exportEntryIPv4)
+		addAF(afIPv4, AddressFamilyL2EVPN, importEntryIPv4EVPN, exportEntryIPv4EVPN)
+
+		addAF(afIPv6, AddressFamilyIPv6Unicast, importEntryIPv6, exportEntryIPv6)
+		addAF(afIPv6, AddressFamilyL2EVPN, importEntryIPv6EVPN, exportEntryIPv6EVPN)
+
+		dom.AfItems.DomAfList.Set(afIPv4)
+		dom.AfItems.DomAfList.Set(afIPv6)
 	}
 
 	return p.Update(ctx, v)

--- a/internal/provider/cisco/nxos/testdata/vrf.json
+++ b/internal/provider/cisco/nxos/testdata/vrf.json
@@ -27,6 +27,55 @@
                                   "RttEntry-list": [
                                     {
                                       "rtt": "route-target:as2-nn2:65148:4101"
+                                    },
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:1101"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "import",
+                                "ent-items": {
+                                  "RttEntry-list": [
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:4101"
+                                    },
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:1101"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "ipv4-ucast",
+                          "rttp-items": {
+                            "RttP-list": [
+                              {
+                                "type": "export",
+                                "ent-items": {
+                                  "RttEntry-list": [
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:4101"
+                                    },
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:1101"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "import",
+                                "ent-items": {
+                                  "RttEntry-list": [
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:4101"
+                                    },
+                                    {
+                                      "rtt": "route-target:as2-nn2:65148:1101"
                                     }
                                   ]
                                 }

--- a/internal/provider/cisco/nxos/vrf_test.go
+++ b/internal/provider/cisco/nxos/vrf_test.go
@@ -4,17 +4,41 @@
 package nxos
 
 func init() {
-	rtt := new(RttEntry)
-	rtt.Type = RttEntryTypeExport
-	rtt.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:4101"})
+	// Note: These route targets will be sorted alphabetically in the output
+	rttExportEvpn := new(RttEntry)
+	rttExportEvpn.Type = RttEntryTypeExport
+	rttExportEvpn.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:4101"})
+	rttExportEvpn.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:1101"})
 
-	ctrl := new(VRFDomAfCtrl)
-	ctrl.Type = AddressFamilyL2EVPN
-	ctrl.RttpItems.RttPList.Set(rtt)
+	rttImportEvpn := new(RttEntry)
+	rttImportEvpn.Type = RttEntryTypeImport
+	rttImportEvpn.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:4101"})
+	rttImportEvpn.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:1101"})
+
+	ctrlEvpn := new(VRFDomAfCtrl)
+	ctrlEvpn.Type = AddressFamilyL2EVPN
+	ctrlEvpn.RttpItems.RttPList.Set(rttExportEvpn)
+	ctrlEvpn.RttpItems.RttPList.Set(rttImportEvpn)
+
+	rttExportIpv4 := new(RttEntry)
+	rttExportIpv4.Type = RttEntryTypeExport
+	rttExportIpv4.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:4101"})
+	rttExportIpv4.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:1101"})
+
+	rttImportIpv4 := new(RttEntry)
+	rttImportIpv4.Type = RttEntryTypeImport
+	rttImportIpv4.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:4101"})
+	rttImportIpv4.EntItems.RttEntryList.Set(&Rtt{Rtt: "route-target:as2-nn2:65148:1101"})
+
+	ctrlIpv4 := new(VRFDomAfCtrl)
+	ctrlIpv4.Type = AddressFamilyIPv4Unicast
+	ctrlIpv4.RttpItems.RttPList.Set(rttExportIpv4)
+	ctrlIpv4.RttpItems.RttPList.Set(rttImportIpv4)
 
 	af := new(VRFDomAf)
 	af.Type = AddressFamilyIPv4Unicast
-	af.CtrlItems.AfCtrlList.Set(ctrl)
+	af.CtrlItems.AfCtrlList.Set(ctrlEvpn)
+	af.CtrlItems.AfCtrlList.Set(ctrlIpv4)
 
 	dom := new(VRFDom)
 	dom.Name = "CC-CLOUD01"


### PR DESCRIPTION
* We overwrote parts of the model leading to missing entries. We now initialize parts of the tree before appending entries.
* Updated test initialization to match test data