### PR TITLE
Register provisioning HTTP server as manager runnable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -612,22 +612,23 @@ func main() {
 
 	// Start provisioning HTTP server if the provisioning provider
 	// is implemented and the port is set to a non-zero value.
+	// The server is added to the manager so it starts after the cache is synced
+	// and shuts down gracefully when the manager stops.
 	provisioningProvider, ok := prov().(provider.ProvisioningProvider)
 	if provisioningHTTPPort != 0 && ok {
-		provisioningServer := provisioning.HTTPServer{
+		provisioningServer := &provisioning.HTTPServer{
 			Client:           mgr.GetClient(),
 			Logger:           klog.NewKlogr().WithName("provisioning"),
 			Recorder:         mgr.GetEventRecorderFor("provisioning"),
 			ValidateSourceIP: provisioningHTTPValidateSourceIP,
 			Provider:         provisioningProvider,
+			Port:             provisioningHTTPPort,
 		}
-		setupLog.Info("Starting provisioning HTTP server", "port", provisioningHTTPPort, "validateSourceIP", provisioningHTTPValidateSourceIP)
-		go func() {
-			if err := provisioningServer.Start(provisioningHTTPPort); err != nil {
-				setupLog.Error(err, "provisioning HTTP server failed")
-				os.Exit(1)
-			}
-		}()
+		setupLog.Info("Adding provisioning HTTP server to manager", "port", provisioningHTTPPort, "validateSourceIP", provisioningHTTPValidateSourceIP)
+		if err := mgr.Add(provisioningServer); err != nil {
+			setupLog.Error(err, "unable to add provisioning server to manager")
+			os.Exit(1)
+		}
 	}
 
 	// +kubebuilder:scaffold:builder

--- a/internal/provisioning/http.go
+++ b/internal/provisioning/http.go
@@ -88,9 +88,10 @@ type HTTPServer struct {
 	Recorder         record.EventRecorder
 	ValidateSourceIP bool
 	Provider         provider.ProvisioningProvider
+	Port             int
 }
 
-func (s *HTTPServer) Start(port int) error {
+func (s *HTTPServer) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/provisioning/status-report", s.HandleStatusReport)
 	mux.HandleFunc("/provisioning/config", s.HandleProvisioningRequest)
@@ -98,11 +99,19 @@ func (s *HTTPServer) Start(port int) error {
 	mux.HandleFunc("/provisioning/mtls-client-ca", s.GetMTLSClientCA)
 
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
+		Addr:    fmt.Sprintf(":%d", s.Port),
 		Handler: mux,
 	}
 
-	s.Logger.Info("Starting provisioning server", "port", port)
+	go func() {
+		<-ctx.Done()
+		s.Logger.Info("Shutting down provisioning server")
+		if err := httpServer.Shutdown(context.Background()); err != nil {
+			s.Logger.Error(err, "Error shutting down provisioning server")
+		}
+	}()
+
+	s.Logger.Info("Starting provisioning server", "port", s.Port)
 
 	err := httpServer.ListenAndServe()
 	if err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
The provisioning HTTP server was previously started in a raw goroutine before mgr.Start(), which meant it could receive requests before the controller-runtime cache had synced. With ReaderFailOnMissingInformer enabled, this caused 'Kind=Device is not cached' errors when devices called the provisioning endpoint during startup.

Register the server via mgr.Add() instead, so it only starts after the cache is fully synced. This also provides graceful shutdown via context cancellation when the manager stops, improving safety with LeaderElectionReleaseOnCancel enabled.

The HTTPServer.Start method now satisfies the manager.Runnable interface (Start(ctx context.Context) error), with Port moved to a struct field.