### PR TITLE
Rename reset-phase-to-provisioning to reset-phase and improve documentation

### DIFF
--- a/api/core/v1alpha1/groupversion_info.go
+++ b/api/core/v1alpha1/groupversion_info.go
@@ -70,10 +70,14 @@ const (
 	// DeviceMaintenanceFactoryReset requests a factory reset of the device. A factory reset
 	// will erase all configuration and return the device to its original state.
 	DeviceMaintenanceFactoryReset = "factory-reset"
-	// DeviceMaintenanceReprovision requests reprovisioning of the device, without completely resetting it.
+	// DeviceMaintenanceReprovision triggers a zero touch provisioning process on the device
+	// without a full factory reset. The provider initiates the provisioning workflow e.g.,
+	// by rebooting into a provisioning image or triggering a provisioning mode.
 	DeviceMaintenanceReprovision = "reprovision"
-	// DeviceMaintenanceResetPhaseToProvisioning requests resetting the device's maintenance phase to "provisioning" without rebooting or preparing the device.
-	DeviceMaintenanceResetPhaseToProvisioning = "reset-phase-to-provisioning"
+	// DeviceMaintenanceResetPhase resets the device's phase to Pending without performing any
+	// device-side operations. This is useful for recovering from terminal states (e.g., Failed)
+	// after manual intervention.
+	DeviceMaintenanceResetPhase = "reset-phase"
 )
 
 // Condition types that are used across different objects.

--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -325,8 +325,11 @@ func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alph
 		return nil
 	}
 	delete(obj.Annotations, v1alpha1.DeviceMaintenanceAnnotation)
+
 	switch action {
 	case v1alpha1.DeviceMaintenanceReboot:
+		// Reboot triggers a device restart. The device remains in its current phase
+		// and will resume normal operation after the reboot completes.
 		r.Recorder.Event(obj, "Normal", "RebootRequested", "Device reboot has been requested")
 		if err := prov.Reboot(ctx, conn); err != nil {
 			conditions.Set(obj, metav1.Condition{
@@ -340,6 +343,8 @@ func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alph
 		}
 
 	case v1alpha1.DeviceMaintenanceFactoryReset:
+		// FactoryReset erases all device configuration and returns it to its original state.
+		// After completion, the device phase is reset to Pending to restart the lifecycle.
 		r.Recorder.Event(obj, "Normal", "FactoryResetRequested", "Device factory reset has been requested")
 		if err := prov.FactoryReset(ctx, conn); err != nil {
 			conditions.Set(obj, metav1.Condition{
@@ -351,28 +356,36 @@ func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alph
 			r.Recorder.Event(obj, "Warning", "FactoryResetFailed", fmt.Sprintf("Device factory reset has failed: %v", err))
 			return fmt.Errorf("failed to reset device to factory defaults: %w", err)
 		}
+		obj.Status.Phase = v1alpha1.DevicePhasePending
 
 	case v1alpha1.DeviceMaintenanceReprovision:
-		r.Recorder.Event(obj, "Normal", "ReprovisioningRequested", "Device reprovisioning has been requested. Preparing the device.")
+		// Reprovision prepares the device for re-provisioning without a full factory reset.
+		// The provider initiates the provisioning process, then the phase is reset to Pending.
+		r.Recorder.Event(obj, "Normal", "ReprovisionRequested", "Device reprovisioning has been requested")
 		if err := prov.Reprovision(ctx, conn); err != nil {
 			conditions.Set(obj, metav1.Condition{
 				Type:    v1alpha1.ReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1alpha1.MaintenanceFailedReason,
-				Message: fmt.Sprintf("Failed to reprovision device: %v", err),
+				Message: fmt.Sprintf("Failed to prepare device for reprovisioning: %v", err),
 			})
-			r.Recorder.Event(obj, "Warning", "ReprovisioningFailed", fmt.Sprintf("Device reprovisioning has failed: %v", err))
-			return fmt.Errorf("failed to reset device to reprovision: %w", err)
+			r.Recorder.Event(obj, "Warning", "ReprovisionFailed", fmt.Sprintf("Device reprovisioning preparation has failed: %v", err))
+			return fmt.Errorf("failed to prepare device for reprovisioning: %w", err)
 		}
 		obj.Status.Phase = v1alpha1.DevicePhasePending
 
-	case v1alpha1.DeviceMaintenanceResetPhaseToProvisioning:
-		r.Recorder.Event(obj, "Normal", "ResetPhaseToProvisioningRequested", "Device phase reset to Pending has been requested.")
+	case v1alpha1.DeviceMaintenanceResetPhase:
+		// Reset phase is a soft reset that only changes the device phase to Pending without
+		// performing any device-side operations. This is useful for recovering from terminal
+		// states (e.g., Failed) after manual intervention.
+		r.Recorder.Event(obj, "Normal", "PhaseReset", "Device phase has been reset to Pending")
 		obj.Status.Phase = v1alpha1.DevicePhasePending
 
 	default:
-		return fmt.Errorf("unknown device action: %s", action)
+		r.Recorder.Event(obj, "Warning", "UnknownMaintenanceAction", "Unknown maintenance action: %s"+action)
+		return fmt.Errorf("unknown maintenance action: %s", action)
 	}
+
 	return nil
 }
 

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Device Controller", func() {
 			}).Should(Succeed())
 		})
 
-		It("Should transition from Running to Provisioning once the reset-phase-to-provisioning annotation is set", func() {
+		It("Should transition from Running to Provisioning once the reset-phase annotation is set", func() {
 			By("Creating a Device")
 			device := &v1alpha1.Device{
 				ObjectMeta: metav1.ObjectMeta{
@@ -280,13 +280,13 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 			}).Should(Succeed())
 
-			By("Adding the reset-phase-to-provisioning annotation to the device")
+			By("Adding the reset-phase annotation to the device")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.Device{}
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				patch := resource.DeepCopy()
 				annotations := make(map[string]string)
-				annotations[v1alpha1.DeviceMaintenanceAnnotation] = v1alpha1.DeviceMaintenanceResetPhaseToProvisioning
+				annotations[v1alpha1.DeviceMaintenanceAnnotation] = v1alpha1.DeviceMaintenanceResetPhase
 				patch.SetAnnotations(annotations)
 				g.Expect(k8sClient.Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
 			}).Should(Succeed())


### PR DESCRIPTION
This patch renames the DeviceMaintenanceResetPhaseToProvisioning constant to DeviceMaintenanceResetPhase for clarity, as it simply resets the phase to Pending without any provisioning-specific behavior. Additionally, inline comments have been added to each maintenance action in the controller to document their purpose and behavior.