### PR TITLE
Fix YAML indentation in Helm Chart for v2-alpha plugin

### DIFF
--- a/charts/network-operator/templates/cert-manager/metrics-certs.yaml
+++ b/charts/network-operator/templates/cert-manager/metrics-certs.yaml
@@ -2,19 +2,19 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-certs" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-certs" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    dnsNames:
-        - {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ include "network-operator.namespaceName" $ }}.svc
-        - {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ include "network-operator.namespaceName" $ }}.svc.cluster.local
-    issuerRef:
-        kind: Issuer
-        name: {{ include "network-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
-    secretName: metrics-server-cert
+  dnsNames:
+  - {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ include "network-operator.namespaceName" $ }}.svc
+  - {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ include "network-operator.namespaceName" $ }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "network-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
+  secretName: metrics-server-cert
 {{- end }}

--- a/charts/network-operator/templates/cert-manager/selfsigned-issuer.yaml
+++ b/charts/network-operator/templates/cert-manager/selfsigned-issuer.yaml
@@ -2,13 +2,13 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    selfSigned: {}
+  selfSigned: {}
 {{- end }}

--- a/charts/network-operator/templates/cert-manager/serving-cert.yaml
+++ b/charts/network-operator/templates/cert-manager/serving-cert.yaml
@@ -2,19 +2,19 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    dnsNames:
-        - {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}.{{ .Release.Namespace }}.svc
-        - {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}.{{ .Release.Namespace }}.svc.cluster.local
-    issuerRef:
-        kind: Issuer
-        name: {{ include "network-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
-    secretName: webhook-server-cert
+  dnsNames:
+  - {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}.{{ .Release.Namespace }}.svc
+  - {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "network-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
+  secretName: webhook-server-cert
 {{- end }}

--- a/charts/network-operator/templates/crd/accesscontrollists.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/accesscontrollists.networking.metal.ironcore.dev.yaml
@@ -2,265 +2,270 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: accesscontrollists.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: accesscontrollists.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: AccessControlList
-        listKind: AccessControlListList
-        plural: accesscontrollists
-        shortNames:
-            - acl
-        singular: accesscontrollist
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.name
-              name: ACL
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.entriesSummary
-              name: Entries
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: AccessControlList is the Schema for the accesscontrollists API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: AccessControlList
+    listKind: AccessControlListList
+    plural: accesscontrollists
+    shortNames:
+    - acl
+    singular: accesscontrollist
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: ACL
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.entriesSummary
+      name: Entries
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AccessControlList is the Schema for the accesscontrollists API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            entries:
-                                description: A list of rules/entries to apply.
-                                items:
-                                    properties:
-                                        action:
-                                            description: The forwarding action of the ACL entry.
-                                            enum:
-                                                - Permit
-                                                - Deny
-                                            type: string
-                                        description:
-                                            description: Description provides a human-readable description of the ACL entry.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        destinationAddress:
-                                            description: |-
-                                                Destination IP address prefix. Can be IPv4 or IPv6.
-                                                Use 0.0.0.0/0 (::/0) to represent 'any'.
-                                            format: cidr
-                                            type: string
-                                        protocol:
-                                            default: IP
-                                            description: |-
-                                                The protocol to match. If not specified, defaults to "IP".
-                                                Available options are: ICMP, IP, OSPF, PIM, TCP, UDP.
-                                            enum:
-                                                - ICMP
-                                                - IP
-                                                - OSPF
-                                                - PIM
-                                                - TCP
-                                                - UDP
-                                            type: string
-                                        sequence:
-                                            description: The sequence number of the ACL entry.
-                                            format: int32
-                                            minimum: 1
-                                            type: integer
-                                        sourceAddress:
-                                            description: |-
-                                                Source IP address prefix. Can be IPv4 or IPv6.
-                                                Use 0.0.0.0/0 (::/0) to represent 'any'.
-                                            format: cidr
-                                            type: string
-                                    required:
-                                        - action
-                                        - destinationAddress
-                                        - sequence
-                                        - sourceAddress
-                                    type: object
-                                maxItems: 100
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - sequence
-                                x-kubernetes-list-type: map
-                            name:
-                                description: |-
-                                    Name is the identifier of the AccessControlList on the device.
-                                    Immutable.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Name is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the AccessControlList to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        required:
-                            - deviceRef
-                            - entries
-                            - name
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the AccessControlList.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            entriesSummary:
-                                description: EntriesSummary provides a human-readable summary of the number of ACL entries.
-                                type: string
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              entries:
+                description: A list of rules/entries to apply.
+                items:
+                  properties:
+                    action:
+                      description: The forwarding action of the ACL entry.
+                      enum:
+                      - Permit
+                      - Deny
+                      type: string
+                    description:
+                      description: Description provides a human-readable description
+                        of the ACL entry.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    destinationAddress:
+                      description: |-
+                        Destination IP address prefix. Can be IPv4 or IPv6.
+                        Use 0.0.0.0/0 (::/0) to represent 'any'.
+                      format: cidr
+                      type: string
+                    protocol:
+                      default: IP
+                      description: |-
+                        The protocol to match. If not specified, defaults to "IP".
+                        Available options are: ICMP, IP, OSPF, PIM, TCP, UDP.
+                      enum:
+                      - ICMP
+                      - IP
+                      - OSPF
+                      - PIM
+                      - TCP
+                      - UDP
+                      type: string
+                    sequence:
+                      description: The sequence number of the ACL entry.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    sourceAddress:
+                      description: |-
+                        Source IP address prefix. Can be IPv4 or IPv6.
+                        Use 0.0.0.0/0 (::/0) to represent 'any'.
+                      format: cidr
+                      type: string
+                  required:
+                  - action
+                  - destinationAddress
+                  - sequence
+                  - sourceAddress
+                  type: object
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - sequence
+                x-kubernetes-list-type: map
+              name:
+                description: |-
+                  Name is the identifier of the AccessControlList on the device.
+                  Immutable.
+                maxLength: 63
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Name is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the AccessControlList to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - deviceRef
+            - entries
+            - name
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the AccessControlList.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              entriesSummary:
+                description: EntriesSummary provides a human-readable summary of the
+                  number of ACL entries.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/banners.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/banners.networking.metal.ironcore.dev.yaml
@@ -2,265 +2,272 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: banners.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: banners.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: Banner
-        listKind: BannerList
-        plural: banners
-        singular: banner
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.type
-              name: Type
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: Banner is the Schema for the banners API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: Banner
+    listKind: BannerList
+    plural: banners
+    singular: banner
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Banner is the Schema for the banners API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            message:
-                                description: Message is the banner message to display.
-                                properties:
-                                    configMapRef:
-                                        description: Reference to a ConfigMap containing the template
-                                        properties:
-                                            key:
-                                                description: |-
-                                                    Key is the of the entry in the configmap resource's `data` or `binaryData`
-                                                    field to be used.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            name:
-                                                description: Name is unique within a namespace to reference a configmap resource.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            namespace:
-                                                description: |-
-                                                    Namespace defines the space within which the configmap name must be unique.
-                                                    If omitted, the namespace of the object being reconciled will be used.
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - key
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    inline:
-                                        description: Inline template content
-                                        minLength: 1
-                                        type: string
-                                    secretRef:
-                                        description: Reference to a Secret containing the template
-                                        properties:
-                                            key:
-                                                description: |-
-                                                    Key is the of the entry in the secret resource's `data` or `stringData`
-                                                    field to be used.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            name:
-                                                description: Name is unique within a namespace to reference a secret resource.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            namespace:
-                                                description: |-
-                                                    Namespace defines the space within which the secret name must be unique.
-                                                    If omitted, the namespace of the object being reconciled will be used.
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - key
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                type: object
-                                x-kubernetes-validations:
-                                    - message: exactly one of 'inline', 'secretRef', or 'configMapRef' must be specified
-                                      rule: '[has(self.inline), has(self.secretRef), has(self.configMapRef)].filter(x, x).size() == 1'
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Banner to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type:
-                                default: PreLogin
-                                description: |-
-                                    Type specifies the banner type to configure, either PreLogin or PostLogin.
-                                    Immutable.
-                                enum:
-                                    - PreLogin
-                                    - PostLogin
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Type is immutable
-                                      rule: self == oldSelf
-                        required:
-                            - deviceRef
-                            - message
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Banner.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              message:
+                description: Message is the banner message to display.
+                properties:
+                  configMapRef:
+                    description: Reference to a ConfigMap containing the template
+                    properties:
+                      key:
+                        description: |-
+                          Key is the of the entry in the configmap resource's `data` or `binaryData`
+                          field to be used.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a configmap resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which the configmap name must be unique.
+                          If omitted, the namespace of the object being reconciled will be used.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  inline:
+                    description: Inline template content
+                    minLength: 1
+                    type: string
+                  secretRef:
+                    description: Reference to a Secret containing the template
+                    properties:
+                      key:
+                        description: |-
+                          Key is the of the entry in the secret resource's `data` or `stringData`
+                          field to be used.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a secret resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which the secret name must be unique.
+                          If omitted, the namespace of the object being reconciled will be used.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of 'inline', 'secretRef', or 'configMapRef'
+                    must be specified
+                  rule: '[has(self.inline), has(self.secretRef), has(self.configMapRef)].filter(x,
+                    x).size() == 1'
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Banner to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              type:
+                default: PreLogin
+                description: |-
+                  Type specifies the banner type to configure, either PreLogin or PostLogin.
+                  Immutable.
+                enum:
+                - PreLogin
+                - PostLogin
+                type: string
+                x-kubernetes-validations:
+                - message: Type is immutable
+                  rule: self == oldSelf
+            required:
+            - deviceRef
+            - message
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Banner.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/bgp.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bgp.networking.metal.ironcore.dev.yaml
@@ -2,379 +2,391 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: bgp.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: bgp.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: BGP
-        listKind: BGPList
-        plural: bgp
-        singular: bgp
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.asNumber
-              name: AS Number
-              type: string
-            - jsonPath: .spec.routerId
-              name: Router-ID
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: BGP is the Schema for the bgp API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: BGP
+    listKind: BGPList
+    plural: bgp
+    singular: bgp
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.asNumber
+      name: AS Number
+      type: string
+    - jsonPath: .spec.routerId
+      name: Router-ID
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BGP is the Schema for the bgp API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              addressFamilies:
+                description: AddressFamilies configures supported BGP address families
+                  and their specific settings.
                 properties:
-                    apiVersion:
+                  ipv4Unicast:
+                    description: |-
+                      Ipv4Unicast configures IPv4 unicast address family support.
+                      Enables exchange of IPv4 unicast routes between BGP peers.
+                    properties:
+                      enabled:
                         description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
+                          Enabled determines whether this address family is activated for BGP sessions.
+                          When false, the address family is not negotiated with peers.
+                        type: boolean
+                      multipath:
                         description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                          Multipath configures address family specific multipath behavior.
+                          When specified, overrides global multipath settings for this address family.
                         properties:
-                            addressFamilies:
-                                description: AddressFamilies configures supported BGP address families and their specific settings.
-                                properties:
-                                    ipv4Unicast:
-                                        description: |-
-                                            Ipv4Unicast configures IPv4 unicast address family support.
-                                            Enables exchange of IPv4 unicast routes between BGP peers.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled determines whether this address family is activated for BGP sessions.
-                                                    When false, the address family is not negotiated with peers.
-                                                type: boolean
-                                            multipath:
-                                                description: |-
-                                                    Multipath configures address family specific multipath behavior.
-                                                    When specified, overrides global multipath settings for this address family.
-                                                properties:
-                                                    ebgp:
-                                                        description: Ebgp configures multipath behavior for external BGP (eBGP) paths.
-                                                        properties:
-                                                            allowMultipleAs:
-                                                                description: |-
-                                                                    AllowMultipleAs enables the use of multiple paths with different AS paths for eBGP.
-                                                                    When true, relaxes the requirement that multipath candidates must have identical AS paths.
-                                                                    This corresponds to the "RelaxAs" mode.
-                                                                type: boolean
-                                                            maximumPaths:
-                                                                description: |-
-                                                                    MaximumPaths sets the maximum number of eBGP paths that can be used for multipath load balancing.
-                                                                    Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
-                                                                maximum: 64
-                                                                minimum: 1
-                                                                type: integer
-                                                        type: object
-                                                    enabled:
-                                                        description: |-
-                                                            Enabled determines whether BGP is allowed to use multiple paths for forwarding.
-                                                            When false, BGP will only use a single best path regardless of multiple equal-cost paths.
-                                                        type: boolean
-                                                    ibgp:
-                                                        description: Ibgp configures multipath behavior for internal BGP (iBGP) paths.
-                                                        properties:
-                                                            maximumPaths:
-                                                                description: |-
-                                                                    MaximumPaths sets the maximum number of iBGP paths that can be used for multipath load balancing.
-                                                                    Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
-                                                                maximum: 64
-                                                                minimum: 1
-                                                                type: integer
-                                                        type: object
-                                                type: object
-                                        type: object
-                                    ipv6Unicast:
-                                        description: |-
-                                            Ipv6Unicast configures IPv6 unicast address family support.
-                                            Enables exchange of IPv6 unicast routes between BGP peers.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled determines whether this address family is activated for BGP sessions.
-                                                    When false, the address family is not negotiated with peers.
-                                                type: boolean
-                                            multipath:
-                                                description: |-
-                                                    Multipath configures address family specific multipath behavior.
-                                                    When specified, overrides global multipath settings for this address family.
-                                                properties:
-                                                    ebgp:
-                                                        description: Ebgp configures multipath behavior for external BGP (eBGP) paths.
-                                                        properties:
-                                                            allowMultipleAs:
-                                                                description: |-
-                                                                    AllowMultipleAs enables the use of multiple paths with different AS paths for eBGP.
-                                                                    When true, relaxes the requirement that multipath candidates must have identical AS paths.
-                                                                    This corresponds to the "RelaxAs" mode.
-                                                                type: boolean
-                                                            maximumPaths:
-                                                                description: |-
-                                                                    MaximumPaths sets the maximum number of eBGP paths that can be used for multipath load balancing.
-                                                                    Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
-                                                                maximum: 64
-                                                                minimum: 1
-                                                                type: integer
-                                                        type: object
-                                                    enabled:
-                                                        description: |-
-                                                            Enabled determines whether BGP is allowed to use multiple paths for forwarding.
-                                                            When false, BGP will only use a single best path regardless of multiple equal-cost paths.
-                                                        type: boolean
-                                                    ibgp:
-                                                        description: Ibgp configures multipath behavior for internal BGP (iBGP) paths.
-                                                        properties:
-                                                            maximumPaths:
-                                                                description: |-
-                                                                    MaximumPaths sets the maximum number of iBGP paths that can be used for multipath load balancing.
-                                                                    Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
-                                                                maximum: 64
-                                                                minimum: 1
-                                                                type: integer
-                                                        type: object
-                                                type: object
-                                        type: object
-                                    l2vpnEvpn:
-                                        description: |-
-                                            L2vpnEvpn configures L2VPN EVPN address family support.
-                                            Enables exchange of Ethernet VPN routes for overlay network services.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled determines whether this address family is activated for BGP sessions.
-                                                    When false, the address family is not negotiated with peers.
-                                                type: boolean
-                                            multipath:
-                                                description: |-
-                                                    Multipath configures address family specific multipath behavior.
-                                                    When specified, overrides global multipath settings for this address family.
-                                                properties:
-                                                    ebgp:
-                                                        description: Ebgp configures multipath behavior for external BGP (eBGP) paths.
-                                                        properties:
-                                                            allowMultipleAs:
-                                                                description: |-
-                                                                    AllowMultipleAs enables the use of multiple paths with different AS paths for eBGP.
-                                                                    When true, relaxes the requirement that multipath candidates must have identical AS paths.
-                                                                    This corresponds to the "RelaxAs" mode.
-                                                                type: boolean
-                                                            maximumPaths:
-                                                                description: |-
-                                                                    MaximumPaths sets the maximum number of eBGP paths that can be used for multipath load balancing.
-                                                                    Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
-                                                                maximum: 64
-                                                                minimum: 1
-                                                                type: integer
-                                                        type: object
-                                                    enabled:
-                                                        description: |-
-                                                            Enabled determines whether BGP is allowed to use multiple paths for forwarding.
-                                                            When false, BGP will only use a single best path regardless of multiple equal-cost paths.
-                                                        type: boolean
-                                                    ibgp:
-                                                        description: Ibgp configures multipath behavior for internal BGP (iBGP) paths.
-                                                        properties:
-                                                            maximumPaths:
-                                                                description: |-
-                                                                    MaximumPaths sets the maximum number of iBGP paths that can be used for multipath load balancing.
-                                                                    Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
-                                                                maximum: 64
-                                                                minimum: 1
-                                                                type: integer
-                                                        type: object
-                                                type: object
-                                            routeTargetPolicy:
-                                                description: |-
-                                                    RouteTargetPolicy configures route target filtering behavior for EVPN routes.
-                                                    Controls which routes are retained based on route target matching.
-                                                properties:
-                                                    retainAll:
-                                                        description: RetainAll controls whether all route targets are retained regardless of import policy.
-                                                        type: boolean
-                                                type: object
-                                        type: object
-                                type: object
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether this BGP router is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            asNumber:
-                                anyOf:
-                                    - type: integer
-                                    - type: string
+                          ebgp:
+                            description: Ebgp configures multipath behavior for external
+                              BGP (eBGP) paths.
+                            properties:
+                              allowMultipleAs:
                                 description: |-
-                                    ASNumber is the autonomous system number (ASN) for the BGP router.
-                                    Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
-                                x-kubernetes-int-or-string: true
-                            deviceRef:
+                                  AllowMultipleAs enables the use of multiple paths with different AS paths for eBGP.
+                                  When true, relaxes the requirement that multipath candidates must have identical AS paths.
+                                  This corresponds to the "RelaxAs" mode.
+                                type: boolean
+                              maximumPaths:
                                 description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
+                                  MaximumPaths sets the maximum number of eBGP paths that can be used for multipath load balancing.
+                                  Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
+                                maximum: 64
+                                minimum: 1
+                                type: integer
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled determines whether BGP is allowed to use multiple paths for forwarding.
+                              When false, BGP will only use a single best path regardless of multiple equal-cost paths.
+                            type: boolean
+                          ibgp:
+                            description: Ibgp configures multipath behavior for internal
+                              BGP (iBGP) paths.
+                            properties:
+                              maximumPaths:
                                 description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the BGP to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            routerId:
-                                description: |-
-                                    RouterID is the BGP router identifier, used in BGP messages to identify the originating router.
-                                    Follows dotted quad notation (IPv4 format).
-                                format: ipv4
-                                type: string
-                        required:
-                            - asNumber
-                            - deviceRef
-                            - routerId
+                                  MaximumPaths sets the maximum number of iBGP paths that can be used for multipath load balancing.
+                                  Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
+                                maximum: 64
+                                minimum: 1
+                                type: integer
+                            type: object
                         type: object
-                    status:
+                    type: object
+                  ipv6Unicast:
+                    description: |-
+                      Ipv6Unicast configures IPv6 unicast address family support.
+                      Enables exchange of IPv6 unicast routes between BGP peers.
+                    properties:
+                      enabled:
                         description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                          Enabled determines whether this address family is activated for BGP sessions.
+                          When false, the address family is not negotiated with peers.
+                        type: boolean
+                      multipath:
+                        description: |-
+                          Multipath configures address family specific multipath behavior.
+                          When specified, overrides global multipath settings for this address family.
                         properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the BGP.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
+                          ebgp:
+                            description: Ebgp configures multipath behavior for external
+                              BGP (eBGP) paths.
+                            properties:
+                              allowMultipleAs:
+                                description: |-
+                                  AllowMultipleAs enables the use of multiple paths with different AS paths for eBGP.
+                                  When true, relaxes the requirement that multipath candidates must have identical AS paths.
+                                  This corresponds to the "RelaxAs" mode.
+                                type: boolean
+                              maximumPaths:
+                                description: |-
+                                  MaximumPaths sets the maximum number of eBGP paths that can be used for multipath load balancing.
+                                  Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
+                                maximum: 64
+                                minimum: 1
+                                type: integer
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled determines whether BGP is allowed to use multiple paths for forwarding.
+                              When false, BGP will only use a single best path regardless of multiple equal-cost paths.
+                            type: boolean
+                          ibgp:
+                            description: Ibgp configures multipath behavior for internal
+                              BGP (iBGP) paths.
+                            properties:
+                              maximumPaths:
+                                description: |-
+                                  MaximumPaths sets the maximum number of iBGP paths that can be used for multipath load balancing.
+                                  Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
+                                maximum: 64
+                                minimum: 1
+                                type: integer
+                            type: object
                         type: object
-                required:
-                    - spec
+                    type: object
+                  l2vpnEvpn:
+                    description: |-
+                      L2vpnEvpn configures L2VPN EVPN address family support.
+                      Enables exchange of Ethernet VPN routes for overlay network services.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled determines whether this address family is activated for BGP sessions.
+                          When false, the address family is not negotiated with peers.
+                        type: boolean
+                      multipath:
+                        description: |-
+                          Multipath configures address family specific multipath behavior.
+                          When specified, overrides global multipath settings for this address family.
+                        properties:
+                          ebgp:
+                            description: Ebgp configures multipath behavior for external
+                              BGP (eBGP) paths.
+                            properties:
+                              allowMultipleAs:
+                                description: |-
+                                  AllowMultipleAs enables the use of multiple paths with different AS paths for eBGP.
+                                  When true, relaxes the requirement that multipath candidates must have identical AS paths.
+                                  This corresponds to the "RelaxAs" mode.
+                                type: boolean
+                              maximumPaths:
+                                description: |-
+                                  MaximumPaths sets the maximum number of eBGP paths that can be used for multipath load balancing.
+                                  Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
+                                maximum: 64
+                                minimum: 1
+                                type: integer
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled determines whether BGP is allowed to use multiple paths for forwarding.
+                              When false, BGP will only use a single best path regardless of multiple equal-cost paths.
+                            type: boolean
+                          ibgp:
+                            description: Ibgp configures multipath behavior for internal
+                              BGP (iBGP) paths.
+                            properties:
+                              maximumPaths:
+                                description: |-
+                                  MaximumPaths sets the maximum number of iBGP paths that can be used for multipath load balancing.
+                                  Valid range is 1-64 when specified. When omitted, no explicit limit is configured.
+                                maximum: 64
+                                minimum: 1
+                                type: integer
+                            type: object
+                        type: object
+                      routeTargetPolicy:
+                        description: |-
+                          RouteTargetPolicy configures route target filtering behavior for EVPN routes.
+                          Controls which routes are retained based on route target matching.
+                        properties:
+                          retainAll:
+                            description: RetainAll controls whether all route targets
+                              are retained regardless of import policy.
+                            type: boolean
+                        type: object
+                    type: object
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+              adminState:
+                default: Up
+                description: AdminState indicates whether this BGP router is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              asNumber:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  ASNumber is the autonomous system number (ASN) for the BGP router.
+                  Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                x-kubernetes-int-or-string: true
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the BGP to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              routerId:
+                description: |-
+                  RouterID is the BGP router identifier, used in BGP messages to identify the originating router.
+                  Follows dotted quad notation (IPv4 format).
+                format: ipv4
+                type: string
+            required:
+            - asNumber
+            - deviceRef
+            - routerId
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the BGP.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/bgppeers.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bgppeers.networking.metal.ironcore.dev.yaml
@@ -2,415 +2,422 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: bgppeers.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: bgppeers.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: BGPPeer
-        listKind: BGPPeerList
-        plural: bgppeers
-        shortNames:
-            - peer
-            - bgpneighbor
-        singular: bgppeer
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.address
-              name: Peer Address
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.asNumber
-              name: AS Number
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Configured")].status
-              name: Configured
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Operational")].status
-              name: Operational
-              priority: 1
-              type: string
-            - jsonPath: .status.sessionState
-              name: Session State
-              priority: 1
-              type: string
-            - jsonPath: .status.lastEstablishedTime
-              name: Last Established
-              priority: 1
-              type: date
-            - jsonPath: .status.advertisedPrefixesSummary
-              name: Advertised Prefixes
-              priority: 1
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: BGPPeer is the Schema for the bgppeers API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    shortNames:
+    - peer
+    - bgpneighbor
+    singular: bgppeer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.address
+      name: Peer Address
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.asNumber
+      name: AS Number
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Configured")].status
+      name: Configured
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Operational")].status
+      name: Operational
+      priority: 1
+      type: string
+    - jsonPath: .status.sessionState
+      name: Session State
+      priority: 1
+      type: string
+    - jsonPath: .status.lastEstablishedTime
+      name: Last Established
+      priority: 1
+      type: date
+    - jsonPath: .status.advertisedPrefixesSummary
+      name: Advertised Prefixes
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BGPPeer is the Schema for the bgppeers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              address:
+                description: Address is the IPv4 address of the BGP peer.
+                format: ipv4
+                type: string
+              addressFamilies:
+                description: |-
+                  AddressFamilies configures address family specific settings for this BGP peer.
+                  Controls which address families are enabled and their specific configuration.
                 properties:
-                    apiVersion:
+                  ipv4Unicast:
+                    description: |-
+                      Ipv4Unicast configures IPv4 unicast address family settings for this peer.
+                      Controls IPv4 unicast route exchange and peer-specific behavior.
+                    properties:
+                      enabled:
                         description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                          Enabled determines whether this address family is activated for this specific peer.
+                          When false, the address family is not negotiated with this peer.
+                          Defaults to false.
+                        type: boolean
+                      routeReflectorClient:
+                        description: |-
+                          RouteReflectorClient indicates whether this peer should be treated as a route reflector client
+                          for this specific address family. Defaults to false.
+                        type: boolean
+                      sendCommunity:
+                        description: |-
+                          SendCommunity specifies which community attributes should be sent to this BGP peer
+                          for this address family. If not specified, no community attributes are sent.
+                        enum:
+                        - Standard
+                        - Extended
+                        - Both
                         type: string
-                    kind:
+                    type: object
+                  ipv6Unicast:
+                    description: |-
+                      Ipv6Unicast configures IPv6 unicast address family settings for this peer.
+                      Controls IPv6 unicast route exchange and peer-specific behavior.
+                    properties:
+                      enabled:
                         description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          Enabled determines whether this address family is activated for this specific peer.
+                          When false, the address family is not negotiated with this peer.
+                          Defaults to false.
+                        type: boolean
+                      routeReflectorClient:
+                        description: |-
+                          RouteReflectorClient indicates whether this peer should be treated as a route reflector client
+                          for this specific address family. Defaults to false.
+                        type: boolean
+                      sendCommunity:
+                        description: |-
+                          SendCommunity specifies which community attributes should be sent to this BGP peer
+                          for this address family. If not specified, no community attributes are sent.
+                        enum:
+                        - Standard
+                        - Extended
+                        - Both
                         type: string
-                    metadata:
-                        type: object
-                    spec:
+                    type: object
+                  l2vpnEvpn:
+                    description: |-
+                      L2vpnEvpn configures L2VPN EVPN address family settings for this peer.
+                      Controls EVPN route exchange and peer-specific behavior.
+                    properties:
+                      enabled:
                         description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            address:
-                                description: Address is the IPv4 address of the BGP peer.
-                                format: ipv4
-                                type: string
-                            addressFamilies:
-                                description: |-
-                                    AddressFamilies configures address family specific settings for this BGP peer.
-                                    Controls which address families are enabled and their specific configuration.
-                                properties:
-                                    ipv4Unicast:
-                                        description: |-
-                                            Ipv4Unicast configures IPv4 unicast address family settings for this peer.
-                                            Controls IPv4 unicast route exchange and peer-specific behavior.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled determines whether this address family is activated for this specific peer.
-                                                    When false, the address family is not negotiated with this peer.
-                                                    Defaults to false.
-                                                type: boolean
-                                            routeReflectorClient:
-                                                description: |-
-                                                    RouteReflectorClient indicates whether this peer should be treated as a route reflector client
-                                                    for this specific address family. Defaults to false.
-                                                type: boolean
-                                            sendCommunity:
-                                                description: |-
-                                                    SendCommunity specifies which community attributes should be sent to this BGP peer
-                                                    for this address family. If not specified, no community attributes are sent.
-                                                enum:
-                                                    - Standard
-                                                    - Extended
-                                                    - Both
-                                                type: string
-                                        type: object
-                                    ipv6Unicast:
-                                        description: |-
-                                            Ipv6Unicast configures IPv6 unicast address family settings for this peer.
-                                            Controls IPv6 unicast route exchange and peer-specific behavior.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled determines whether this address family is activated for this specific peer.
-                                                    When false, the address family is not negotiated with this peer.
-                                                    Defaults to false.
-                                                type: boolean
-                                            routeReflectorClient:
-                                                description: |-
-                                                    RouteReflectorClient indicates whether this peer should be treated as a route reflector client
-                                                    for this specific address family. Defaults to false.
-                                                type: boolean
-                                            sendCommunity:
-                                                description: |-
-                                                    SendCommunity specifies which community attributes should be sent to this BGP peer
-                                                    for this address family. If not specified, no community attributes are sent.
-                                                enum:
-                                                    - Standard
-                                                    - Extended
-                                                    - Both
-                                                type: string
-                                        type: object
-                                    l2vpnEvpn:
-                                        description: |-
-                                            L2vpnEvpn configures L2VPN EVPN address family settings for this peer.
-                                            Controls EVPN route exchange and peer-specific behavior.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled determines whether this address family is activated for this specific peer.
-                                                    When false, the address family is not negotiated with this peer.
-                                                    Defaults to false.
-                                                type: boolean
-                                            routeReflectorClient:
-                                                description: |-
-                                                    RouteReflectorClient indicates whether this peer should be treated as a route reflector client
-                                                    for this specific address family. Defaults to false.
-                                                type: boolean
-                                            sendCommunity:
-                                                description: |-
-                                                    SendCommunity specifies which community attributes should be sent to this BGP peer
-                                                    for this address family. If not specified, no community attributes are sent.
-                                                enum:
-                                                    - Standard
-                                                    - Extended
-                                                    - Both
-                                                type: string
-                                        type: object
-                                type: object
-                            adminState:
-                                default: Up
-                                description: |-
-                                    AdminState indicates whether this BGP peer is administratively up or down.
-                                    When Down, the BGP session with this peer is administratively shut down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            asNumber:
-                                anyOf:
-                                    - type: integer
-                                    - type: string
-                                description: |-
-                                    ASNumber is the autonomous system number (ASN) of the BGP peer.
-                                    Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
-                                x-kubernetes-int-or-string: true
-                            description:
-                                description: |-
-                                    Description is an optional human-readable description for this BGP peer.
-                                    This field is used for documentation purposes and may be displayed in management interfaces.
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            localAddress:
-                                description: |-
-                                    LocalAddress specifies the local address configuration for the BGP session with this peer.
-                                    This determines the source address/interface for BGP packets sent to this peer.
-                                properties:
-                                    interfaceRef:
-                                        description: |-
-                                            InterfaceRef is a reference to an Interface resource whose IP address will be used
-                                            as the source address for BGP packets sent to this peer.
-                                            The Interface object must exist in the same namespace.
-                                        properties:
-                                            name:
-                                                description: |-
-                                                    Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                required:
-                                    - interfaceRef
-                                type: object
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the BGP to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        required:
-                            - address
-                            - asNumber
-                            - deviceRef
-                        type: object
-                    status:
+                          Enabled determines whether this address family is activated for this specific peer.
+                          When false, the address family is not negotiated with this peer.
+                          Defaults to false.
+                        type: boolean
+                      routeReflectorClient:
                         description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            addressFamilies:
-                                description: |-
-                                    AddressFamilies contains per-address-family statistics for this peer.
-                                    Only address families that are enabled and negotiated with the peer are included.
-                                items:
-                                    description: AddressFamilyStatus defines the prefix exchange statistics for a single address family (e.g., IPv4-Unicast).
-                                    properties:
-                                        acceptedPrefixes:
-                                            description: |-
-                                                AcceptedPrefixes is the number of prefixes received from the peer that have passed the inbound policy
-                                                and are stored in the neighbor-specific table (Adj-RIB-In).
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        advertisedPrefixes:
-                                            description: |-
-                                                AdvertisedPrefixes is the number of prefixes currently being advertised to the peer after passing
-                                                the outbound policy. This reflects the state of the outbound routing table for the peer (Adj-RIB-Out).
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        afiSafi:
-                                            description: AfiSafi identifies the address family and subsequent address family.
-                                            enum:
-                                                - IPv4Unicast
-                                                - IPv6Unicast
-                                                - L2vpnEvpn
-                                            type: string
-                                    required:
-                                        - afiSafi
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - afiSafi
-                                x-kubernetes-list-type: map
-                            advertisedPrefixesSummary:
-                                description: |-
-                                    AdvertisedPrefixesSummary provides a human-readable summary of advertised prefixes
-                                    across all address families (e.g., "10 (IPv4Unicast), 5 (IPv6Unicast)").
-                                    This field is computed by the controller from the AddressFamilies field.
-                                type: string
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the BGP.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            lastEstablishedTime:
-                                description: |-
-                                    LastEstablishedTime is the timestamp when the BGP session last transitioned to the ESTABLISHED state.
-                                    A frequently changing timestamp indicates session instability (flapping).
-                                format: date-time
-                                type: string
-                            observedGeneration:
-                                description: ObservedGeneration reflects the .metadata.generation that was last processed by the controller.
-                                format: int64
-                                type: integer
-                            sessionState:
-                                description: SessionState is the current operational state of the BGP session.
-                                enum:
-                                    - Idle
-                                    - Connect
-                                    - Active
-                                    - OpenSent
-                                    - OpenConfirm
-                                    - Established
-                                    - Unknown
-                                type: string
-                        type: object
-                required:
-                    - spec
+                          RouteReflectorClient indicates whether this peer should be treated as a route reflector client
+                          for this specific address family. Defaults to false.
+                        type: boolean
+                      sendCommunity:
+                        description: |-
+                          SendCommunity specifies which community attributes should be sent to this BGP peer
+                          for this address family. If not specified, no community attributes are sent.
+                        enum:
+                        - Standard
+                        - Extended
+                        - Both
+                        type: string
+                    type: object
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+              adminState:
+                default: Up
+                description: |-
+                  AdminState indicates whether this BGP peer is administratively up or down.
+                  When Down, the BGP session with this peer is administratively shut down.
+                enum:
+                - Up
+                - Down
+                type: string
+              asNumber:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  ASNumber is the autonomous system number (ASN) of the BGP peer.
+                  Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                x-kubernetes-int-or-string: true
+              description:
+                description: |-
+                  Description is an optional human-readable description for this BGP peer.
+                  This field is used for documentation purposes and may be displayed in management interfaces.
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              localAddress:
+                description: |-
+                  LocalAddress specifies the local address configuration for the BGP session with this peer.
+                  This determines the source address/interface for BGP packets sent to this peer.
+                properties:
+                  interfaceRef:
+                    description: |-
+                      InterfaceRef is a reference to an Interface resource whose IP address will be used
+                      as the source address for BGP packets sent to this peer.
+                      The Interface object must exist in the same namespace.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - interfaceRef
+                type: object
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the BGP to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - address
+            - asNumber
+            - deviceRef
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              addressFamilies:
+                description: |-
+                  AddressFamilies contains per-address-family statistics for this peer.
+                  Only address families that are enabled and negotiated with the peer are included.
+                items:
+                  description: AddressFamilyStatus defines the prefix exchange statistics
+                    for a single address family (e.g., IPv4-Unicast).
+                  properties:
+                    acceptedPrefixes:
+                      description: |-
+                        AcceptedPrefixes is the number of prefixes received from the peer that have passed the inbound policy
+                        and are stored in the neighbor-specific table (Adj-RIB-In).
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    advertisedPrefixes:
+                      description: |-
+                        AdvertisedPrefixes is the number of prefixes currently being advertised to the peer after passing
+                        the outbound policy. This reflects the state of the outbound routing table for the peer (Adj-RIB-Out).
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    afiSafi:
+                      description: AfiSafi identifies the address family and subsequent
+                        address family.
+                      enum:
+                      - IPv4Unicast
+                      - IPv6Unicast
+                      - L2vpnEvpn
+                      type: string
+                  required:
+                  - afiSafi
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - afiSafi
+                x-kubernetes-list-type: map
+              advertisedPrefixesSummary:
+                description: |-
+                  AdvertisedPrefixesSummary provides a human-readable summary of advertised prefixes
+                  across all address families (e.g., "10 (IPv4Unicast), 5 (IPv6Unicast)").
+                  This field is computed by the controller from the AddressFamilies field.
+                type: string
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the BGP.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastEstablishedTime:
+                description: |-
+                  LastEstablishedTime is the timestamp when the BGP session last transitioned to the ESTABLISHED state.
+                  A frequently changing timestamp indicates session instability (flapping).
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the .metadata.generation
+                  that was last processed by the controller.
+                format: int64
+                type: integer
+              sessionState:
+                description: SessionState is the current operational state of the
+                  BGP session.
+                enum:
+                - Idle
+                - Connect
+                - Active
+                - OpenSent
+                - OpenConfirm
+                - Established
+                - Unknown
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/bordergateways.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bordergateways.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -2,293 +2,300 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: bordergateways.nx.cisco.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: bordergateways.nx.cisco.networking.metal.ironcore.dev
 spec:
-    group: nx.cisco.networking.metal.ironcore.dev
-    names:
-        kind: BorderGateway
-        listKind: BorderGatewayList
-        plural: bordergateways
-        shortNames:
-            - bgw
-        singular: bordergateway
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.multisiteId
-              name: Multisite-ID
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.sourceInterfaceRef.name
-              name: Source Interface
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: BorderGateway is the Schema for the bordergateways API
+  group: nx.cisco.networking.metal.ironcore.dev
+  names:
+    kind: BorderGateway
+    listKind: BorderGatewayList
+    plural: bordergateways
+    shortNames:
+    - bgw
+    singular: bordergateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.multisiteId
+      name: Multisite-ID
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.sourceInterfaceRef.name
+      name: Source Interface
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BorderGateway is the Schema for the bordergateways API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the BorderGateway instance
+                  is administratively up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              bgpPeerRefs:
+                description: |-
+                  BGPPeerRefs is a list of BGP peers that are part of the border gateway configuration.
+                  Each peer can be configured with a peer type to specify its role in the EVPN multisite topology.
+                items:
+                  description: BGPPeerReference defines a BGP peer used for border
+                    gateway with peer type configuration.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    peerType:
+                      description: |-
+                        PeerType specifies the role of this BGP peer in the EVPN multisite topology.
+                        FabricExternal is used for peers outside the fabric, while FabricBorderLeaf is used
+                        for border leaf peers within the fabric.
+                      enum:
+                      - FabricExternal
+                      - FabricBorderLeaf
+                      type: string
+                  required:
+                  - name
+                  - peerType
+                  type: object
+                  x-kubernetes-map-type: atomic
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              delayRestoreTime:
+                default: 180s
+                description: |-
+                  DelayRestoreTime specifies the time to wait before restoring EVPN multisite border gateway
+                  functionality after a failure. This allows time for the network to stabilize before resuming
+                  traffic forwarding across sites.
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether the BorderGateway instance is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            bgpPeerRefs:
-                                description: |-
-                                    BGPPeerRefs is a list of BGP peers that are part of the border gateway configuration.
-                                    Each peer can be configured with a peer type to specify its role in the EVPN multisite topology.
-                                items:
-                                    description: BGPPeerReference defines a BGP peer used for border gateway with peer type configuration.
-                                    properties:
-                                        name:
-                                            description: |-
-                                                Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        peerType:
-                                            description: |-
-                                                PeerType specifies the role of this BGP peer in the EVPN multisite topology.
-                                                FabricExternal is used for peers outside the fabric, while FabricBorderLeaf is used
-                                                for border leaf peers within the fabric.
-                                            enum:
-                                                - FabricExternal
-                                                - FabricBorderLeaf
-                                            type: string
-                                    required:
-                                        - name
-                                        - peerType
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            delayRestoreTime:
-                                default: 180s
-                                description: |-
-                                    DelayRestoreTime specifies the time to wait before restoring EVPN multisite border gateway
-                                    functionality after a failure. This allows time for the network to stabilize before resuming
-                                    traffic forwarding across sites.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            interconnectInterfaceRefs:
-                                description: |-
-                                    InterconnectInterfaceRefs is a list of interfaces that provide connectivity to the border gateway.
-                                    Each interface can be configured with object tracking to monitor its availability.
-                                items:
-                                    description: |-
-                                        InterconnectInterfaceReference defines an interface used for border gateway interconnectivity
-                                        with optional object tracking configuration.
-                                    properties:
-                                        name:
-                                            description: |-
-                                                Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        tracking:
-                                            description: Tracking specifies the EVPN multisite tracking mode for this interconnect interface.
-                                            enum:
-                                                - DataCenterInterconnect
-                                                - Fabric
-                                            type: string
-                                    required:
-                                        - name
-                                        - tracking
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            multisiteId:
-                                description: MultisiteID is the identifier for the multisite border gateway.
-                                format: int64
-                                maximum: 281474976710655
-                                minimum: 1
-                                type: integer
-                            sourceInterfaceRef:
-                                description: |-
-                                    SourceInterfaceRef is a reference to the loopback interface used as the source for the
-                                    border gateway virtual IP address. A best practice is to use a separate loopback address
-                                    for the NVE source interface and multi-site source interface. The loopback interface must
-                                    be configured with a /32 IPv4 address. This /32 IP address needs be known by the transient
-                                    devices in the transport network and the remote VTEPs.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            stormControl:
-                                description: |-
-                                    StormControl is the storm control configuration for the border gateway, allowing to rate-limit
-                                    BUM (Broadcast, Unknown unicast, Multicast) traffic on the border gateway interface.
-                                items:
-                                    properties:
-                                        level:
-                                            description: |-
-                                                Level is the suppression level as a percentage of the interface bandwidth.
-                                                Must be a floating point number between 1.0 and 100.0.
-                                            pattern: ^([1-9][0-9]?(\.[0-9]+)?|100(\.0+)?)$
-                                            type: string
-                                        traffic:
-                                            description: Traffic specifies the type of BUM traffic the storm control applies to.
-                                            enum:
-                                                - Broadcast
-                                                - Multicast
-                                                - Unicast
-                                            type: string
-                                    required:
-                                        - level
-                                        - traffic
-                                    type: object
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - traffic
-                                x-kubernetes-list-type: map
-                        required:
-                            - deviceRef
-                            - multisiteId
-                            - sourceInterfaceRef
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Banner.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              interconnectInterfaceRefs:
+                description: |-
+                  InterconnectInterfaceRefs is a list of interfaces that provide connectivity to the border gateway.
+                  Each interface can be configured with object tracking to monitor its availability.
+                items:
+                  description: |-
+                    InterconnectInterfaceReference defines an interface used for border gateway interconnectivity
+                    with optional object tracking configuration.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tracking:
+                      description: Tracking specifies the EVPN multisite tracking
+                        mode for this interconnect interface.
+                      enum:
+                      - DataCenterInterconnect
+                      - Fabric
+                      type: string
+                  required:
+                  - name
+                  - tracking
+                  type: object
+                  x-kubernetes-map-type: atomic
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              multisiteId:
+                description: MultisiteID is the identifier for the multisite border
+                  gateway.
+                format: int64
+                maximum: 281474976710655
+                minimum: 1
+                type: integer
+              sourceInterfaceRef:
+                description: |-
+                  SourceInterfaceRef is a reference to the loopback interface used as the source for the
+                  border gateway virtual IP address. A best practice is to use a separate loopback address
+                  for the NVE source interface and multi-site source interface. The loopback interface must
+                  be configured with a /32 IPv4 address. This /32 IP address needs be known by the transient
+                  devices in the transport network and the remote VTEPs.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              stormControl:
+                description: |-
+                  StormControl is the storm control configuration for the border gateway, allowing to rate-limit
+                  BUM (Broadcast, Unknown unicast, Multicast) traffic on the border gateway interface.
+                items:
+                  properties:
+                    level:
+                      description: |-
+                        Level is the suppression level as a percentage of the interface bandwidth.
+                        Must be a floating point number between 1.0 and 100.0.
+                      pattern: ^([1-9][0-9]?(\.[0-9]+)?|100(\.0+)?)$
+                      type: string
+                    traffic:
+                      description: Traffic specifies the type of BUM traffic the storm
+                        control applies to.
+                      enum:
+                      - Broadcast
+                      - Multicast
+                      - Unicast
+                      type: string
+                  required:
+                  - level
+                  - traffic
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - traffic
+                x-kubernetes-list-type: map
+            required:
+            - deviceRef
+            - multisiteId
+            - sourceInterfaceRef
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Banner.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/certificates.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/certificates.networking.metal.ironcore.dev.yaml
@@ -2,223 +2,227 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: certificates.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: certificates.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: Certificate
-        listKind: CertificateList
-        plural: certificates
-        shortNames:
-            - cert
-            - netcert
-        singular: certificate
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.id
-              name: Certificate
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: Certificate is the Schema for the certificates API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    - netcert
+    singular: certificate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.id
+      name: Certificate
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Certificate is the Schema for the certificates API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            id:
-                                description: |-
-                                    The certificate management id.
-                                    Immutable.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: ID is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Certificate to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            secretRef:
-                                description: |-
-                                    Secret containing the certificate source.
-                                    The secret must be of type kubernetes.io/tls and as such contain the following keys: 'tls.crt' and 'tls.key'.
-                                properties:
-                                    name:
-                                        description: Name is unique within a namespace to reference a secret resource.
-                                        maxLength: 253
-                                        minLength: 1
-                                        type: string
-                                    namespace:
-                                        description: |-
-                                            Namespace defines the space within which the secret name must be unique.
-                                            If omitted, the namespace of the object being reconciled will be used.
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        required:
-                            - deviceRef
-                            - id
-                            - secretRef
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Certificate.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              id:
+                description: |-
+                  The certificate management id.
+                  Immutable.
+                maxLength: 63
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: ID is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Certificate to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              secretRef:
+                description: |-
+                  Secret containing the certificate source.
+                  The secret must be of type kubernetes.io/tls and as such contain the following keys: 'tls.crt' and 'tls.key'.
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace defines the space within which the secret name must be unique.
+                      If omitted, the namespace of the object being reconciled will be used.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - deviceRef
+            - id
+            - secretRef
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Certificate.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/devices.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/devices.networking.metal.ironcore.dev.yaml
@@ -2,442 +2,464 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: devices.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: devices.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: Device
-        listKind: DeviceList
-        plural: devices
-        shortNames:
-            - dev
-        singular: device
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.endpoint.address
-              name: Endpoint
-              type: string
-            - jsonPath: .status.manufacturer
-              name: Manufacturer
-              priority: 1
-              type: string
-            - jsonPath: .status.model
-              name: Model
-              priority: 1
-              type: string
-            - jsonPath: .status.serialNumber
-              name: SerialNumber
-              priority: 1
-              type: string
-            - jsonPath: .status.firmwareVersion
-              name: FirmwareVersion
-              priority: 1
-              type: string
-            - jsonPath: .status.portSummary
-              name: Ports
-              priority: 1
-              type: string
-            - jsonPath: .status.phase
-              name: Phase
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: Device is the Schema for the devices API.
+  group: networking.metal.ironcore.dev
+  names:
+    kind: Device
+    listKind: DeviceList
+    plural: devices
+    shortNames:
+    - dev
+    singular: device
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint.address
+      name: Endpoint
+      type: string
+    - jsonPath: .status.manufacturer
+      name: Manufacturer
+      priority: 1
+      type: string
+    - jsonPath: .status.model
+      name: Model
+      priority: 1
+      type: string
+    - jsonPath: .status.serialNumber
+      name: SerialNumber
+      priority: 1
+      type: string
+    - jsonPath: .status.firmwareVersion
+      name: FirmwareVersion
+      priority: 1
+      type: string
+    - jsonPath: .status.portSummary
+      name: Ports
+      priority: 1
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Device is the Schema for the devices API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              endpoint:
+                description: Endpoint contains the connection information for the
+                  device.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  address:
+                    description: Address is the management address of the device provided
+                      in IP:Port format.
+                    pattern: ^(\d{1,3}\.){3}\d{1,3}:\d{1,5}$
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef is name of the authentication secret for the device containing the username and password.
+                      The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
+                    properties:
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a secret resource.
+                        maxLength: 253
+                        minLength: 1
                         type: string
-                    kind:
+                      namespace:
                         description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          Namespace defines the space within which the secret name must be unique.
+                          If omitted, the namespace of the object being reconciled will be used.
+                        maxLength: 63
+                        minLength: 1
                         type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  tls:
+                    description: Transport credentials for grpc connection to the
+                      switch.
+                    properties:
+                      ca:
+                        description: The CA certificate to verify the server's identity.
                         properties:
-                            endpoint:
-                                description: Endpoint contains the connection information for the device.
-                                properties:
-                                    address:
-                                        description: Address is the management address of the device provided in IP:Port format.
-                                        pattern: ^(\d{1,3}\.){3}\d{1,3}:\d{1,5}$
-                                        type: string
-                                    secretRef:
-                                        description: |-
-                                            SecretRef is name of the authentication secret for the device containing the username and password.
-                                            The secret must be of type kubernetes.io/basic-auth and as such contain the following keys: 'username' and 'password'.
-                                        properties:
-                                            name:
-                                                description: Name is unique within a namespace to reference a secret resource.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            namespace:
-                                                description: |-
-                                                    Namespace defines the space within which the secret name must be unique.
-                                                    If omitted, the namespace of the object being reconciled will be used.
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    tls:
-                                        description: Transport credentials for grpc connection to the switch.
-                                        properties:
-                                            ca:
-                                                description: The CA certificate to verify the server's identity.
-                                                properties:
-                                                    key:
-                                                        description: |-
-                                                            Key is the of the entry in the secret resource's `data` or `stringData`
-                                                            field to be used.
-                                                        maxLength: 253
-                                                        minLength: 1
-                                                        type: string
-                                                    name:
-                                                        description: Name is unique within a namespace to reference a secret resource.
-                                                        maxLength: 253
-                                                        minLength: 1
-                                                        type: string
-                                                    namespace:
-                                                        description: |-
-                                                            Namespace defines the space within which the secret name must be unique.
-                                                            If omitted, the namespace of the object being reconciled will be used.
-                                                        maxLength: 63
-                                                        minLength: 1
-                                                        type: string
-                                                required:
-                                                    - key
-                                                    - name
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                            certificate:
-                                                description: |-
-                                                    The client certificate and private key to use for mutual TLS authentication.
-                                                    Leave empty if mTLS is not desired.
-                                                properties:
-                                                    secretRef:
-                                                        description: |-
-                                                            Secret containing the certificate.
-                                                            The secret must be of type kubernetes.io/tls and as such contain the following keys: 'tls.crt' and 'tls.key'.
-                                                        properties:
-                                                            name:
-                                                                description: Name is unique within a namespace to reference a secret resource.
-                                                                maxLength: 253
-                                                                minLength: 1
-                                                                type: string
-                                                            namespace:
-                                                                description: |-
-                                                                    Namespace defines the space within which the secret name must be unique.
-                                                                    If omitted, the namespace of the object being reconciled will be used.
-                                                                maxLength: 63
-                                                                minLength: 1
-                                                                type: string
-                                                        required:
-                                                            - name
-                                                        type: object
-                                                        x-kubernetes-map-type: atomic
-                                                required:
-                                                    - secretRef
-                                                type: object
-                                        required:
-                                            - ca
-                                        type: object
-                                required:
-                                    - address
-                                type: object
-                                x-kubernetes-validations:
-                                    - message: SecretRef is required once set
-                                      rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
-                            provisioning:
+                          key:
+                            description: |-
+                              Key is the of the entry in the secret resource's `data` or `stringData`
+                              field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace defines the space within which the secret name must be unique.
+                              If omitted, the namespace of the object being reconciled will be used.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      certificate:
+                        description: |-
+                          The client certificate and private key to use for mutual TLS authentication.
+                          Leave empty if mTLS is not desired.
+                        properties:
+                          secretRef:
+                            description: |-
+                              Secret containing the certificate.
+                              The secret must be of type kubernetes.io/tls and as such contain the following keys: 'tls.crt' and 'tls.key'.
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
                                 description: |-
-                                    Provisioning is an optional configuration for the device provisioning process.
-                                    It can be used to provide initial configuration templates or scripts that are applied during the device provisioning.
-                                properties:
-                                    bootScript:
-                                        description: BootScript defines the script delivered by a TFTP server to the device during bootstrapping.
-                                        properties:
-                                            configMapRef:
-                                                description: Reference to a ConfigMap containing the template
-                                                properties:
-                                                    key:
-                                                        description: |-
-                                                            Key is the of the entry in the configmap resource's `data` or `binaryData`
-                                                            field to be used.
-                                                        maxLength: 253
-                                                        minLength: 1
-                                                        type: string
-                                                    name:
-                                                        description: Name is unique within a namespace to reference a configmap resource.
-                                                        maxLength: 253
-                                                        minLength: 1
-                                                        type: string
-                                                    namespace:
-                                                        description: |-
-                                                            Namespace defines the space within which the configmap name must be unique.
-                                                            If omitted, the namespace of the object being reconciled will be used.
-                                                        maxLength: 63
-                                                        minLength: 1
-                                                        type: string
-                                                required:
-                                                    - key
-                                                    - name
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                            inline:
-                                                description: Inline template content
-                                                minLength: 1
-                                                type: string
-                                            secretRef:
-                                                description: Reference to a Secret containing the template
-                                                properties:
-                                                    key:
-                                                        description: |-
-                                                            Key is the of the entry in the secret resource's `data` or `stringData`
-                                                            field to be used.
-                                                        maxLength: 253
-                                                        minLength: 1
-                                                        type: string
-                                                    name:
-                                                        description: Name is unique within a namespace to reference a secret resource.
-                                                        maxLength: 253
-                                                        minLength: 1
-                                                        type: string
-                                                    namespace:
-                                                        description: |-
-                                                            Namespace defines the space within which the secret name must be unique.
-                                                            If omitted, the namespace of the object being reconciled will be used.
-                                                        maxLength: 63
-                                                        minLength: 1
-                                                        type: string
-                                                required:
-                                                    - key
-                                                    - name
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                        type: object
-                                        x-kubernetes-validations:
-                                            - message: exactly one of 'inline', 'secretRef', or 'configMapRef' must be specified
-                                              rule: '[has(self.inline), has(self.secretRef), has(self.configMapRef)].filter(x, x).size() == 1'
-                                    image:
-                                        description: Image defines the image to be used for provisioning the device.
-                                        properties:
-                                            checksum:
-                                                description: |-
-                                                    Checksum is the checksum of the image for verification.
-                                                    kubebuilder:validation:MinLength=1
-                                                type: string
-                                            checksumType:
-                                                default: MD5
-                                                description: ChecksumType is the type of the checksum (e.g., sha256, md5).
-                                                enum:
-                                                    - SHA256
-                                                    - MD5
-                                                type: string
-                                            url:
-                                                description: URL is the location of the image to be used for provisioning.
-                                                type: string
-                                        required:
-                                            - checksum
-                                            - checksumType
-                                            - url
-                                        type: object
-                                required:
-                                    - image
-                                type: object
+                                  Namespace defines the space within which the secret name must be unique.
+                                  If omitted, the namespace of the object being reconciled will be used.
+                                maxLength: 63
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
                         required:
-                            - endpoint
+                        - secretRef
                         type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Device.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            firmwareVersion:
-                                description: FirmwareVersion is the firmware version running on the Device.
-                                type: string
-                            manufacturer:
-                                description: Manufacturer is the manufacturer of the Device.
-                                type: string
-                            model:
-                                description: Model is the model identifier of the Device.
-                                type: string
-                            phase:
-                                default: Pending
-                                description: Phase represents the current phase of the Device.
-                                enum:
-                                    - Pending
-                                    - Provisioning
-                                    - Running
-                                    - Failed
-                                    - Provisioned
-                                type: string
-                            portSummary:
-                                description: PostSummary shows a summary of the port configured, grouped by type, e.g. "1/4 (10g), 3/64 (100g)".
-                                type: string
-                            ports:
-                                description: Ports is the list of ports on the Device.
-                                items:
-                                    properties:
-                                        interfaceName:
-                                            description: |-
-                                                InterfaceRef is the reference to the corresponding Interface resource
-                                                configuring this port, if any.
-                                            properties:
-                                                name:
-                                                    description: |-
-                                                        Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    maxLength: 63
-                                                    minLength: 1
-                                                    type: string
-                                            required:
-                                                - name
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                        name:
-                                            description: Name is the name of the port.
-                                            type: string
-                                        supportedSpeedsGbps:
-                                            description: SupportedSpeedsGbps is the list of supported speeds in Gbps for this port.
-                                            items:
-                                                format: int32
-                                                type: integer
-                                            type: array
-                                        transceiver:
-                                            description: Transceiver is the type of transceiver plugged into the port, if any.
-                                            type: string
-                                        type:
-                                            description: Type is the type of the port, e.g. "10g".
-                                            type: string
-                                    required:
-                                        - name
-                                    type: object
-                                type: array
-                            provisioning:
-                                description: Provisioning is the list of provisioning attempts for the Device.
-                                items:
-                                    properties:
-                                        endTime:
-                                            format: date-time
-                                            type: string
-                                        error:
-                                            type: string
-                                        phase:
-                                            description: ProvisioningPhase represents the reason for the current provisioning status.
-                                            type: string
-                                        reboot:
-                                            format: date-time
-                                            type: string
-                                        startTime:
-                                            format: date-time
-                                            type: string
-                                        token:
-                                            type: string
-                                    required:
-                                        - phase
-                                        - startTime
-                                        - token
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - startTime
-                                x-kubernetes-list-type: map
-                            serialNumber:
-                                description: SerialNumber is the serial number of the Device.
-                                type: string
-                        required:
-                            - phase
-                        type: object
+                    required:
+                    - ca
+                    type: object
+                required:
+                - address
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-validations:
+                - message: SecretRef is required once set
+                  rule: '!has(oldSelf.secretRef) || has(self.secretRef)'
+              provisioning:
+                description: |-
+                  Provisioning is an optional configuration for the device provisioning process.
+                  It can be used to provide initial configuration templates or scripts that are applied during the device provisioning.
+                properties:
+                  bootScript:
+                    description: BootScript defines the script delivered by a TFTP
+                      server to the device during bootstrapping.
+                    properties:
+                      configMapRef:
+                        description: Reference to a ConfigMap containing the template
+                        properties:
+                          key:
+                            description: |-
+                              Key is the of the entry in the configmap resource's `data` or `binaryData`
+                              field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a configmap resource.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace defines the space within which the configmap name must be unique.
+                              If omitted, the namespace of the object being reconciled will be used.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      inline:
+                        description: Inline template content
+                        minLength: 1
+                        type: string
+                      secretRef:
+                        description: Reference to a Secret containing the template
+                        properties:
+                          key:
+                            description: |-
+                              Key is the of the entry in the secret resource's `data` or `stringData`
+                              field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace defines the space within which the secret name must be unique.
+                              If omitted, the namespace of the object being reconciled will be used.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of 'inline', 'secretRef', or 'configMapRef'
+                        must be specified
+                      rule: '[has(self.inline), has(self.secretRef), has(self.configMapRef)].filter(x,
+                        x).size() == 1'
+                  image:
+                    description: Image defines the image to be used for provisioning
+                      the device.
+                    properties:
+                      checksum:
+                        description: |-
+                          Checksum is the checksum of the image for verification.
+                          kubebuilder:validation:MinLength=1
+                        type: string
+                      checksumType:
+                        default: MD5
+                        description: ChecksumType is the type of the checksum (e.g.,
+                          sha256, md5).
+                        enum:
+                        - SHA256
+                        - MD5
+                        type: string
+                      url:
+                        description: URL is the location of the image to be used for
+                          provisioning.
+                        type: string
+                    required:
+                    - checksum
+                    - checksumType
+                    - url
+                    type: object
+                required:
+                - image
+                type: object
+            required:
+            - endpoint
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Device.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              firmwareVersion:
+                description: FirmwareVersion is the firmware version running on the
+                  Device.
+                type: string
+              manufacturer:
+                description: Manufacturer is the manufacturer of the Device.
+                type: string
+              model:
+                description: Model is the model identifier of the Device.
+                type: string
+              phase:
+                default: Pending
+                description: Phase represents the current phase of the Device.
+                enum:
+                - Pending
+                - Provisioning
+                - Running
+                - Failed
+                - Provisioned
+                type: string
+              portSummary:
+                description: PostSummary shows a summary of the port configured, grouped
+                  by type, e.g. "1/4 (10g), 3/64 (100g)".
+                type: string
+              ports:
+                description: Ports is the list of ports on the Device.
+                items:
+                  properties:
+                    interfaceName:
+                      description: |-
+                        InterfaceRef is the reference to the corresponding Interface resource
+                        configuring this port, if any.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: Name is the name of the port.
+                      type: string
+                    supportedSpeedsGbps:
+                      description: SupportedSpeedsGbps is the list of supported speeds
+                        in Gbps for this port.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    transceiver:
+                      description: Transceiver is the type of transceiver plugged
+                        into the port, if any.
+                      type: string
+                    type:
+                      description: Type is the type of the port, e.g. "10g".
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              provisioning:
+                description: Provisioning is the list of provisioning attempts for
+                  the Device.
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    error:
+                      type: string
+                    phase:
+                      description: ProvisioningPhase represents the reason for the
+                        current provisioning status.
+                      type: string
+                    reboot:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    token:
+                      type: string
+                  required:
+                  - phase
+                  - startTime
+                  - token
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - startTime
+                x-kubernetes-list-type: map
+              serialNumber:
+                description: SerialNumber is the serial number of the Device.
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/dns.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/dns.networking.metal.ironcore.dev.yaml
@@ -2,232 +2,238 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: dns.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: dns.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: DNS
-        listKind: DNSList
-        plural: dns
-        singular: dns
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.domain
-              name: Domain
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: DNS is the Schema for the dns API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: DNS
+    listKind: DNSList
+    plural: dns
+    singular: dns
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.domain
+      name: Domain
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNS is the Schema for the dns API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether DNS is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether DNS is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            domain:
-                                description: Default domain name that the device uses to complete unqualified hostnames.
-                                format: hostname
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the DNS to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            servers:
-                                description: A list of DNS servers to use for address resolution.
-                                items:
-                                    properties:
-                                        address:
-                                            description: The Hostname or IP address of the DNS server.
-                                            maxLength: 253
-                                            minLength: 1
-                                            type: string
-                                        vrfName:
-                                            description: The name of the vrf used to communicate with the DNS server.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - address
-                                    type: object
-                                maxItems: 6
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - address
-                                x-kubernetes-list-type: map
-                            sourceInterfaceName:
-                                description: Source interface for all DNS traffic.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                        required:
-                            - deviceRef
-                            - domain
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the DNS.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              domain:
+                description: Default domain name that the device uses to complete
+                  unqualified hostnames.
+                format: hostname
+                maxLength: 253
+                minLength: 1
+                type: string
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the DNS to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              servers:
+                description: A list of DNS servers to use for address resolution.
+                items:
+                  properties:
+                    address:
+                      description: The Hostname or IP address of the DNS server.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    vrfName:
+                      description: The name of the vrf used to communicate with the
+                        DNS server.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - address
+                  type: object
+                maxItems: 6
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - address
+                x-kubernetes-list-type: map
+              sourceInterfaceName:
+                description: Source interface for all DNS traffic.
+                maxLength: 63
+                minLength: 1
+                type: string
+            required:
+            - deviceRef
+            - domain
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the DNS.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/evpninstances.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/evpninstances.networking.metal.ironcore.dev.yaml
@@ -2,283 +2,288 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: evpninstances.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: evpninstances.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: EVPNInstance
-        listKind: EVPNInstanceList
-        plural: evpninstances
-        shortNames:
-            - evi
-            - vni
-        singular: evpninstance
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.vni
-              name: VNI
-              type: integer
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.type
-              name: Type
-              type: string
-            - jsonPath: .spec.routeDistinguisher
-              name: Route Distinguisher
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: EVPNInstance is the Schema for the evpninstances API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: EVPNInstance
+    listKind: EVPNInstanceList
+    plural: evpninstances
+    shortNames:
+    - evi
+    - vni
+    singular: evpninstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.vni
+      name: VNI
+      type: integer
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.routeDistinguisher
+      name: Route Distinguisher
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EVPNInstance is the Schema for the evpninstances API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            multicastGroupAddress:
-                                description: |-
-                                    MulticastGroupAddress specifies the IPv4 multicast group address used for BUM (Broadcast, Unknown unicast, Multicast) traffic.
-                                    The address must be in the valid multicast range (224.0.0.0 - 239.255.255.255).
-                                format: ipv4
-                                type: string
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the BGP to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            routeDistinguisher:
-                                description: |-
-                                    RouteDistinguisher is the route distinguisher for the EVI.
-                                    Formats supported:
-                                     - Type 0: ASN(0-65535):Number(0-4294967295)
-                                     - Type 1: IPv4:Number(0-65535)
-                                     - Type 2: ASN(65536-4294967295):Number(0-65535)
-                                type: string
-                            routeTargets:
-                                description: RouteTargets is the list of route targets for the EVI.
-                                items:
-                                    properties:
-                                        action:
-                                            description: Action defines whether the route target is imported, exported, or both.
-                                            enum:
-                                                - Import
-                                                - Export
-                                                - Both
-                                            type: string
-                                        value:
-                                            description: Value is the route target value, must have the format as RouteDistinguisher.
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - action
-                                        - value
-                                    type: object
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - value
-                                x-kubernetes-list-type: map
-                            type:
-                                description: |-
-                                    Type specifies the EVPN instance type.
-                                    Immutable.
-                                enum:
-                                    - Bridged
-                                    - Routed
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Type is immutable
-                                      rule: self == oldSelf
-                            vlanRef:
-                                description: |-
-                                    VLANRef is a reference to a VLAN resource for which this EVPNInstance builds the MAC-VRF.
-                                    This field is only applicable when Type is Bridged (L2VNI).
-                                    The VLAN resource must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: VLANRef is immutable
-                                      rule: self.name == oldSelf.name
-                            vni:
-                                description: |-
-                                    VNI is the VXLAN Network Identifier.
-                                    Immutable.
-                                format: int32
-                                maximum: 16777214
-                                minimum: 1
-                                type: integer
-                                x-kubernetes-validations:
-                                    - message: VNI is immutable
-                                      rule: self == oldSelf
-                        required:
-                            - deviceRef
-                            - type
-                            - vni
-                        type: object
-                        x-kubernetes-validations:
-                            - message: VLANRef must be specified when Type is Bridged
-                              rule: self.type != 'Bridged' || has(self.vlanRef)
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the EVPNInstance.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              multicastGroupAddress:
+                description: |-
+                  MulticastGroupAddress specifies the IPv4 multicast group address used for BUM (Broadcast, Unknown unicast, Multicast) traffic.
+                  The address must be in the valid multicast range (224.0.0.0 - 239.255.255.255).
+                format: ipv4
+                type: string
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the BGP to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              routeDistinguisher:
+                description: |-
+                  RouteDistinguisher is the route distinguisher for the EVI.
+                  Formats supported:
+                   - Type 0: ASN(0-65535):Number(0-4294967295)
+                   - Type 1: IPv4:Number(0-65535)
+                   - Type 2: ASN(65536-4294967295):Number(0-65535)
+                type: string
+              routeTargets:
+                description: RouteTargets is the list of route targets for the EVI.
+                items:
+                  properties:
+                    action:
+                      description: Action defines whether the route target is imported,
+                        exported, or both.
+                      enum:
+                      - Import
+                      - Export
+                      - Both
+                      type: string
+                    value:
+                      description: Value is the route target value, must have the
+                        format as RouteDistinguisher.
+                      minLength: 1
+                      type: string
+                  required:
+                  - action
+                  - value
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - value
+                x-kubernetes-list-type: map
+              type:
+                description: |-
+                  Type specifies the EVPN instance type.
+                  Immutable.
+                enum:
+                - Bridged
+                - Routed
+                type: string
+                x-kubernetes-validations:
+                - message: Type is immutable
+                  rule: self == oldSelf
+              vlanRef:
+                description: |-
+                  VLANRef is a reference to a VLAN resource for which this EVPNInstance builds the MAC-VRF.
+                  This field is only applicable when Type is Bridged (L2VNI).
+                  The VLAN resource must exist in the same namespace.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: VLANRef is immutable
+                  rule: self.name == oldSelf.name
+              vni:
+                description: |-
+                  VNI is the VXLAN Network Identifier.
+                  Immutable.
+                format: int32
+                maximum: 16777214
+                minimum: 1
+                type: integer
+                x-kubernetes-validations:
+                - message: VNI is immutable
+                  rule: self == oldSelf
+            required:
+            - deviceRef
+            - type
+            - vni
+            type: object
+            x-kubernetes-validations:
+            - message: VLANRef must be specified when Type is Bridged
+              rule: self.type != 'Bridged' || has(self.vlanRef)
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the EVPNInstance.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/interfaceconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/interfaceconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -2,90 +2,91 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: interfaceconfigs.nx.cisco.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: interfaceconfigs.nx.cisco.networking.metal.ironcore.dev
 spec:
-    group: nx.cisco.networking.metal.ironcore.dev
-    names:
-        kind: InterfaceConfig
-        listKind: InterfaceConfigList
-        plural: interfaceconfigs
-        shortNames:
-            - intcfg
-        singular: interfaceconfigs
-    scope: Namespaced
-    versions:
-        - name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: InterfaceConfig is the Schema for the interfaceconfigs API
+  group: nx.cisco.networking.metal.ironcore.dev
+  names:
+    kind: InterfaceConfig
+    listKind: InterfaceConfigList
+    plural: interfaceconfigs
+    shortNames:
+    - intcfg
+    singular: interfaceconfigs
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: InterfaceConfig is the Schema for the interfaceconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bufferBoost:
+                description: |-
+                  BufferBoost defines the buffer boost configuration for the interface.
+                  Buffer boost increases the shared buffer space allocation for the interface.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            bufferBoost:
-                                description: |-
-                                    BufferBoost defines the buffer boost configuration for the interface.
-                                    Buffer boost increases the shared buffer space allocation for the interface.
-                                properties:
-                                    enabled:
-                                        description: |-
-                                            Enabled indicates whether buffer boost is enabled on the interface.
-                                            Maps to CLI command: hardware profile buffer boost
-                                        type: boolean
-                                required:
-                                    - enabled
-                                type: object
-                            spanningTree:
-                                description: SpanningTree defines the spanning tree configuration for the interface.
-                                properties:
-                                    bpduFilter:
-                                        description: |-
-                                            BPDUFilter enables BPDU filter on the interface.
-                                            When enabled, BPDUs are not sent or received on the port.
-                                        type: boolean
-                                    bpduGuard:
-                                        description: |-
-                                            BPDUGuard enables BPDU guard on the interface.
-                                            When enabled, the port is shut down if a BPDU is received.
-                                        type: boolean
-                                    portType:
-                                        description: PortType defines the spanning tree port type.
-                                        enum:
-                                            - Normal
-                                            - Edge
-                                            - Network
-                                        type: string
-                                required:
-                                    - portType
-                                type: object
-                        type: object
+                  enabled:
+                    description: |-
+                      Enabled indicates whether buffer boost is enabled on the interface.
+                      Maps to CLI command: hardware profile buffer boost
+                    type: boolean
                 required:
-                    - spec
+                - enabled
                 type: object
-          served: true
-          storage: true
+              spanningTree:
+                description: SpanningTree defines the spanning tree configuration
+                  for the interface.
+                properties:
+                  bpduFilter:
+                    description: |-
+                      BPDUFilter enables BPDU filter on the interface.
+                      When enabled, BPDUs are not sent or received on the port.
+                    type: boolean
+                  bpduGuard:
+                    description: |-
+                      BPDUGuard enables BPDU guard on the interface.
+                      When enabled, the port is shut down if a BPDU is received.
+                    type: boolean
+                  portType:
+                    description: PortType defines the spanning tree port type.
+                    enum:
+                    - Normal
+                    - Edge
+                    - Network
+                    type: string
+                required:
+                - portType
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
 {{- end }}

--- a/charts/network-operator/templates/crd/interfaces.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/interfaces.networking.metal.ironcore.dev.yaml
@@ -2,523 +2,537 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: interfaces.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: interfaces.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: Interface
-        listKind: InterfaceList
-        plural: interfaces
-        shortNames:
-            - int
-        singular: interface
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.name
-              name: Interface
-              type: string
-            - jsonPath: .spec.type
-              name: Type
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.description
-              name: Description
-              priority: 1
-              type: string
-            - jsonPath: .spec.mtu
-              name: MTU
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Configured")].status
-              name: Configured
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Operational")].status
-              name: Operational
-              priority: 1
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: Interface is the Schema for the interfaces API.
+  group: networking.metal.ironcore.dev
+  names:
+    kind: Interface
+    listKind: InterfaceList
+    plural: interfaces
+    shortNames:
+    - int
+    singular: interface
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Interface
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    - jsonPath: .spec.mtu
+      name: MTU
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Configured")].status
+      name: Configured
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Operational")].status
+      name: Operational
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Interface is the Schema for the interfaces API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the interface is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              aggregation:
+                description: |-
+                  Aggregation defines the aggregation (bundle) configuration for the interface.
+                  This is only applicable for interfaces of type Aggregate.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                  controlProtocol:
+                    default:
+                      mode: Active
+                    description: ControlProtocol defines the lacp configuration for
+                      the aggregate interface.
+                    properties:
+                      mode:
+                        description: Mode defines the LACP mode for the aggregate
+                          interface.
+                        enum:
+                        - Active
+                        - Passive
                         type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether the interface is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            aggregation:
-                                description: |-
-                                    Aggregation defines the aggregation (bundle) configuration for the interface.
-                                    This is only applicable for interfaces of type Aggregate.
-                                properties:
-                                    controlProtocol:
-                                        default:
-                                            mode: Active
-                                        description: ControlProtocol defines the lacp configuration for the aggregate interface.
-                                        properties:
-                                            mode:
-                                                description: Mode defines the LACP mode for the aggregate interface.
-                                                enum:
-                                                    - Active
-                                                    - Passive
-                                                type: string
-                                        required:
-                                            - mode
-                                        type: object
-                                    memberInterfaceRefs:
-                                        description: MemberInterfaceRefs is a list of interface references that are part of the aggregate interface.
-                                        items:
-                                            description: |-
-                                                LocalObjectReference contains enough information to locate a
-                                                referenced object inside the same namespace.
-                                            properties:
-                                                name:
-                                                    description: |-
-                                                        Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    maxLength: 63
-                                                    minLength: 1
-                                                    type: string
-                                            required:
-                                                - name
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                        maxItems: 32
-                                        minItems: 1
-                                        type: array
-                                    multichassis:
-                                        description: Multichassis defines the multichassis configuration for the aggregate interface.
-                                        properties:
-                                            enabled:
-                                                default: true
-                                                description: Enabled indicates whether the aggregate interface is part of a multichassis setup.
-                                                type: boolean
-                                            id:
-                                                description: ID is the multichassis identifier.
-                                                maximum: 4094
-                                                minimum: 1
-                                                type: integer
-                                        required:
-                                            - enabled
-                                            - id
-                                        type: object
-                                required:
-                                    - memberInterfaceRefs
-                                type: object
-                            bfd:
-                                description: |-
-                                    BFD defines the Bidirectional Forwarding Detection configuration for the interface.
-                                    BFD is only applicable for Layer 3 interfaces (Physical, Loopback, RoutedVLAN).
-                                properties:
-                                    desiredMinimumTxInterval:
-                                        description: |-
-                                            DesiredMinimumTxInterval is the minimum interval between transmission of BFD control
-                                            packets that the operator desires. This value is advertised to the peer.
-                                            The actual interval used is the maximum of this value and the remote
-                                            required-minimum-receive interval value.
-                                        pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                                        type: string
-                                    detectionMultiplier:
-                                        description: |-
-                                            DetectionMultiplier is the number of packets that must be missed to declare
-                                            this session as down. The detection interval for the BFD session is calculated
-                                            by multiplying the value of the negotiated transmission interval by this value.
-                                        format: int32
-                                        maximum: 255
-                                        minimum: 1
-                                        type: integer
-                                    enabled:
-                                        description: Enabled indicates whether BFD is enabled on the interface.
-                                        type: boolean
-                                    requiredMinimumReceive:
-                                        description: |-
-                                            RequiredMinimumReceive is the minimum interval between received BFD control packets
-                                            that this system should support. This value is advertised to the remote peer to
-                                            indicate the maximum frequency between BFD control packets that is acceptable
-                                            to the local system.
-                                        pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                                        type: string
-                                required:
-                                    - enabled
-                                type: object
-                            description:
-                                description: Description provides a human-readable description of the interface.
-                                maxLength: 255
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            ipv4:
-                                description: IPv4 defines the IPv4 configuration for the interface.
-                                properties:
-                                    addresses:
-                                        description: |-
-                                            Addresses defines the list of IPv4 addresses assigned to the interface.
-                                            The first address in the list is considered the primary address,
-                                            and any additional addresses are considered secondary addresses.
-                                        items:
-                                            format: cidr
-                                            type: string
-                                        minItems: 1
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    anycastGateway:
-                                        default: false
-                                        description: |-
-                                            AnycastGateway enables distributed anycast gateway functionality.
-                                            When enabled, this interface uses the virtual MAC configured in the
-                                            device's NVE resource for active-active default gateway redundancy.
-                                            Only applicable for RoutedVLAN interfaces in EVPN/VXLAN fabrics.
-                                        type: boolean
-                                    unnumbered:
-                                        description: |-
-                                            Unnumbered defines the unnumbered interface configuration.
-                                            When specified, the interface borrows the IP address from another interface.
-                                        properties:
-                                            interfaceRef:
-                                                description: |-
-                                                    InterfaceRef is a reference to the interface from which to borrow the IP address.
-                                                    The referenced interface must exist and have at least one IPv4 address configured.
-                                                properties:
-                                                    name:
-                                                        description: |-
-                                                            Name of the referent.
-                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        maxLength: 63
-                                                        minLength: 1
-                                                        type: string
-                                                required:
-                                                    - name
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                        required:
-                                            - interfaceRef
-                                        type: object
-                                type: object
-                                x-kubernetes-validations:
-                                    - message: addresses and unnumbered are mutually exclusive
-                                      rule: '!has(self.addresses) || !has(self.unnumbered)'
-                                    - message: anycastGateway and unnumbered are mutually exclusive
-                                      rule: '!has(self.unnumbered) || !self.anycastGateway'
-                            mtu:
-                                description: MTU (Maximum Transmission Unit) specifies the size of the largest packet that can be sent over the interface.
-                                format: int32
-                                maximum: 9216
-                                minimum: 576
-                                type: integer
-                            name:
-                                description: Name is the name of the interface.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Name is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Interface to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            switchport:
-                                description: |-
-                                    Switchport defines the switchport configuration for the interface.
-                                    This is only applicable for Ethernet and Aggregate interfaces.
-                                properties:
-                                    accessVlan:
-                                        description: |-
-                                            AccessVlan specifies the VLAN ID for access mode switchports.
-                                            Only applicable when Mode is set to "Access".
-                                        format: int32
-                                        maximum: 4094
-                                        minimum: 1
-                                        type: integer
-                                    allowedVlans:
-                                        description: |-
-                                            AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
-                                            If not specified, all VLANs (1-4094) are allowed.
-                                            Only applicable when Mode is set to "Trunk".
-                                        items:
-                                            format: int32
-                                            maximum: 4094
-                                            minimum: 1
-                                            type: integer
-                                        minItems: 1
-                                        type: array
-                                    mode:
-                                        description: Mode defines the switchport mode, such as access or trunk.
-                                        enum:
-                                            - Access
-                                            - Trunk
-                                        type: string
-                                    nativeVlan:
-                                        description: |-
-                                            NativeVlan specifies the native VLAN ID for trunk mode switchports.
-                                            Only applicable when Mode is set to "Trunk".
-                                        format: int32
-                                        maximum: 4094
-                                        minimum: 1
-                                        type: integer
-                                required:
-                                    - mode
-                                type: object
-                                x-kubernetes-validations:
-                                    - message: accessVlan must be specified when mode is Access
-                                      rule: self.mode != 'Access' || has(self.accessVlan)
-                            type:
-                                description: Type indicates the type of the interface.
-                                enum:
-                                    - Physical
-                                    - Loopback
-                                    - Aggregate
-                                    - RoutedVLAN
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Type is immutable
-                                      rule: self == oldSelf
-                            vlanRef:
-                                description: |-
-                                    VlanRef is a reference to the VLAN resource that this interface provides routing for.
-                                    This is only applicable for interfaces of type RoutedVLAN.
-                                    The referenced VLAN must exist in the same namespace.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            vrfRef:
-                                description: |-
-                                    VrfRef is a reference to the VRF resource that this interface belongs to.
-                                    If not specified, the interface will be part of the default VRF.
-                                    This is only applicable for Layer 3 interfaces.
-                                    The referenced VRF must exist in the same namespace.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        required:
-                            - deviceRef
-                            - name
-                            - type
-                        type: object
-                        x-kubernetes-validations:
-                            - message: switchport and ipv4 are mutually exclusive
-                              rule: '!has(self.switchport) || !has(self.ipv4)'
-                            - message: switchport must not be specified for interfaces of type Loopback
-                              rule: self.type != 'Loopback' || !has(self.switchport)
-                            - message: unnumbered ipv4 configuration can only be used for interfaces of type Physical
-                              rule: self.type == 'Physical' || !has(self.ipv4) || !has(self.ipv4.unnumbered)
-                            - message: aggregation must be specified for interfaces of type Aggregate
-                              rule: self.type != 'Aggregate' || has(self.aggregation)
-                            - message: aggregation must only be specified on interfaces of type Aggregate
-                              rule: self.type == 'Aggregate' || !has(self.aggregation)
-                            - message: ipv4 must not be specified for interfaces of type Aggregate
-                              rule: self.type != 'Aggregate' || !has(self.ipv4)
-                            - message: vlanRef must be specified for interfaces of type RoutedVLAN
-                              rule: self.type != 'RoutedVLAN' || has(self.vlanRef)
-                            - message: vlanRef must only be specified on interfaces of type RoutedVLAN
-                              rule: self.type == 'RoutedVLAN' || !has(self.vlanRef)
-                            - message: switchport must not be specified for interfaces of type RoutedVLAN
-                              rule: self.type != 'RoutedVLAN' || !has(self.switchport)
-                            - message: aggregation must not be specified for interfaces of type RoutedVLAN
-                              rule: self.type != 'RoutedVLAN' || !has(self.aggregation)
-                            - message: anycastGateway can only be enabled for interfaces of type RoutedVLAN
-                              rule: self.type == 'RoutedVLAN' || !has(self.ipv4) || !self.ipv4.anycastGateway
-                            - message: vrfRef must not be specified for interfaces of type Aggregate
-                              rule: self.type != 'Aggregate' || !has(self.vrfRef)
-                            - message: vrfRef must not be specified for Physical interfaces with switchport configuration
-                              rule: self.type != 'Physical' || !has(self.switchport) || !has(self.vrfRef)
-                            - message: bfd must not be specified for interfaces of type Aggregate
-                              rule: self.type != 'Aggregate' || !has(self.bfd)
-                            - message: bfd must not be specified for interfaces with switchport configuration
-                              rule: '!has(self.bfd) || !has(self.switchport)'
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Interface.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            memberOf:
-                                description: |-
-                                    MemberOf references the aggregate interface this interface is a member of, if any.
-                                    This field only applies to physical interfaces that are part of an aggregate interface.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        type: object
+                    required:
+                    - mode
+                    type: object
+                  memberInterfaceRefs:
+                    description: MemberInterfaceRefs is a list of interface references
+                      that are part of the aggregate interface.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to locate a
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    maxItems: 32
+                    minItems: 1
+                    type: array
+                  multichassis:
+                    description: Multichassis defines the multichassis configuration
+                      for the aggregate interface.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled indicates whether the aggregate interface
+                          is part of a multichassis setup.
+                        type: boolean
+                      id:
+                        description: ID is the multichassis identifier.
+                        maximum: 4094
+                        minimum: 1
+                        type: integer
+                    required:
+                    - enabled
+                    - id
+                    type: object
                 required:
-                    - spec
+                - memberInterfaceRefs
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+              bfd:
+                description: |-
+                  BFD defines the Bidirectional Forwarding Detection configuration for the interface.
+                  BFD is only applicable for Layer 3 interfaces (Physical, Loopback, RoutedVLAN).
+                properties:
+                  desiredMinimumTxInterval:
+                    description: |-
+                      DesiredMinimumTxInterval is the minimum interval between transmission of BFD control
+                      packets that the operator desires. This value is advertised to the peer.
+                      The actual interval used is the maximum of this value and the remote
+                      required-minimum-receive interval value.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  detectionMultiplier:
+                    description: |-
+                      DetectionMultiplier is the number of packets that must be missed to declare
+                      this session as down. The detection interval for the BFD session is calculated
+                      by multiplying the value of the negotiated transmission interval by this value.
+                    format: int32
+                    maximum: 255
+                    minimum: 1
+                    type: integer
+                  enabled:
+                    description: Enabled indicates whether BFD is enabled on the interface.
+                    type: boolean
+                  requiredMinimumReceive:
+                    description: |-
+                      RequiredMinimumReceive is the minimum interval between received BFD control packets
+                      that this system should support. This value is advertised to the remote peer to
+                      indicate the maximum frequency between BFD control packets that is acceptable
+                      to the local system.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                required:
+                - enabled
+                type: object
+              description:
+                description: Description provides a human-readable description of
+                  the interface.
+                maxLength: 255
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              ipv4:
+                description: IPv4 defines the IPv4 configuration for the interface.
+                properties:
+                  addresses:
+                    description: |-
+                      Addresses defines the list of IPv4 addresses assigned to the interface.
+                      The first address in the list is considered the primary address,
+                      and any additional addresses are considered secondary addresses.
+                    items:
+                      format: cidr
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  anycastGateway:
+                    default: false
+                    description: |-
+                      AnycastGateway enables distributed anycast gateway functionality.
+                      When enabled, this interface uses the virtual MAC configured in the
+                      device's NVE resource for active-active default gateway redundancy.
+                      Only applicable for RoutedVLAN interfaces in EVPN/VXLAN fabrics.
+                    type: boolean
+                  unnumbered:
+                    description: |-
+                      Unnumbered defines the unnumbered interface configuration.
+                      When specified, the interface borrows the IP address from another interface.
+                    properties:
+                      interfaceRef:
+                        description: |-
+                          InterfaceRef is a reference to the interface from which to borrow the IP address.
+                          The referenced interface must exist and have at least one IPv4 address configured.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - interfaceRef
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: addresses and unnumbered are mutually exclusive
+                  rule: '!has(self.addresses) || !has(self.unnumbered)'
+                - message: anycastGateway and unnumbered are mutually exclusive
+                  rule: '!has(self.unnumbered) || !self.anycastGateway'
+              mtu:
+                description: MTU (Maximum Transmission Unit) specifies the size of
+                  the largest packet that can be sent over the interface.
+                format: int32
+                maximum: 9216
+                minimum: 576
+                type: integer
+              name:
+                description: Name is the name of the interface.
+                maxLength: 255
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Name is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Interface to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              switchport:
+                description: |-
+                  Switchport defines the switchport configuration for the interface.
+                  This is only applicable for Ethernet and Aggregate interfaces.
+                properties:
+                  accessVlan:
+                    description: |-
+                      AccessVlan specifies the VLAN ID for access mode switchports.
+                      Only applicable when Mode is set to "Access".
+                    format: int32
+                    maximum: 4094
+                    minimum: 1
+                    type: integer
+                  allowedVlans:
+                    description: |-
+                      AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+                      If not specified, all VLANs (1-4094) are allowed.
+                      Only applicable when Mode is set to "Trunk".
+                    items:
+                      format: int32
+                      maximum: 4094
+                      minimum: 1
+                      type: integer
+                    minItems: 1
+                    type: array
+                  mode:
+                    description: Mode defines the switchport mode, such as access
+                      or trunk.
+                    enum:
+                    - Access
+                    - Trunk
+                    type: string
+                  nativeVlan:
+                    description: |-
+                      NativeVlan specifies the native VLAN ID for trunk mode switchports.
+                      Only applicable when Mode is set to "Trunk".
+                    format: int32
+                    maximum: 4094
+                    minimum: 1
+                    type: integer
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: accessVlan must be specified when mode is Access
+                  rule: self.mode != 'Access' || has(self.accessVlan)
+              type:
+                description: Type indicates the type of the interface.
+                enum:
+                - Physical
+                - Loopback
+                - Aggregate
+                - RoutedVLAN
+                type: string
+                x-kubernetes-validations:
+                - message: Type is immutable
+                  rule: self == oldSelf
+              vlanRef:
+                description: |-
+                  VlanRef is a reference to the VLAN resource that this interface provides routing for.
+                  This is only applicable for interfaces of type RoutedVLAN.
+                  The referenced VLAN must exist in the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              vrfRef:
+                description: |-
+                  VrfRef is a reference to the VRF resource that this interface belongs to.
+                  If not specified, the interface will be part of the default VRF.
+                  This is only applicable for Layer 3 interfaces.
+                  The referenced VRF must exist in the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - deviceRef
+            - name
+            - type
+            type: object
+            x-kubernetes-validations:
+            - message: switchport and ipv4 are mutually exclusive
+              rule: '!has(self.switchport) || !has(self.ipv4)'
+            - message: switchport must not be specified for interfaces of type Loopback
+              rule: self.type != 'Loopback' || !has(self.switchport)
+            - message: unnumbered ipv4 configuration can only be used for interfaces
+                of type Physical
+              rule: self.type == 'Physical' || !has(self.ipv4) || !has(self.ipv4.unnumbered)
+            - message: aggregation must be specified for interfaces of type Aggregate
+              rule: self.type != 'Aggregate' || has(self.aggregation)
+            - message: aggregation must only be specified on interfaces of type Aggregate
+              rule: self.type == 'Aggregate' || !has(self.aggregation)
+            - message: ipv4 must not be specified for interfaces of type Aggregate
+              rule: self.type != 'Aggregate' || !has(self.ipv4)
+            - message: vlanRef must be specified for interfaces of type RoutedVLAN
+              rule: self.type != 'RoutedVLAN' || has(self.vlanRef)
+            - message: vlanRef must only be specified on interfaces of type RoutedVLAN
+              rule: self.type == 'RoutedVLAN' || !has(self.vlanRef)
+            - message: switchport must not be specified for interfaces of type RoutedVLAN
+              rule: self.type != 'RoutedVLAN' || !has(self.switchport)
+            - message: aggregation must not be specified for interfaces of type RoutedVLAN
+              rule: self.type != 'RoutedVLAN' || !has(self.aggregation)
+            - message: anycastGateway can only be enabled for interfaces of type RoutedVLAN
+              rule: self.type == 'RoutedVLAN' || !has(self.ipv4) || !self.ipv4.anycastGateway
+            - message: vrfRef must not be specified for interfaces of type Aggregate
+              rule: self.type != 'Aggregate' || !has(self.vrfRef)
+            - message: vrfRef must not be specified for Physical interfaces with switchport
+                configuration
+              rule: self.type != 'Physical' || !has(self.switchport) || !has(self.vrfRef)
+            - message: bfd must not be specified for interfaces of type Aggregate
+              rule: self.type != 'Aggregate' || !has(self.bfd)
+            - message: bfd must not be specified for interfaces with switchport configuration
+              rule: '!has(self.bfd) || !has(self.switchport)'
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Interface.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              memberOf:
+                description: |-
+                  MemberOf references the aggregate interface this interface is a member of, if any.
+                  This field only applies to physical interfaces that are part of an aggregate interface.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/isis.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/isis.networking.metal.ironcore.dev.yaml
@@ -2,267 +2,274 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: isis.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: isis.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: ISIS
-        listKind: ISISList
-        plural: isis
-        singular: isis
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.instance
-              name: Instance
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.networkEntityTitle
-              name: NET
-              type: string
-            - jsonPath: .spec.type
-              name: Level
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: ISIS is the Schema for the isis API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: ISIS
+    listKind: ISISList
+    plural: isis
+    singular: isis
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.instance
+      name: Instance
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.networkEntityTitle
+      name: NET
+      type: string
+    - jsonPath: .spec.type
+      name: Level
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ISIS is the Schema for the isis API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              addressFamilies:
+                description: AddressFamilies is a list of address families for the
+                  ISIS instance.
+                items:
+                  description: AddressFamily represents the address family of an ISIS
+                    instance.
+                  enum:
+                  - IPv4Unicast
+                  - IPv6Unicast
+                  type: string
+                maxItems: 2
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+              adminState:
+                default: Up
+                description: AdminState indicates whether the ISIS instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            addressFamilies:
-                                description: AddressFamilies is a list of address families for the ISIS instance.
-                                items:
-                                    description: AddressFamily represents the address family of an ISIS instance.
-                                    enum:
-                                        - IPv4Unicast
-                                        - IPv6Unicast
-                                    type: string
-                                maxItems: 2
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-type: set
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether the ISIS instance is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            instance:
-                                description: Instance is the name of the ISIS instance.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Instance is immutable
-                                      rule: self == oldSelf
-                            interfaceRefs:
-                                description: InterfaceRefs is a list of interfaces that are part of the ISIS instance.
-                                items:
-                                    description: |-
-                                        LocalObjectReference contains enough information to locate a
-                                        referenced object inside the same namespace.
-                                    properties:
-                                        name:
-                                            description: |-
-                                                Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - name
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            networkEntityTitle:
-                                description: NetworkEntityTitle is the NET of the ISIS instance.
-                                pattern: ^[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}$
-                                type: string
-                            overloadBit:
-                                default: Never
-                                description: OverloadBit indicates the overload bit of the ISIS instance.
-                                enum:
-                                    - Always
-                                    - Never
-                                    - OnStartup
-                                type: string
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Interface to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type:
-                                description: Type indicates the level of the ISIS instance.
-                                enum:
-                                    - Level1
-                                    - Level2
-                                    - Level1-2
-                                type: string
-                        required:
-                            - addressFamilies
-                            - deviceRef
-                            - instance
-                            - networkEntityTitle
-                            - type
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the ISIS.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              instance:
+                description: Instance is the name of the ISIS instance.
+                maxLength: 63
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Instance is immutable
+                  rule: self == oldSelf
+              interfaceRefs:
+                description: InterfaceRefs is a list of interfaces that are part of
+                  the ISIS instance.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to locate a
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+                x-kubernetes-list-type: atomic
+              networkEntityTitle:
+                description: NetworkEntityTitle is the NET of the ISIS instance.
+                pattern: ^[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}$
+                type: string
+              overloadBit:
+                default: Never
+                description: OverloadBit indicates the overload bit of the ISIS instance.
+                enum:
+                - Always
+                - Never
+                - OnStartup
+                type: string
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Interface to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              type:
+                description: Type indicates the level of the ISIS instance.
+                enum:
+                - Level1
+                - Level2
+                - Level1-2
+                type: string
+            required:
+            - addressFamilies
+            - deviceRef
+            - instance
+            - networkEntityTitle
+            - type
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the ISIS.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/managementaccessconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/managementaccessconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -2,80 +2,83 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: managementaccessconfigs.nx.cisco.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: managementaccessconfigs.nx.cisco.networking.metal.ironcore.dev
 spec:
-    group: nx.cisco.networking.metal.ironcore.dev
-    names:
-        kind: ManagementAccessConfig
-        listKind: ManagementAccessConfigList
-        plural: managementaccessconfigs
-        shortNames:
-            - nxmgmt
-            - nxmgmtaccess
-        singular: managementaccessconfig
-    scope: Namespaced
-    versions:
-        - name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: ManagementAccessConfig is the Schema for the managementaccessconfigs API
+  group: nx.cisco.networking.metal.ironcore.dev
+  names:
+    kind: ManagementAccessConfig
+    listKind: ManagementAccessConfigList
+    plural: managementaccessconfigs
+    shortNames:
+    - nxmgmt
+    - nxmgmtaccess
+    singular: managementaccessconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagementAccessConfig is the Schema for the managementaccessconfigs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              console:
+                default:
+                  timeout: 10m
+                description: Console defines the configuration for the terminal console
+                  access on the device.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            console:
-                                default:
-                                    timeout: 10m
-                                description: Console defines the configuration for the terminal console access on the device.
-                                properties:
-                                    timeout:
-                                        default: 10m
-                                        description: |-
-                                            Timeout defines the inactivity timeout for console sessions.
-                                            If a session is inactive for the specified duration, it will be automatically disconnected.
-                                            The format is a string representing a duration (e.g., "10m" for 10 minutes).
-                                        pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                                        type: string
-                                type: object
-                            ssh:
-                                description: SSH defines the SSH server configuration for the VTY terminal access on the device.
-                                properties:
-                                    accessControlListName:
-                                        description: |-
-                                            AccessControlListName defines the name of the access control list (ACL) to apply for incoming
-                                            SSH connections on the VTY terminal. The ACL must be configured separately on the device.
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                type: object
-                        type: object
-                required:
-                    - spec
+                  timeout:
+                    default: 10m
+                    description: |-
+                      Timeout defines the inactivity timeout for console sessions.
+                      If a session is inactive for the specified duration, it will be automatically disconnected.
+                      The format is a string representing a duration (e.g., "10m" for 10 minutes).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
                 type: object
-          served: true
-          storage: true
+              ssh:
+                description: SSH defines the SSH server configuration for the VTY
+                  terminal access on the device.
+                properties:
+                  accessControlListName:
+                    description: |-
+                      AccessControlListName defines the name of the access control list (ACL) to apply for incoming
+                      SSH connections on the VTY terminal. The ACL must be configured separately on the device.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
 {{- end }}

--- a/charts/network-operator/templates/crd/managementaccesses.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/managementaccesses.networking.metal.ironcore.dev.yaml
@@ -2,289 +2,293 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: managementaccesses.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: managementaccesses.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: ManagementAccess
-        listKind: ManagementAccessList
-        plural: managementaccesses
-        shortNames:
-            - mgmt
-            - mgmtaccess
-        singular: managementaccess
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.ssh.enabled
-              name: SSH
-              type: boolean
-            - jsonPath: .spec.grpc.enabled
-              name: gRPC
-              type: boolean
-            - jsonPath: .spec.grpc.port
-              name: gRPC Port
-              priority: 1
-              type: integer
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: ManagementAccess is the Schema for the managementaccesses API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: ManagementAccess
+    listKind: ManagementAccessList
+    plural: managementaccesses
+    shortNames:
+    - mgmt
+    - mgmtaccess
+    singular: managementaccess
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.ssh.enabled
+      name: SSH
+      type: boolean
+    - jsonPath: .spec.grpc.enabled
+      name: gRPC
+      type: boolean
+    - jsonPath: .spec.grpc.port
+      name: gRPC Port
+      priority: 1
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagementAccess is the Schema for the managementaccesses API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            grpc:
-                                default:
-                                    enabled: true
-                                    port: 9339
-                                description: |-
-                                    Configuration for the gRPC server on the device.
-                                    Currently, only a single "default" gRPC server is supported.
-                                properties:
-                                    certificateId:
-                                        description: |-
-                                            Name of the certificate that is associated with the gRPC service.
-                                            The certificate is provisioned through other interfaces on the device,
-                                            such as e.g. the gNOI certificate management service.
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                    enabled:
-                                        default: true
-                                        description: |-
-                                            Enable or disable the gRPC server on the device.
-                                            If not specified, the gRPC server is enabled by default.
-                                        type: boolean
-                                    gnmi:
-                                        default:
-                                            keepAliveTimeout: 10m
-                                            maxConcurrentCall: 8
-                                        description: |-
-                                            Additional gNMI configuration for the gRPC server.
-                                            This may not be supported by all devices.
-                                        properties:
-                                            keepAliveTimeout:
-                                                default: 10m
-                                                description: |-
-                                                    Configure the keepalive timeout for inactive or unauthorized connections.
-                                                    The gRPC agent is expected to periodically send an empty response to the client, on which the client is expected to respond with an empty request.
-                                                    If the client does not respond within the keepalive timeout, the gRPC agent should close the connection.
-                                                    The default interval value is 10 minutes.
-                                                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                                                type: string
-                                            maxConcurrentCall:
-                                                default: 8
-                                                description: |-
-                                                    The maximum number of concurrent gNMI calls that can be made to the gRPC server on the switch for each VRF.
-                                                    Configure a limit from 1 through 16. The default limit is 8.
-                                                maximum: 16
-                                                minimum: 1
-                                                type: integer
-                                        type: object
-                                    port:
-                                        default: 9339
-                                        description: |-
-                                            The TCP port on which the gRPC server should listen.
-                                            The range of port-id is from 1024 to 65535.
-                                            Port 9339 is the default.
-                                        format: int32
-                                        maximum: 65535
-                                        minimum: 1024
-                                        type: integer
-                                    vrfName:
-                                        description: Enable the gRPC agent to accept incoming (dial-in) RPC requests from a given vrf.
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                type: object
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Interface to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            ssh:
-                                default:
-                                    enabled: true
-                                    sessionLimit: 32
-                                    timeout: 10m
-                                description: Configuration for the SSH server on the device.
-                                properties:
-                                    enabled:
-                                        default: true
-                                        description: |-
-                                            Enable or disable the SSH server on the device.
-                                            If not specified, the SSH server is enabled by default.
-                                        type: boolean
-                                    sessionLimit:
-                                        default: 32
-                                        description: |-
-                                            The maximum number of concurrent SSH sessions allowed.
-                                            If not specified, the default limit is 32.
-                                        maximum: 64
-                                        minimum: 1
-                                        type: integer
-                                    timeout:
-                                        default: 10m
-                                        description: |-
-                                            The timeout duration for SSH sessions.
-                                            If not specified, the default timeout is 10 minutes.
-                                        type: string
-                                type: object
-                        required:
-                            - deviceRef
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the ManagementAccess.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              grpc:
+                default:
+                  enabled: true
+                  port: 9339
+                description: |-
+                  Configuration for the gRPC server on the device.
+                  Currently, only a single "default" gRPC server is supported.
+                properties:
+                  certificateId:
+                    description: |-
+                      Name of the certificate that is associated with the gRPC service.
+                      The certificate is provisioned through other interfaces on the device,
+                      such as e.g. the gNOI certificate management service.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                  enabled:
+                    default: true
+                    description: |-
+                      Enable or disable the gRPC server on the device.
+                      If not specified, the gRPC server is enabled by default.
+                    type: boolean
+                  gnmi:
+                    default:
+                      keepAliveTimeout: 10m
+                      maxConcurrentCall: 8
+                    description: |-
+                      Additional gNMI configuration for the gRPC server.
+                      This may not be supported by all devices.
+                    properties:
+                      keepAliveTimeout:
+                        default: 10m
+                        description: |-
+                          Configure the keepalive timeout for inactive or unauthorized connections.
+                          The gRPC agent is expected to periodically send an empty response to the client, on which the client is expected to respond with an empty request.
+                          If the client does not respond within the keepalive timeout, the gRPC agent should close the connection.
+                          The default interval value is 10 minutes.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                        type: string
+                      maxConcurrentCall:
+                        default: 8
+                        description: |-
+                          The maximum number of concurrent gNMI calls that can be made to the gRPC server on the switch for each VRF.
+                          Configure a limit from 1 through 16. The default limit is 8.
+                        maximum: 16
+                        minimum: 1
+                        type: integer
+                    type: object
+                  port:
+                    default: 9339
+                    description: |-
+                      The TCP port on which the gRPC server should listen.
+                      The range of port-id is from 1024 to 65535.
+                      Port 9339 is the default.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1024
+                    type: integer
+                  vrfName:
+                    description: Enable the gRPC agent to accept incoming (dial-in)
+                      RPC requests from a given vrf.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                type: object
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Interface to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              ssh:
+                default:
+                  enabled: true
+                  sessionLimit: 32
+                  timeout: 10m
+                description: Configuration for the SSH server on the device.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enable or disable the SSH server on the device.
+                      If not specified, the SSH server is enabled by default.
+                    type: boolean
+                  sessionLimit:
+                    default: 32
+                    description: |-
+                      The maximum number of concurrent SSH sessions allowed.
+                      If not specified, the default limit is 32.
+                    maximum: 64
+                    minimum: 1
+                    type: integer
+                  timeout:
+                    default: 10m
+                    description: |-
+                      The timeout duration for SSH sessions.
+                      If not specified, the default timeout is 10 minutes.
+                    type: string
+                type: object
+            required:
+            - deviceRef
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the ManagementAccess.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/networkvirtualizationedgeconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/networkvirtualizationedgeconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -2,94 +2,97 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: networkvirtualizationedgeconfigs.nx.cisco.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: networkvirtualizationedgeconfigs.nx.cisco.networking.metal.ironcore.dev
 spec:
-    group: nx.cisco.networking.metal.ironcore.dev
-    names:
-        kind: NetworkVirtualizationEdgeConfig
-        listKind: NetworkVirtualizationEdgeConfigList
-        plural: networkvirtualizationedgeconfigs
-        shortNames:
-            - nveconfig
-        singular: networkvirtualizationedgeconfig
-    scope: Namespaced
-    versions:
-        - name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: NetworkVirtualizationEdgeConfig is the Schema for the NetworkVirtualizationEdgeConfig API
-                properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: spec defines the desired state of NVE
-                        properties:
-                            advertiseVirtualMAC:
-                                default: false
-                                description: AdvertiseVirtualMAC controls if the NVE should advertise a virtual MAC address
-                                type: boolean
-                            holdDownTime:
-                                default: 180
-                                description: HoldDownTime defines the duration for which the switch suppresses the advertisement of the NVE loopback address.
-                                maximum: 1500
-                                minimum: 1
-                                type: integer
-                            infraVLANs:
-                                description: |-
-                                    InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.
-                                    The total number of VLANs configured must not exceed 512.
-                                    Elements in the list must not overlap with each other.
-                                items:
-                                    description: |-
-                                        VLANListItem represents a single VLAN ID or a range start-end. If ID is set, rangeMin and rangeMax must be absent. If ID is absent, both rangeMin
-                                        and rangeMax must be set.
-                                    properties:
-                                        id:
-                                            maximum: 3967
-                                            minimum: 1
-                                            type: integer
-                                        rangeMax:
-                                            maximum: 3967
-                                            minimum: 1
-                                            type: integer
-                                        rangeMin:
-                                            maximum: 3967
-                                            minimum: 1
-                                            type: integer
-                                    type: object
-                                    x-kubernetes-validations:
-                                        - message: rangeMax must be greater than rangeMin
-                                          rule: '!has(self.rangeMax) || self.rangeMax > self.rangeMin'
-                                        - message: either ID or both rangeMin and rangeMax must be set
-                                          rule: has(self.id) || (has(self.rangeMin) && has(self.rangeMax))
-                                        - message: rangeMin and rangeMax must be omitted when ID is set
-                                          rule: '!has(self.id) || (!has(self.rangeMin) && !has(self.rangeMax))'
-                                maxItems: 10
-                                type: array
-                        type: object
-                required:
-                    - spec
-                type: object
-          served: true
-          storage: true
+  group: nx.cisco.networking.metal.ironcore.dev
+  names:
+    kind: NetworkVirtualizationEdgeConfig
+    listKind: NetworkVirtualizationEdgeConfigList
+    plural: networkvirtualizationedgeconfigs
+    shortNames:
+    - nveconfig
+    singular: networkvirtualizationedgeconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkVirtualizationEdgeConfig is the Schema for the NetworkVirtualizationEdgeConfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of NVE
+            properties:
+              advertiseVirtualMAC:
+                default: false
+                description: AdvertiseVirtualMAC controls if the NVE should advertise
+                  a virtual MAC address
+                type: boolean
+              holdDownTime:
+                default: 180
+                description: HoldDownTime defines the duration for which the switch
+                  suppresses the advertisement of the NVE loopback address.
+                maximum: 1500
+                minimum: 1
+                type: integer
+              infraVLANs:
+                description: |-
+                  InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.
+                  The total number of VLANs configured must not exceed 512.
+                  Elements in the list must not overlap with each other.
+                items:
+                  description: |-
+                    VLANListItem represents a single VLAN ID or a range start-end. If ID is set, rangeMin and rangeMax must be absent. If ID is absent, both rangeMin
+                    and rangeMax must be set.
+                  properties:
+                    id:
+                      maximum: 3967
+                      minimum: 1
+                      type: integer
+                    rangeMax:
+                      maximum: 3967
+                      minimum: 1
+                      type: integer
+                    rangeMin:
+                      maximum: 3967
+                      minimum: 1
+                      type: integer
+                  type: object
+                  x-kubernetes-validations:
+                  - message: rangeMax must be greater than rangeMin
+                    rule: '!has(self.rangeMax) || self.rangeMax > self.rangeMin'
+                  - message: either ID or both rangeMin and rangeMax must be set
+                    rule: has(self.id) || (has(self.rangeMin) && has(self.rangeMax))
+                  - message: rangeMin and rangeMax must be omitted when ID is set
+                    rule: '!has(self.id) || (!has(self.rangeMin) && !has(self.rangeMax))'
+                maxItems: 10
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
 {{- end }}

--- a/charts/network-operator/templates/crd/networkvirtualizationedges.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/networkvirtualizationedges.networking.metal.ironcore.dev.yaml
@@ -2,301 +2,316 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: networkvirtualizationedges.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: networkvirtualizationedges.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: NetworkVirtualizationEdge
-        listKind: NetworkVirtualizationEdgeList
-        plural: networkvirtualizationedges
-        shortNames:
-            - nve
-            - vtep
-        singular: networkvirtualizationedge
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Configured")].status
-              name: Configured
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Operational")].status
-              name: Operational
-              priority: 1
-              type: string
-            - jsonPath: .status.sourceInterfaceName
-              name: Source Interface
-              type: string
-            - jsonPath: .status.anycastSourceInterfaceName
-              name: Anycast Interface
-              type: string
-            - jsonPath: .status.hostReachability
-              name: HostReachability
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
+  group: networking.metal.ironcore.dev
+  names:
+    kind: NetworkVirtualizationEdge
+    listKind: NetworkVirtualizationEdgeList
+    plural: networkvirtualizationedges
+    shortNames:
+    - nve
+    - vtep
+    singular: networkvirtualizationedge
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Configured")].status
+      name: Configured
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Operational")].status
+      name: Operational
+      priority: 1
+      type: string
+    - jsonPath: .status.sourceInterfaceName
+      name: Source Interface
+      type: string
+    - jsonPath: .status.anycastSourceInterfaceName
+      name: Anycast Interface
+      type: string
+    - jsonPath: .status.hostReachability
+      name: HostReachability
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NetworkVirtualizationEdge is the Schema for the networkvirtualizationedges API
+          The NVE resource is the equivalent to an Endpoint for a Network Virtualization Overlay Object in OpenConfig (`nvo:Ep`).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkVirtualizationEdgeSpec defines the desired state of
+              a Network Virtualization Edge (NVE).
+            properties:
+              adminState:
+                description: AdminState indicates whether the interface is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              anycastGateway:
                 description: |-
-                    NetworkVirtualizationEdge is the Schema for the networkvirtualizationedges API
-                    The NVE resource is the equivalent to an Endpoint for a Network Virtualization Overlay Object in OpenConfig (`nvo:Ep`).
+                  AnycastGateway defines the distributed anycast gateway configuration.
+                  This enables multiple NVEs to share the same gateway IP and MAC
+                  for active-active first-hop redundancy.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: NetworkVirtualizationEdgeSpec defines the desired state of a Network Virtualization Edge (NVE).
-                        properties:
-                            adminState:
-                                description: AdminState indicates whether the interface is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            anycastGateway:
-                                description: |-
-                                    AnycastGateway defines the distributed anycast gateway configuration.
-                                    This enables multiple NVEs to share the same gateway IP and MAC
-                                    for active-active first-hop redundancy.
-                                properties:
-                                    virtualMAC:
-                                        description: |-
-                                            VirtualMAC is the shared MAC address used by all NVEs in the fabric
-                                            for anycast gateway functionality on RoutedVLAN (SVI) interfaces.
-                                            All switches in the fabric must use the same MAC address.
-                                            Format: IEEE 802 MAC-48 address (e.g., "00:00:5E:00:01:01")
-                                        pattern: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
-                                        type: string
-                                required:
-                                    - virtualMAC
-                                type: object
-                            anycastSourceInterfaceRef:
-                                description: AnycastSourceInterfaceRef is the reference to the loopback interface used for anycast NVE IP address.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            hostReachability:
-                                description: HostReachability specifies the method used for host reachability.
-                                enum:
-                                    - FloodAndLearn
-                                    - BGP
-                                type: string
-                            multicastGroups:
-                                description: MulticastGroups defines multicast group addresses for BUM traffic.
-                                properties:
-                                    l2:
-                                        description: L2 is the multicast group for Layer 2 VNIs (BUM traffic in bridged VLANs).
-                                        format: ipv4
-                                        type: string
-                                    l3:
-                                        description: L3 is the multicast group for Layer 3 VNIs (BUM traffic in routed VRFs).
-                                        format: ipv4
-                                        type: string
-                                type: object
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration for this NVE.
-                                    If not specified the provider applies the target platform's default settings.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            sourceInterfaceRef:
-                                description: SourceInterface is the reference to the loopback interface used for the primary NVE IP address.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            suppressARP:
-                                default: false
-                                description: SuppressARP indicates whether ARP suppression is enabled for this NVE.
-                                type: boolean
-                        required:
-                            - adminState
-                            - deviceRef
-                            - hostReachability
-                            - sourceInterfaceRef
-                        type: object
-                        x-kubernetes-validations:
-                            - message: anycastSourceInterfaceRef.name must differ from sourceInterfaceRef.name
-                              rule: '!has(self.anycastSourceInterfaceRef) || self.anycastSourceInterfaceRef.name != self.sourceInterfaceRef.name'
-                    status:
-                        description: NetworkVirtualizationEdgeStatus defines the observed state of the NVE.
-                        properties:
-                            anycastSourceInterfaceName:
-                                description: AnycastSourceInterfaceName is the resolved anycast source interface IP address used for NVE encapsulation.
-                                type: string
-                            conditions:
-                                description: |-
-                                    conditions represent the current state of the NVE resource.
-                                    Each condition has a unique type and reflects the status of a specific aspect of the resource.
-
-                                    Standard condition types include:
-                                    - "Available": the resource is fully functional
-                                    - "Progressing": the resource is being created or updated
-                                    - "Degraded": the resource failed to reach or maintain its desired state
-
-                                    The conditions are a list of status objects that describe the state of the NVE.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            hostReachability:
-                                description: HostReachability indicates the actual method used for host reachability.
-                                type: string
-                            sourceInterfaceName:
-                                description: SourceInterfaceName is the resolved source interface IP address used for NVE encapsulation.
-                                type: string
-                        type: object
+                  virtualMAC:
+                    description: |-
+                      VirtualMAC is the shared MAC address used by all NVEs in the fabric
+                      for anycast gateway functionality on RoutedVLAN (SVI) interfaces.
+                      All switches in the fabric must use the same MAC address.
+                      Format: IEEE 802 MAC-48 address (e.g., "00:00:5E:00:01:01")
+                    pattern: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
+                    type: string
                 required:
-                    - spec
+                - virtualMAC
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+              anycastSourceInterfaceRef:
+                description: AnycastSourceInterfaceRef is the reference to the loopback
+                  interface used for anycast NVE IP address.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              hostReachability:
+                description: HostReachability specifies the method used for host reachability.
+                enum:
+                - FloodAndLearn
+                - BGP
+                type: string
+              multicastGroups:
+                description: MulticastGroups defines multicast group addresses for
+                  BUM traffic.
+                properties:
+                  l2:
+                    description: L2 is the multicast group for Layer 2 VNIs (BUM traffic
+                      in bridged VLANs).
+                    format: ipv4
+                    type: string
+                  l3:
+                    description: L3 is the multicast group for Layer 3 VNIs (BUM traffic
+                      in routed VRFs).
+                    format: ipv4
+                    type: string
+                type: object
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration for this NVE.
+                  If not specified the provider applies the target platform's default settings.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              sourceInterfaceRef:
+                description: SourceInterface is the reference to the loopback interface
+                  used for the primary NVE IP address.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              suppressARP:
+                default: false
+                description: SuppressARP indicates whether ARP suppression is enabled
+                  for this NVE.
+                type: boolean
+            required:
+            - adminState
+            - deviceRef
+            - hostReachability
+            - sourceInterfaceRef
+            type: object
+            x-kubernetes-validations:
+            - message: anycastSourceInterfaceRef.name must differ from sourceInterfaceRef.name
+              rule: '!has(self.anycastSourceInterfaceRef) || self.anycastSourceInterfaceRef.name
+                != self.sourceInterfaceRef.name'
+          status:
+            description: NetworkVirtualizationEdgeStatus defines the observed state
+              of the NVE.
+            properties:
+              anycastSourceInterfaceName:
+                description: AnycastSourceInterfaceName is the resolved anycast source
+                  interface IP address used for NVE encapsulation.
+                type: string
+              conditions:
+                description: |-
+                  conditions represent the current state of the NVE resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The conditions are a list of status objects that describe the state of the NVE.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              hostReachability:
+                description: HostReachability indicates the actual method used for
+                  host reachability.
+                type: string
+              sourceInterfaceName:
+                description: SourceInterfaceName is the resolved source interface
+                  IP address used for NVE encapsulation.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/ntp.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/ntp.networking.metal.ironcore.dev.yaml
@@ -2,230 +2,236 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: ntp.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: ntp.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: NTP
-        listKind: NTPList
-        plural: ntp
-        singular: ntp
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.sourceInterfaceName
-              name: Source Interface
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: NTP is the Schema for the ntp API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: NTP
+    listKind: NTPList
+    plural: ntp
+    singular: ntp
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.sourceInterfaceName
+      name: Source Interface
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NTP is the Schema for the ntp API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether NTP is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether NTP is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the NTP to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            servers:
-                                description: NTP servers.
-                                items:
-                                    properties:
-                                        address:
-                                            description: Hostname/IP address of the NTP server.
-                                            maxLength: 253
-                                            minLength: 1
-                                            type: string
-                                        prefer:
-                                            default: false
-                                            description: Indicates whether this server should be preferred or not.
-                                            type: boolean
-                                        vrfName:
-                                            description: The name of the vrf used to communicate with the NTP server.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - address
-                                    type: object
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - address
-                                x-kubernetes-list-type: map
-                            sourceInterfaceName:
-                                description: Source interface for all NTP traffic.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                        required:
-                            - deviceRef
-                            - servers
-                            - sourceInterfaceName
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the NTP.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the NTP to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              servers:
+                description: NTP servers.
+                items:
+                  properties:
+                    address:
+                      description: Hostname/IP address of the NTP server.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    prefer:
+                      default: false
+                      description: Indicates whether this server should be preferred
+                        or not.
+                      type: boolean
+                    vrfName:
+                      description: The name of the vrf used to communicate with the
+                        NTP server.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - address
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - address
+                x-kubernetes-list-type: map
+              sourceInterfaceName:
+                description: Source interface for all NTP traffic.
+                maxLength: 63
+                minLength: 1
+                type: string
+            required:
+            - deviceRef
+            - servers
+            - sourceInterfaceName
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the NTP.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/ospf.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/ospf.networking.metal.ironcore.dev.yaml
@@ -2,340 +2,351 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: ospf.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: ospf.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: OSPF
-        listKind: OSPFList
-        plural: ospf
-        singular: ospf
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.instance
-              name: Instance
-              type: string
-            - jsonPath: .spec.routerId
-              name: Router-ID
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Configured")].status
-              name: Configured
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Operational")].status
-              name: Operational
-              priority: 1
-              type: string
-            - jsonPath: .status.adjacencySummary
-              name: Adjacencies
-              priority: 1
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: OSPF is the Schema for the ospf API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: OSPF
+    listKind: OSPFList
+    plural: ospf
+    singular: ospf
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.instance
+      name: Instance
+      type: string
+    - jsonPath: .spec.routerId
+      name: Router-ID
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Configured")].status
+      name: Configured
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Operational")].status
+      name: Operational
+      priority: 1
+      type: string
+    - jsonPath: .status.adjacencySummary
+      name: Adjacencies
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OSPF is the Schema for the ospf API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the OSPF instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether the OSPF instance is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            instance:
-                                description: Instance is the process tag of the OSPF instance.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Instance is immutable
-                                      rule: self == oldSelf
-                            interfaceRefs:
-                                description: InterfaceRefs is a list of interfaces that are part of the OSPF instance.
-                                items:
-                                    description: |-
-                                        OSPFInterface defines the OSPF-specific configuration for an interface
-                                        that is participating in an OSPF instance.
-                                    properties:
-                                        area:
-                                            description: |-
-                                                Area is the OSPF area identifier for this interface.
-                                                Must be specified in dotted-quad notation (e.g., "0.0.0.0" for the backbone area).
-                                                This is semantically a 32-bit identifier displayed in IPv4 address format,
-                                                not an actual IPv4 address. Area 0 (0.0.0.0) is the OSPF backbone area and
-                                                is required for proper OSPF operation in multi-area configurations.
-                                            format: ipv4
-                                            type: string
-                                        name:
-                                            description: |-
-                                                Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        passive:
-                                            description: |-
-                                                Passive indicates whether this interface should operate in passive mode.
-                                                In passive mode, OSPF will advertise the interface's network in LSAs but will not
-                                                send or receive OSPF protocol packets (Hello, LSU, etc.) on this interface.
-                                                This is typically used for loopback interfaces where OSPF adjacencies
-                                                should not be formed but the network should still be advertised.
-                                                Defaults to false (active mode).
-                                            type: boolean
-                                    required:
-                                        - area
-                                        - name
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            logAdjacencyChanges:
-                                description: |-
-                                    LogAdjacencyChanges enables logging when the state of an OSPF neighbor changes.
-                                    When true, a log message is generated for adjacency state transitions.
-                                type: boolean
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Interface to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            routerId:
-                                description: |-
-                                    RouterID is the OSPF router identifier, used in OSPF messages to identify the originating router.
-                                    Follows dotted quad notation (IPv4 format).
-                                format: ipv4
-                                type: string
-                        required:
-                            - deviceRef
-                            - instance
-                            - routerId
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adjacencySummary:
-                                description: |-
-                                    AdjacencySummary provides a human-readable summary of neighbor adjacencies
-                                    by state (e.g., "3 Full, 1 ExStart, 1 Down").
-                                    This field is computed by the controller from the Neighbors field.
-                                type: string
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the OSPF.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            neighbors:
-                                description: Neighbors is a list of OSPF neighbors and their adjacency states.
-                                items:
-                                    description: OSPFNeighbor represents an OSPF neighbor with its adjacency information.
-                                    properties:
-                                        address:
-                                            description: Address is the IP address of the remote OSPF neighbor.
-                                            type: string
-                                        adjacencyState:
-                                            description: AdjacencyState is the current state of the adjacency with this neighbor.
-                                            enum:
-                                                - Down
-                                                - Attempt
-                                                - Init
-                                                - TwoWay
-                                                - ExStart
-                                                - Exchange
-                                                - Loading
-                                                - Full
-                                            type: string
-                                        interfaceRef:
-                                            description: InterfaceRef is a reference to the local interface through which this neighbor is connected.
-                                            properties:
-                                                name:
-                                                    description: |-
-                                                        Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    maxLength: 63
-                                                    minLength: 1
-                                                    type: string
-                                            required:
-                                                - name
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                        lastEstablishedTime:
-                                            description: |-
-                                                LastEstablishedTime is the timestamp when the adjacency last transitioned to the FULL state.
-                                                A frequently changing timestamp indicates adjacency instability (flapping).
-                                            format: date-time
-                                            type: string
-                                        priority:
-                                            description: |-
-                                                Priority is the remote system's priority to become the designated router.
-                                                Valid range is 0-255.
-                                            type: integer
-                                        routerId:
-                                            description: RouterID is the router identifier of the remote OSPF neighbor.
-                                            type: string
-                                    required:
-                                        - address
-                                        - interfaceRef
-                                        - routerId
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - routerId
-                                x-kubernetes-list-type: map
-                            observedGeneration:
-                                description: ObservedGeneration reflects the .metadata.generation that was last processed by the controller.
-                                format: int64
-                                type: integer
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              instance:
+                description: Instance is the process tag of the OSPF instance.
+                maxLength: 63
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Instance is immutable
+                  rule: self == oldSelf
+              interfaceRefs:
+                description: InterfaceRefs is a list of interfaces that are part of
+                  the OSPF instance.
+                items:
+                  description: |-
+                    OSPFInterface defines the OSPF-specific configuration for an interface
+                    that is participating in an OSPF instance.
+                  properties:
+                    area:
+                      description: |-
+                        Area is the OSPF area identifier for this interface.
+                        Must be specified in dotted-quad notation (e.g., "0.0.0.0" for the backbone area).
+                        This is semantically a 32-bit identifier displayed in IPv4 address format,
+                        not an actual IPv4 address. Area 0 (0.0.0.0) is the OSPF backbone area and
+                        is required for proper OSPF operation in multi-area configurations.
+                      format: ipv4
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    passive:
+                      description: |-
+                        Passive indicates whether this interface should operate in passive mode.
+                        In passive mode, OSPF will advertise the interface's network in LSAs but will not
+                        send or receive OSPF protocol packets (Hello, LSU, etc.) on this interface.
+                        This is typically used for loopback interfaces where OSPF adjacencies
+                        should not be formed but the network should still be advertised.
+                        Defaults to false (active mode).
+                      type: boolean
+                  required:
+                  - area
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              logAdjacencyChanges:
+                description: |-
+                  LogAdjacencyChanges enables logging when the state of an OSPF neighbor changes.
+                  When true, a log message is generated for adjacency state transitions.
+                type: boolean
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Interface to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              routerId:
+                description: |-
+                  RouterID is the OSPF router identifier, used in OSPF messages to identify the originating router.
+                  Follows dotted quad notation (IPv4 format).
+                format: ipv4
+                type: string
+            required:
+            - deviceRef
+            - instance
+            - routerId
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adjacencySummary:
+                description: |-
+                  AdjacencySummary provides a human-readable summary of neighbor adjacencies
+                  by state (e.g., "3 Full, 1 ExStart, 1 Down").
+                  This field is computed by the controller from the Neighbors field.
+                type: string
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the OSPF.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              neighbors:
+                description: Neighbors is a list of OSPF neighbors and their adjacency
+                  states.
+                items:
+                  description: OSPFNeighbor represents an OSPF neighbor with its adjacency
+                    information.
+                  properties:
+                    address:
+                      description: Address is the IP address of the remote OSPF neighbor.
+                      type: string
+                    adjacencyState:
+                      description: AdjacencyState is the current state of the adjacency
+                        with this neighbor.
+                      enum:
+                      - Down
+                      - Attempt
+                      - Init
+                      - TwoWay
+                      - ExStart
+                      - Exchange
+                      - Loading
+                      - Full
+                      type: string
+                    interfaceRef:
+                      description: InterfaceRef is a reference to the local interface
+                        through which this neighbor is connected.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    lastEstablishedTime:
+                      description: |-
+                        LastEstablishedTime is the timestamp when the adjacency last transitioned to the FULL state.
+                        A frequently changing timestamp indicates adjacency instability (flapping).
+                      format: date-time
+                      type: string
+                    priority:
+                      description: |-
+                        Priority is the remote system's priority to become the designated router.
+                        Valid range is 0-255.
+                      type: integer
+                    routerId:
+                      description: RouterID is the router identifier of the remote
+                        OSPF neighbor.
+                      type: string
+                  required:
+                  - address
+                  - interfaceRef
+                  - routerId
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - routerId
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the .metadata.generation
+                  that was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/pim.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/pim.networking.metal.ironcore.dev.yaml
@@ -2,250 +2,258 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: pim.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: pim.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: PIM
-        listKind: PIMList
-        plural: pim
-        singular: pim
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: PIM is the Schema for the pim API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: PIM
+    listKind: PIMList
+    plural: pim
+    singular: pim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PIM is the Schema for the pim API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the PIM instance is administratively
+                  up or down.
+                enum:
+                - Up
+                - Down
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether the PIM instance is administratively up or down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            interfaceRefs:
-                                description: InterfaceRefs is a list of interfaces that are part of the PIM instance.
-                                items:
-                                    properties:
-                                        mode:
-                                            default: Sparse
-                                            description: Mode is the PIM mode to use when delivering multicast traffic via this interface.
-                                            enum:
-                                                - Sparse
-                                                - Dense
-                                            type: string
-                                        name:
-                                            description: |-
-                                                Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - name
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the PIM to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            rendezvousPoints:
-                                description: RendezvousPoints defines the list of rendezvous points for sparse mode multicast.
-                                items:
-                                    properties:
-                                        address:
-                                            description: Address is the IPv4 address of the rendezvous point.
-                                            format: ipv4
-                                            type: string
-                                        anycastAddresses:
-                                            description: AnycastAddresses is a list of redundant anycast ipv4 addresses associated with the rendezvous point.
-                                            items:
-                                                format: ipv4
-                                                type: string
-                                            type: array
-                                            x-kubernetes-list-type: set
-                                        multicastGroups:
-                                            description: |-
-                                                MulticastGroups defined the list of multicast IPv4 address ranges associated with the rendezvous point.
-                                                If not specified, the rendezvous point will be used for all multicast groups.
-                                            items:
-                                                format: cidr
-                                                type: string
-                                            type: array
-                                    required:
-                                        - address
-                                    type: object
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - address
-                                x-kubernetes-list-type: map
-                        required:
-                            - deviceRef
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the PIM.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              interfaceRefs:
+                description: InterfaceRefs is a list of interfaces that are part of
+                  the PIM instance.
+                items:
+                  properties:
+                    mode:
+                      default: Sparse
+                      description: Mode is the PIM mode to use when delivering multicast
+                        traffic via this interface.
+                      enum:
+                      - Sparse
+                      - Dense
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the PIM to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              rendezvousPoints:
+                description: RendezvousPoints defines the list of rendezvous points
+                  for sparse mode multicast.
+                items:
+                  properties:
+                    address:
+                      description: Address is the IPv4 address of the rendezvous point.
+                      format: ipv4
+                      type: string
+                    anycastAddresses:
+                      description: AnycastAddresses is a list of redundant anycast
+                        ipv4 addresses associated with the rendezvous point.
+                      items:
+                        format: ipv4
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    multicastGroups:
+                      description: |-
+                        MulticastGroups defined the list of multicast IPv4 address ranges associated with the rendezvous point.
+                        If not specified, the rendezvous point will be used for all multicast groups.
+                      items:
+                        format: cidr
+                        type: string
+                      type: array
+                  required:
+                  - address
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - address
+                x-kubernetes-list-type: map
+            required:
+            - deviceRef
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the PIM.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/prefixsets.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/prefixsets.networking.metal.ironcore.dev.yaml
@@ -2,252 +2,256 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: prefixsets.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: prefixsets.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: PrefixSet
-        listKind: PrefixSetList
-        plural: prefixsets
-        singular: prefixset
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.name
-              name: Prefix Set
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.entriesSummary
-              name: Entries
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: PrefixSet is the Schema for the prefixsets API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: PrefixSet
+    listKind: PrefixSetList
+    plural: prefixsets
+    singular: prefixset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Prefix Set
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.entriesSummary
+      name: Entries
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PrefixSet is the Schema for the prefixsets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            entries:
-                                description: |-
-                                    A list of entries to apply.
-                                    The address families (IPv4, IPv6) of all prefixes in the list must match.
-                                items:
-                                    properties:
-                                        maskLengthRange:
-                                            description: |-
-                                                Optional mask length range for the prefix.
-                                                If not specified, only the exact prefix length is matched.
-                                            properties:
-                                                max:
-                                                    description: Maximum mask length.
-                                                    maximum: 128
-                                                    minimum: 0
-                                                    type: integer
-                                                min:
-                                                    description: Minimum mask length.
-                                                    maximum: 128
-                                                    minimum: 0
-                                                    type: integer
-                                            required:
-                                                - max
-                                                - min
-                                            type: object
-                                        prefix:
-                                            description: |-
-                                                IP prefix. Can be IPv4 or IPv6.
-                                                Use 0.0.0.0/0 (::/0) to represent 'any'.
-                                            format: cidr
-                                            type: string
-                                        sequence:
-                                            description: The sequence number of the Prefix entry.
-                                            format: int32
-                                            minimum: 1
-                                            type: integer
-                                    required:
-                                        - prefix
-                                        - sequence
-                                    type: object
-                                maxItems: 100
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - sequence
-                                x-kubernetes-list-type: map
-                            name:
-                                description: |-
-                                    Name is the name of the PrefixSet.
-                                    Immutable.
-                                maxLength: 32
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Name is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Banner to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        required:
-                            - deviceRef
-                            - entries
-                            - name
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the PrefixSet.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            entriesSummary:
-                                description: EntriesSummary provides a human-readable summary of the number of prefix entries.
-                                type: string
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              entries:
+                description: |-
+                  A list of entries to apply.
+                  The address families (IPv4, IPv6) of all prefixes in the list must match.
+                items:
+                  properties:
+                    maskLengthRange:
+                      description: |-
+                        Optional mask length range for the prefix.
+                        If not specified, only the exact prefix length is matched.
+                      properties:
+                        max:
+                          description: Maximum mask length.
+                          maximum: 128
+                          minimum: 0
+                          type: integer
+                        min:
+                          description: Minimum mask length.
+                          maximum: 128
+                          minimum: 0
+                          type: integer
+                      required:
+                      - max
+                      - min
+                      type: object
+                    prefix:
+                      description: |-
+                        IP prefix. Can be IPv4 or IPv6.
+                        Use 0.0.0.0/0 (::/0) to represent 'any'.
+                      format: cidr
+                      type: string
+                    sequence:
+                      description: The sequence number of the Prefix entry.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  required:
+                  - prefix
+                  - sequence
+                  type: object
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - sequence
+                x-kubernetes-list-type: map
+              name:
+                description: |-
+                  Name is the name of the PrefixSet.
+                  Immutable.
+                maxLength: 32
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Name is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Banner to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - deviceRef
+            - entries
+            - name
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the PrefixSet.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              entriesSummary:
+                description: EntriesSummary provides a human-readable summary of the
+                  number of prefix entries.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/routingpolicies.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/routingpolicies.networking.metal.ironcore.dev.yaml
@@ -2,309 +2,318 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: routingpolicies.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: routingpolicies.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: RoutingPolicy
-        listKind: RoutingPolicyList
-        plural: routingpolicies
-        shortNames:
-            - routemap
-        singular: routingpolicy
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.name
-              name: Routing Policy
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.statementsSummary
-              name: Statements
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: RoutingPolicy is the Schema for the routingpolicies API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: RoutingPolicy
+    listKind: RoutingPolicyList
+    plural: routingpolicies
+    shortNames:
+    - routemap
+    singular: routingpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Routing Policy
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.statementsSummary
+      name: Statements
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RoutingPolicy is the Schema for the routingpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            name:
-                                description: |-
-                                    Name is the identifier of the RoutingPolicy on the device.
-                                    Immutable.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Name is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Banner to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            statements:
-                                description: A list of policy statements to apply.
-                                items:
-                                    properties:
-                                        actions:
-                                            description: Actions define what to do when conditions match.
-                                            properties:
-                                                bgpActions:
-                                                    description: |-
-                                                        BgpActions specifies BGP-specific actions to apply when the route is accepted.
-                                                        Only applicable when RouteDisposition is AcceptRoute.
-                                                    properties:
-                                                        setCommunity:
-                                                            description: SetCommunity configures BGP standard community attributes.
-                                                            properties:
-                                                                communities:
-                                                                    description: |-
-                                                                        Communities is the list of BGP standard communities to set.
-                                                                        The communities must be in the format defined by [RFC 1997].
-                                                                        [RFC 1997]: https://datatracker.ietf.org/doc/html/rfc1997
-                                                                    items:
-                                                                        type: string
-                                                                    minItems: 1
-                                                                    type: array
-                                                            required:
-                                                                - communities
-                                                            type: object
-                                                        setExtCommunity:
-                                                            description: SetExtCommunity configures BGP extended community attributes.
-                                                            properties:
-                                                                communities:
-                                                                    description: |-
-                                                                        Communities is the list of BGP extended communities to set.
-                                                                        The communities must be in the format defined by [RFC 4360].
-                                                                        [RFC 4360]: https://datatracker.ietf.org/doc/html/rfc4360
-                                                                    items:
-                                                                        type: string
-                                                                    minItems: 1
-                                                                    type: array
-                                                            required:
-                                                                - communities
-                                                            type: object
-                                                    type: object
-                                                    x-kubernetes-validations:
-                                                        - message: at least one BGP action must be specified
-                                                          rule: has(self.setCommunity) || has(self.setExtCommunity)
-                                                routeDisposition:
-                                                    description: RouteDisposition specifies whether to accept or reject the route.
-                                                    enum:
-                                                        - AcceptRoute
-                                                        - RejectRoute
-                                                    type: string
-                                            required:
-                                                - routeDisposition
-                                            type: object
-                                            x-kubernetes-validations:
-                                                - message: bgpActions cannot be specified when routeDisposition is RejectRoute
-                                                  rule: self.routeDisposition == 'AcceptRoute' || !has(self.bgpActions)
-                                        conditions:
-                                            description: |-
-                                                Conditions define the match criteria for this statement.
-                                                If no conditions are specified, the statement matches all routes.
-                                            properties:
-                                                matchPrefixSet:
-                                                    description: MatchPrefixSet matches routes against a PrefixSet resource.
-                                                    properties:
-                                                        prefixSetRef:
-                                                            description: |-
-                                                                PrefixSetRef references a PrefixSet in the same namespace.
-                                                                The PrefixSet must exist and belong to the same device.
-                                                            properties:
-                                                                name:
-                                                                    description: |-
-                                                                        Name of the referent.
-                                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                                    maxLength: 63
-                                                                    minLength: 1
-                                                                    type: string
-                                                            required:
-                                                                - name
-                                                            type: object
-                                                            x-kubernetes-map-type: atomic
-                                                    required:
-                                                        - prefixSetRef
-                                                    type: object
-                                            type: object
-                                        sequence:
-                                            description: The sequence number of the policy statement.
-                                            format: int32
-                                            minimum: 1
-                                            type: integer
-                                    required:
-                                        - actions
-                                        - sequence
-                                    type: object
-                                maxItems: 100
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - sequence
-                                x-kubernetes-list-type: map
-                        required:
-                            - deviceRef
-                            - name
-                            - statements
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the RoutingPolicy.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            statementsSummary:
-                                description: StatementsSummary provides a human-readable summary of the number of policy statements.
-                                type: string
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              name:
+                description: |-
+                  Name is the identifier of the RoutingPolicy on the device.
+                  Immutable.
+                maxLength: 63
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Name is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Banner to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              statements:
+                description: A list of policy statements to apply.
+                items:
+                  properties:
+                    actions:
+                      description: Actions define what to do when conditions match.
+                      properties:
+                        bgpActions:
+                          description: |-
+                            BgpActions specifies BGP-specific actions to apply when the route is accepted.
+                            Only applicable when RouteDisposition is AcceptRoute.
+                          properties:
+                            setCommunity:
+                              description: SetCommunity configures BGP standard community
+                                attributes.
+                              properties:
+                                communities:
+                                  description: |-
+                                    Communities is the list of BGP standard communities to set.
+                                    The communities must be in the format defined by [RFC 1997].
+                                    [RFC 1997]: https://datatracker.ietf.org/doc/html/rfc1997
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                              required:
+                              - communities
+                              type: object
+                            setExtCommunity:
+                              description: SetExtCommunity configures BGP extended
+                                community attributes.
+                              properties:
+                                communities:
+                                  description: |-
+                                    Communities is the list of BGP extended communities to set.
+                                    The communities must be in the format defined by [RFC 4360].
+                                    [RFC 4360]: https://datatracker.ietf.org/doc/html/rfc4360
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                              required:
+                              - communities
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                          - message: at least one BGP action must be specified
+                            rule: has(self.setCommunity) || has(self.setExtCommunity)
+                        routeDisposition:
+                          description: RouteDisposition specifies whether to accept
+                            or reject the route.
+                          enum:
+                          - AcceptRoute
+                          - RejectRoute
+                          type: string
+                      required:
+                      - routeDisposition
+                      type: object
+                      x-kubernetes-validations:
+                      - message: bgpActions cannot be specified when routeDisposition
+                          is RejectRoute
+                        rule: self.routeDisposition == 'AcceptRoute' || !has(self.bgpActions)
+                    conditions:
+                      description: |-
+                        Conditions define the match criteria for this statement.
+                        If no conditions are specified, the statement matches all routes.
+                      properties:
+                        matchPrefixSet:
+                          description: MatchPrefixSet matches routes against a PrefixSet
+                            resource.
+                          properties:
+                            prefixSetRef:
+                              description: |-
+                                PrefixSetRef references a PrefixSet in the same namespace.
+                                The PrefixSet must exist and belong to the same device.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  maxLength: 63
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - prefixSetRef
+                          type: object
+                      type: object
+                    sequence:
+                      description: The sequence number of the policy statement.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  required:
+                  - actions
+                  - sequence
+                  type: object
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - sequence
+                x-kubernetes-list-type: map
+            required:
+            - deviceRef
+            - name
+            - statements
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the RoutingPolicy.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              statementsSummary:
+                description: StatementsSummary provides a human-readable summary of
+                  the number of policy statements.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/snmp.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/snmp.networking.metal.ironcore.dev.yaml
@@ -2,282 +2,287 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: snmp.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: snmp.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: SNMP
-        listKind: SNMPList
-        plural: snmp
-        singular: snmp
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.sourceInterfaceName
-              name: Source Interface
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: SNMP is the Schema for the snmp API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: SNMP
+    listKind: SNMPList
+    plural: snmp
+    singular: snmp
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.sourceInterfaceName
+      name: Source Interface
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SNMP is the Schema for the snmp API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              communities:
+                description: SNMP communities for SNMPv1 or SNMPv2c.
+                items:
+                  properties:
+                    aclName:
+                      description: ACL name to filter SNMP requests.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    group:
+                      description: Group to which the community belongs.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the community.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              contact:
+                description: The contact information for the SNMP server.
+                maxLength: 63
+                minLength: 1
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            communities:
-                                description: SNMP communities for SNMPv1 or SNMPv2c.
-                                items:
-                                    properties:
-                                        aclName:
-                                            description: ACL name to filter SNMP requests.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        group:
-                                            description: Group to which the community belongs.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        name:
-                                            description: Name of the community.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - name
-                                    type: object
-                                maxItems: 16
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - name
-                                x-kubernetes-list-type: map
-                            contact:
-                                description: The contact information for the SNMP server.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            hosts:
-                                description: SNMP destination hosts for SNMP traps or informs messages.
-                                items:
-                                    properties:
-                                        address:
-                                            description: The Hostname or IP address of the SNMP host to send notifications to.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        community:
-                                            description: SNMP community or user name.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        type:
-                                            default: Traps
-                                            description: Type of message to send to host. Default is traps.
-                                            enum:
-                                                - Traps
-                                                - Informs
-                                            type: string
-                                        version:
-                                            default: v2c
-                                            description: SNMP version. Default is v2c.
-                                            enum:
-                                                - v1
-                                                - v2c
-                                                - v3
-                                            type: string
-                                        vrfName:
-                                            description: The name of the vrf instance to use to source traffic.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - address
-                                    type: object
-                                maxItems: 16
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - address
-                                x-kubernetes-list-type: map
-                            location:
-                                description: The location information for the SNMP server.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the SNMP to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            sourceInterfaceName:
-                                description: The name of the interface to be used for sending out SNMP Trap/Inform notifications.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                            traps:
-                                description: The list of trap notifications to enable.
-                                items:
-                                    type: string
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-type: set
-                        required:
-                            - deviceRef
-                            - hosts
-                            - sourceInterfaceName
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the SNMP.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              hosts:
+                description: SNMP destination hosts for SNMP traps or informs messages.
+                items:
+                  properties:
+                    address:
+                      description: The Hostname or IP address of the SNMP host to
+                        send notifications to.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    community:
+                      description: SNMP community or user name.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    type:
+                      default: Traps
+                      description: Type of message to send to host. Default is traps.
+                      enum:
+                      - Traps
+                      - Informs
+                      type: string
+                    version:
+                      default: v2c
+                      description: SNMP version. Default is v2c.
+                      enum:
+                      - v1
+                      - v2c
+                      - v3
+                      type: string
+                    vrfName:
+                      description: The name of the vrf instance to use to source traffic.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - address
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - address
+                x-kubernetes-list-type: map
+              location:
+                description: The location information for the SNMP server.
+                maxLength: 63
+                minLength: 1
+                type: string
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the SNMP to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              sourceInterfaceName:
+                description: The name of the interface to be used for sending out
+                  SNMP Trap/Inform notifications.
+                maxLength: 63
+                minLength: 1
+                type: string
+              traps:
+                description: The list of trap notifications to enable.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - deviceRef
+            - hosts
+            - sourceInterfaceName
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the SNMP.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/syslogs.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/syslogs.networking.metal.ironcore.dev.yaml
@@ -2,262 +2,270 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: syslogs.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: syslogs.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: Syslog
-        listKind: SyslogList
-        plural: syslogs
-        singular: syslog
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.serversSummary
-              name: Servers
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: Syslog is the Schema for the syslogs API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: Syslog
+    listKind: SyslogList
+    plural: syslogs
+    singular: syslog
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.serversSummary
+      name: Servers
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Syslog is the Schema for the syslogs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            facilities:
-                                description: Facilities is a list of log facilities to configure on the device.
-                                items:
-                                    properties:
-                                        name:
-                                            description: The name of the log facility.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                        severity:
-                                            description: The severity level of the log messages for this facility.
-                                            enum:
-                                                - Debug
-                                                - Info
-                                                - Notice
-                                                - Warning
-                                                - Error
-                                                - Critical
-                                                - Alert
-                                                - Emergency
-                                            type: string
-                                    required:
-                                        - name
-                                        - severity
-                                    type: object
-                                maxItems: 64
-                                minItems: 1
-                                type: array
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the Interface to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            servers:
-                                description: Servers is a list of remote log servers to which the device will send logs.
-                                items:
-                                    properties:
-                                        address:
-                                            description: IP address or hostname of the remote log server
-                                            maxLength: 253
-                                            minLength: 1
-                                            type: string
-                                        port:
-                                            default: 514
-                                            description: |-
-                                                The destination port number for syslog UDP messages to
-                                                the server. The default is 514.
-                                            format: int32
-                                            type: integer
-                                        severity:
-                                            description: The servity level of the log messages sent to the server.
-                                            enum:
-                                                - Debug
-                                                - Info
-                                                - Notice
-                                                - Warning
-                                                - Error
-                                                - Critical
-                                                - Alert
-                                                - Emergency
-                                            type: string
-                                        vrfName:
-                                            description: The name of the vrf used to reach the log server.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - address
-                                        - severity
-                                        - vrfName
-                                    type: object
-                                maxItems: 16
-                                minItems: 1
-                                type: array
-                        required:
-                            - deviceRef
-                            - facilities
-                            - servers
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Banner.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            serversSummary:
-                                description: ServersSummary provides a human-readable summary of the number of log servers.
-                                type: string
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              facilities:
+                description: Facilities is a list of log facilities to configure on
+                  the device.
+                items:
+                  properties:
+                    name:
+                      description: The name of the log facility.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: The severity level of the log messages for this
+                        facility.
+                      enum:
+                      - Debug
+                      - Info
+                      - Notice
+                      - Warning
+                      - Error
+                      - Critical
+                      - Alert
+                      - Emergency
+                      type: string
+                  required:
+                  - name
+                  - severity
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the Interface to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              servers:
+                description: Servers is a list of remote log servers to which the
+                  device will send logs.
+                items:
+                  properties:
+                    address:
+                      description: IP address or hostname of the remote log server
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    port:
+                      default: 514
+                      description: |-
+                        The destination port number for syslog UDP messages to
+                        the server. The default is 514.
+                      format: int32
+                      type: integer
+                    severity:
+                      description: The servity level of the log messages sent to the
+                        server.
+                      enum:
+                      - Debug
+                      - Info
+                      - Notice
+                      - Warning
+                      - Error
+                      - Critical
+                      - Alert
+                      - Emergency
+                      type: string
+                    vrfName:
+                      description: The name of the vrf used to reach the log server.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - address
+                  - severity
+                  - vrfName
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - deviceRef
+            - facilities
+            - servers
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Banner.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              serversSummary:
+                description: ServersSummary provides a human-readable summary of the
+                  number of log servers.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/systems.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/systems.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -2,175 +2,177 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: systems.nx.cisco.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: systems.nx.cisco.networking.metal.ironcore.dev
 spec:
-    group: nx.cisco.networking.metal.ironcore.dev
-    names:
-        kind: System
-        listKind: SystemList
-        plural: systems
-        shortNames:
-            - nxsystem
-        singular: system
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: System is the Schema for the systems API
+  group: nx.cisco.networking.metal.ironcore.dev
+  names:
+    kind: System
+    listKind: SystemList
+    plural: systems
+    shortNames:
+    - nxsystem
+    singular: system
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: System is the Schema for the systems API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            jumboMtu:
-                                default: 9216
-                                description: |-
-                                    JumboMtu defines the system-wide jumbo MTU setting.
-                                    Valid values are from 1501 to 9216.
-                                maximum: 9216
-                                minimum: 1501
-                                type: integer
-                            reservedVlan:
-                                default: 3968
-                                description: |-
-                                    ReservedVlan specifies the VLAN ID to be reserved for system use.
-                                    Valid values are from 1 to 4032.
-                                maximum: 4032
-                                minimum: 1
-                                type: integer
-                            vlanLongName:
-                                default: false
-                                description: |-
-                                    VlanLongName enables or disables 128-character VLAN names
-                                    Disabled by default.
-                                type: boolean
-                        required:
-                            - deviceRef
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the Banner.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              jumboMtu:
+                default: 9216
+                description: |-
+                  JumboMtu defines the system-wide jumbo MTU setting.
+                  Valid values are from 1501 to 9216.
+                maximum: 9216
+                minimum: 1501
+                type: integer
+              reservedVlan:
+                default: 3968
+                description: |-
+                  ReservedVlan specifies the VLAN ID to be reserved for system use.
+                  Valid values are from 1 to 4032.
+                maximum: 4032
+                minimum: 1
+                type: integer
+              vlanLongName:
+                default: false
+                description: |-
+                  VlanLongName enables or disables 128-character VLAN names
+                  Disabled by default.
+                type: boolean
+            required:
+            - deviceRef
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the Banner.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/users.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/users.networking.metal.ironcore.dev.yaml
@@ -2,285 +2,291 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: users.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: users.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: User
-        listKind: UserList
-        plural: users
-        singular: user
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.username
-              name: Username
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: User is the Schema for the users API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: User
+    listKind: UserList
+    plural: users
+    singular: user
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.username
+      name: Username
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: User is the Schema for the users API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            password:
-                                description: The user password, supplied in cleartext.
-                                properties:
-                                    secretKeyRef:
-                                        description: Selects a key of a secret.
-                                        properties:
-                                            key:
-                                                description: |-
-                                                    Key is the of the entry in the secret resource's `data` or `stringData`
-                                                    field to be used.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            name:
-                                                description: Name is unique within a namespace to reference a secret resource.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            namespace:
-                                                description: |-
-                                                    Namespace defines the space within which the secret name must be unique.
-                                                    If omitted, the namespace of the object being reconciled will be used.
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - key
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                required:
-                                    - secretKeyRef
-                                type: object
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the User to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            roles:
-                                description: Role which the user is to be assigned to.
-                                items:
-                                    description: UserRole represents a role that can be assigned to a user.
-                                    properties:
-                                        name:
-                                            description: The name of the role.
-                                            maxLength: 63
-                                            minLength: 1
-                                            type: string
-                                    required:
-                                        - name
-                                    type: object
-                                maxItems: 64
-                                minItems: 1
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - name
-                                x-kubernetes-list-type: map
-                            sshPublicKey:
-                                description: SSH public key for this user.
-                                properties:
-                                    secretKeyRef:
-                                        description: Selects a key of a secret.
-                                        properties:
-                                            key:
-                                                description: |-
-                                                    Key is the of the entry in the secret resource's `data` or `stringData`
-                                                    field to be used.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            name:
-                                                description: Name is unique within a namespace to reference a secret resource.
-                                                maxLength: 253
-                                                minLength: 1
-                                                type: string
-                                            namespace:
-                                                description: |-
-                                                    Namespace defines the space within which the secret name must be unique.
-                                                    If omitted, the namespace of the object being reconciled will be used.
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - key
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                required:
-                                    - secretKeyRef
-                                type: object
-                            username:
-                                description: |-
-                                    Assigned username for this user.
-                                    Immutable.
-                                maxLength: 63
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Username is immutable
-                                      rule: self == oldSelf
-                        required:
-                            - deviceRef
-                            - password
-                            - roles
-                            - username
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the User.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              password:
+                description: The user password, supplied in cleartext.
+                properties:
+                  secretKeyRef:
+                    description: Selects a key of a secret.
+                    properties:
+                      key:
+                        description: |-
+                          Key is the of the entry in the secret resource's `data` or `stringData`
+                          field to be used.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a secret resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which the secret name must be unique.
+                          If omitted, the namespace of the object being reconciled will be used.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - secretKeyRef
+                type: object
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the User to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              roles:
+                description: Role which the user is to be assigned to.
+                items:
+                  description: UserRole represents a role that can be assigned to
+                    a user.
+                  properties:
+                    name:
+                      description: The name of the role.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              sshPublicKey:
+                description: SSH public key for this user.
+                properties:
+                  secretKeyRef:
+                    description: Selects a key of a secret.
+                    properties:
+                      key:
+                        description: |-
+                          Key is the of the entry in the secret resource's `data` or `stringData`
+                          field to be used.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a secret resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which the secret name must be unique.
+                          If omitted, the namespace of the object being reconciled will be used.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - secretKeyRef
+                type: object
+              username:
+                description: |-
+                  Assigned username for this user.
+                  Immutable.
+                maxLength: 63
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Username is immutable
+                  rule: self == oldSelf
+            required:
+            - deviceRef
+            - password
+            - roles
+            - username
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the User.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/vlans.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/vlans.networking.metal.ironcore.dev.yaml
@@ -2,258 +2,262 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: vlans.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: vlans.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: VLAN
-        listKind: VLANList
-        plural: vlans
-        singular: vlan
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.id
-              name: VLAN-ID
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .spec.name
-              name: Name
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Configured")].status
-              name: Configured
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Operational")].status
-              name: Operational
-              priority: 1
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: VLAN is the Schema for the vlans API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: VLAN
+    listKind: VLANList
+    plural: vlans
+    singular: vlan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.id
+      name: VLAN-ID
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .spec.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Configured")].status
+      name: Configured
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Operational")].status
+      name: Operational
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VLAN is the Schema for the vlans API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired state of the resource.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              adminState:
+                default: Up
+                description: AdminState indicates whether the VLAN is administratively
+                  active or inactive/suspended.
+                enum:
+                - Up
+                - Down
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Specification of the desired state of the resource.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            adminState:
-                                default: Up
-                                description: AdminState indicates whether the VLAN is administratively active or inactive/suspended.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            id:
-                                description: |-
-                                    ID is the VLAN ID. Valid values are between 1 and 4094.
-                                    Immutable.
-                                maximum: 4094
-                                minimum: 1
-                                type: integer
-                                x-kubernetes-validations:
-                                    - message: Name is immutable
-                                      rule: self == oldSelf
-                            name:
-                                description: Name is the name of the VLAN.
-                                maxLength: 128
-                                minLength: 1
-                                pattern: ^[^\s]+$
-                                type: string
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this vlan.
-                                    This reference is used to link the VLAN to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        required:
-                            - deviceRef
-                            - id
-                        type: object
-                    status:
-                        description: |-
-                            Status of the resource. This is set and updated automatically.
-                            Read-only.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            bridgedBy:
-                                description: |-
-                                    BridgedBy references the EVPNInstance that provides a L2VNI for this VLAN, if any.
-                                    This field is set when an EVPNInstance of type Bridged references this VLAN.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the VLAN.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            routedBy:
-                                description: |-
-                                    RoutedBy references the interface that provides Layer 3 routing for this VLAN, if any.
-                                    This field is set when an Interface of type RoutedVLAN references this VLAN.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              id:
+                description: |-
+                  ID is the VLAN ID. Valid values are between 1 and 4094.
+                  Immutable.
+                maximum: 4094
+                minimum: 1
+                type: integer
+                x-kubernetes-validations:
+                - message: Name is immutable
+                  rule: self == oldSelf
+              name:
+                description: Name is the name of the VLAN.
+                maxLength: 128
+                minLength: 1
+                pattern: ^[^\s]+$
+                type: string
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this vlan.
+                  This reference is used to link the VLAN to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - deviceRef
+            - id
+            type: object
+          status:
+            description: |-
+              Status of the resource. This is set and updated automatically.
+              Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bridgedBy:
+                description: |-
+                  BridgedBy references the EVPNInstance that provides a L2VNI for this VLAN, if any.
+                  This field is set when an EVPNInstance of type Bridged references this VLAN.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the VLAN.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              routedBy:
+                description: |-
+                  RoutedBy references the interface that provides Layer 3 routing for this VLAN, if any.
+                  This field is set when an Interface of type RoutedVLAN references this VLAN.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/vpcdomains.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/vpcdomains.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -2,431 +2,448 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: vpcdomains.nx.cisco.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: vpcdomains.nx.cisco.networking.metal.ironcore.dev
 spec:
-    group: nx.cisco.networking.metal.ironcore.dev
-    names:
-        kind: VPCDomain
-        listKind: VPCDomainList
-        plural: vpcdomains
-        shortNames:
-            - vpcdomain
-        singular: vpcdomain
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.domainId
-              name: Domain
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.adminState
-              name: Admin State
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Configured")].status
-              name: Configured
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Operational")].status
-              name: Operational
-              priority: 1
-              type: string
-            - jsonPath: .status.peerStatus
-              name: Peer Status
-              priority: 1
-              type: string
-            - jsonPath: .status.role
-              name: Role
-              priority: 1
-              type: string
-            - jsonPath: .status.peerLinkIf
-              name: Peer Link Interface
-              priority: 1
-              type: string
-            - jsonPath: .status.peerLinkIfOperStatus
-              name: Peer Link Status
-              priority: 1
-              type: string
-            - jsonPath: .status.keepaliveStatus
-              name: Keepalive Peer Status
-              priority: 1
-              type: string
-            - jsonPath: .status.peerUptime
-              name: Keepalive Peer Uptime
-              priority: 1
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: VPCDomain is the Schema for the VPCDomains API
+  group: nx.cisco.networking.metal.ironcore.dev
+  names:
+    kind: VPCDomain
+    listKind: VPCDomainList
+    plural: vpcdomains
+    shortNames:
+    - vpcdomain
+    singular: vpcdomain
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.domainId
+      name: Domain
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.adminState
+      name: Admin State
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Configured")].status
+      name: Configured
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Operational")].status
+      name: Operational
+      priority: 1
+      type: string
+    - jsonPath: .status.peerStatus
+      name: Peer Status
+      priority: 1
+      type: string
+    - jsonPath: .status.role
+      name: Role
+      priority: 1
+      type: string
+    - jsonPath: .status.peerLinkIf
+      name: Peer Link Interface
+      priority: 1
+      type: string
+    - jsonPath: .status.peerLinkIfOperStatus
+      name: Peer Link Status
+      priority: 1
+      type: string
+    - jsonPath: .status.keepaliveStatus
+      name: Keepalive Peer Status
+      priority: 1
+      type: string
+    - jsonPath: .status.peerUptime
+      name: Keepalive Peer Uptime
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VPCDomain is the Schema for the VPCDomains API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of VPCDomain resource
+            properties:
+              adminState:
+                default: Up
+                description: |-
+                  AdminState is the administrative state of the vPC domain (enabled/disabled).
+                  When disabled, the vPC domain is administratively shut down.
+                enum:
+                - Up
+                - Down
+                type: string
+              delayRestoreSVI:
+                default: 10
+                description: |-
+                  DelayRestoreSVI is the delay in seconds (1-3600) before bringing up interface-vlan (SVI) after peer-link comes up.
+                  This prevents traffic blackholing during convergence.
+                maximum: 3600
+                minimum: 1
+                type: integer
+              delayRestoreVPC:
+                default: 30
+                description: DelayRestoreVPC is the delay in seconds (1-3600) before
+                  bringing up the member ports after the peer-link is restored.
+                maximum: 3600
+                minimum: 1
+                type: integer
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: spec defines the desired state of VPCDomain resource
-                        properties:
-                            adminState:
-                                default: Up
-                                description: |-
-                                    AdminState is the administrative state of the vPC domain (enabled/disabled).
-                                    When disabled, the vPC domain is administratively shut down.
-                                enum:
-                                    - Up
-                                    - Down
-                                type: string
-                            delayRestoreSVI:
-                                default: 10
-                                description: |-
-                                    DelayRestoreSVI is the delay in seconds (1-3600) before bringing up interface-vlan (SVI) after peer-link comes up.
-                                    This prevents traffic blackholing during convergence.
-                                maximum: 3600
-                                minimum: 1
-                                type: integer
-                            delayRestoreVPC:
-                                default: 30
-                                description: DelayRestoreVPC is the delay in seconds (1-3600) before bringing up the member ports after the peer-link is restored.
-                                maximum: 3600
-                                minimum: 1
-                                type: integer
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            domainId:
-                                description: |-
-                                    DomainID is the vPC domain ID (1-1000).
-                                    This uniquely identifies the vPC domain and must match on both peer switches.
-                                    Changing this value will recreate the vPC domain and flap the peer-link.
-                                maximum: 1000
-                                minimum: 1
-                                type: integer
-                            fastConvergence:
-                                default:
-                                    enabled: false
-                                description: |-
-                                    FastConvergence ensures that both SVIs and member ports are shut down simultaneously when the peer-link goes down.
-                                    This synchronization helps prevent traffic loss.
-                                properties:
-                                    enabled:
-                                        description: Enabled indicates whether a configuration property is administratively enabled (true) or disabled (false).
-                                        type: boolean
-                                required:
-                                    - enabled
-                                type: object
-                            peer:
-                                description: Peer contains the vPC's domain peer configuration including peer-link, keepalive.
-                                properties:
-                                    adminState:
-                                        default: Up
-                                        description: AdminState defines the administrative state of the peer-link.
-                                        enum:
-                                            - Up
-                                            - Down
-                                        type: string
-                                    autoRecovery:
-                                        description: AutoRecovery defines auto-recovery settings for restoring vPC domain after peer failure.
-                                        properties:
-                                            enabled:
-                                                description: |-
-                                                    Enabled indicates whether auto-recovery is enabled.
-                                                    When enabled, the switch will wait for ReloadDelay seconds after peer failure
-                                                    before assuming the peer is dead and restoring the vPC's domain functionality.
-                                                type: boolean
-                                            reloadDelay:
-                                                default: 240
-                                                description: |-
-                                                    ReloadDelay is the time in seconds (60-3600) to wait before assuming the peer is dead
-                                                    and automatically attempting to restore the communication with the peer.
-                                                maximum: 3600
-                                                minimum: 60
-                                                type: integer
-                                        required:
-                                            - enabled
-                                        type: object
-                                        x-kubernetes-validations:
-                                            - message: reloadDelay must be set when enabled and absent when disabled
-                                              rule: 'self.enabled ? has(self.reloadDelay) : !has(self.reloadDelay)'
-                                    gateway:
-                                        default:
-                                            enabled: false
-                                        description: |-
-                                            Gateway enables peer-gateway functionality on this peer.
-                                            When enabled, each vPC domain peer can act as the active gateway for packets destined to the
-                                            peer's MAC address, improving convergence.
-                                        properties:
-                                            enabled:
-                                                description: Enabled indicates whether a configuration property is administratively enabled (true) or disabled (false).
-                                                type: boolean
-                                        required:
-                                            - enabled
-                                        type: object
-                                    interfaceRef:
-                                        description: |-
-                                            InterfaceRef is a reference to an Interface resource and identifies the interface to be used as the vPC domain's peer-link.
-                                            This interface carries control and data traffic between the two vPC domain peers.
-                                            It is usually dedicated port-channel, but it can also be a single physical interface.
-                                        properties:
-                                            name:
-                                                description: |-
-                                                    Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                        required:
-                                            - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    keepalive:
-                                        description: KeepAlive defines the out-of-band keepalive configuration.
-                                        properties:
-                                            destination:
-                                                description: |-
-                                                    Destination is the destination IP address of the vPC's domain peer keepalive interface.
-                                                    This is the IP address the local switch will send keepalive messages to.
-                                                format: ipv4
-                                                type: string
-                                            source:
-                                                description: |-
-                                                    Source is the source IP address for keepalive messages.
-                                                    This is the local IP address used to send keepalive packets to the peer.
-                                                format: ipv4
-                                                type: string
-                                            vrfName:
-                                                description: |-
-                                                    The name of the vrf used to send keepalive packets to the peer.
-                                                    Mutually exclusive with VrfRef.
-                                                maxLength: 63
-                                                minLength: 1
-                                                type: string
-                                            vrfRef:
-                                                description: |-
-                                                    The reference to a VRF resource used to send keepalive packets to the peer.
-                                                    Mutually exclusive with VrfName.
-                                                properties:
-                                                    name:
-                                                        description: |-
-                                                            Name of the referent.
-                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        maxLength: 63
-                                                        minLength: 1
-                                                        type: string
-                                                required:
-                                                    - name
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                        required:
-                                            - destination
-                                            - source
-                                        type: object
-                                        x-kubernetes-validations:
-                                            - message: Exactly one of vrfName or vrfRef must be specified
-                                              rule: has(self.vrfName) != has(self.vrfRef)
-                                    l3router:
-                                        default:
-                                            enabled: false
-                                        description: L3Router enables Layer 3 peer-router functionality on this peer.
-                                        properties:
-                                            enabled:
-                                                description: Enabled indicates whether a configuration property is administratively enabled (true) or disabled (false).
-                                                type: boolean
-                                        required:
-                                            - enabled
-                                        type: object
-                                    switch:
-                                        default:
-                                            enabled: false
-                                        description: |-
-                                            Switch enables peer-switch functionality on this peer.
-                                            When enabled, both vPC domain peers use the same spanning-tree bridge ID, allowing both
-                                            to forward traffic for all VLANs without blocking any ports.
-                                        properties:
-                                            enabled:
-                                                description: Enabled indicates whether a configuration property is administratively enabled (true) or disabled (false).
-                                                type: boolean
-                                        required:
-                                            - enabled
-                                        type: object
-                                required:
-                                    - interfaceRef
-                                    - keepalive
-                                type: object
-                            rolePriority:
-                                default: 32667
-                                description: |-
-                                    RolePriority is the role priority for this vPC domain (1-65535).
-                                    The switch with the lower role priority becomes the operational primary.
-                                format: int32
-                                maximum: 65535
-                                minimum: 1
-                                type: integer
-                            systemPriority:
-                                default: 32667
-                                description: |-
-                                    SystemPriority is the system priority for this vPC domain (1-65535).
-                                    Used to ensure that the vPC domain devices are primary devices on LACP. Must match on both peers.
-                                format: int32
-                                maximum: 65535
-                                minimum: 1
-                                type: integer
-                        required:
-                            - deviceRef
-                            - domainId
-                            - peer
-                        type: object
-                    status:
-                        description: status defines the observed state of VPCDomain resource
-                        properties:
-                            conditions:
-                                description: |-
-                                    Conditions represent the latest available observations about the vPCDomain state.
-                                    Standard conditions include:
-                                    - Ready: overall readiness of the vPC domain
-                                    - Configured: whether the vPCDomain configuration was successfully applied to the device
-                                    - Operational: whether the vPC domain is operationally up. This condition is true when
-                                      the status fields `PeerLinkIfOperStatus`, `KeepAliveStatus`, and `PeerStatus` are all set
-                                      to `UP`.
-
-                                    For this Cisco model there is not one single unique operational property that reflects the
-                                    operational status of the vPC domain. The combination of peer status, keepalive status, and
-                                    the interface used as peer-link determine the overall health and operational condition of
-                                    the vPC domain.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                            keepaliveStatus:
-                                description: KeepAliveStatus indicates the status of the peer via the keepalive link.
-                                type: string
-                            keepaliveStatusMsg:
-                                description: KeepAliveStatusMsg provides additional information about the keepalive status, a list of strings reported by the device.
-                                items:
-                                    type: string
-                                type: array
-                            peerLinkIf:
-                                description: PeerLinkIf is the name of the interface used as the vPC domain peer-link.
-                                type: string
-                            peerLinkIfOperStatus:
-                                description: PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`.
-                                type: string
-                            peerStatus:
-                                description: |-
-                                    PeerStatus indicates the status of the vPC domain peer-link in the latest consistency check with the peer. This means that if
-                                    the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status
-                                    will remain unchanged (with the value of the last check).
-                                type: string
-                            peerStatusMsg:
-                                description: PeerStatusMsg provides additional information about the peer status, a list of strings reported by the device.
-                                items:
-                                    type: string
-                                type: array
-                            peerUptime:
-                                description: PeerUptime indicates how long the vPC domain peer has been up and reachable via keepalive.
-                                type: string
-                            role:
-                                description: Role indicates the current operational role of this vPC domain peer.
-                                type: string
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              domainId:
+                description: |-
+                  DomainID is the vPC domain ID (1-1000).
+                  This uniquely identifies the vPC domain and must match on both peer switches.
+                  Changing this value will recreate the vPC domain and flap the peer-link.
+                maximum: 1000
+                minimum: 1
+                type: integer
+              fastConvergence:
+                default:
+                  enabled: false
+                description: |-
+                  FastConvergence ensures that both SVIs and member ports are shut down simultaneously when the peer-link goes down.
+                  This synchronization helps prevent traffic loss.
+                properties:
+                  enabled:
+                    description: Enabled indicates whether a configuration property
+                      is administratively enabled (true) or disabled (false).
+                    type: boolean
+                required:
+                - enabled
+                type: object
+              peer:
+                description: Peer contains the vPC's domain peer configuration including
+                  peer-link, keepalive.
+                properties:
+                  adminState:
+                    default: Up
+                    description: AdminState defines the administrative state of the
+                      peer-link.
+                    enum:
+                    - Up
+                    - Down
+                    type: string
+                  autoRecovery:
+                    description: AutoRecovery defines auto-recovery settings for restoring
+                      vPC domain after peer failure.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled indicates whether auto-recovery is enabled.
+                          When enabled, the switch will wait for ReloadDelay seconds after peer failure
+                          before assuming the peer is dead and restoring the vPC's domain functionality.
+                        type: boolean
+                      reloadDelay:
+                        default: 240
+                        description: |-
+                          ReloadDelay is the time in seconds (60-3600) to wait before assuming the peer is dead
+                          and automatically attempting to restore the communication with the peer.
+                        maximum: 3600
+                        minimum: 60
+                        type: integer
+                    required:
+                    - enabled
+                    type: object
+                    x-kubernetes-validations:
+                    - message: reloadDelay must be set when enabled and absent when
+                        disabled
+                      rule: 'self.enabled ? has(self.reloadDelay) : !has(self.reloadDelay)'
+                  gateway:
+                    default:
+                      enabled: false
+                    description: |-
+                      Gateway enables peer-gateway functionality on this peer.
+                      When enabled, each vPC domain peer can act as the active gateway for packets destined to the
+                      peer's MAC address, improving convergence.
+                    properties:
+                      enabled:
+                        description: Enabled indicates whether a configuration property
+                          is administratively enabled (true) or disabled (false).
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  interfaceRef:
+                    description: |-
+                      InterfaceRef is a reference to an Interface resource and identifies the interface to be used as the vPC domain's peer-link.
+                      This interface carries control and data traffic between the two vPC domain peers.
+                      It is usually dedicated port-channel, but it can also be a single physical interface.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  keepalive:
+                    description: KeepAlive defines the out-of-band keepalive configuration.
+                    properties:
+                      destination:
+                        description: |-
+                          Destination is the destination IP address of the vPC's domain peer keepalive interface.
+                          This is the IP address the local switch will send keepalive messages to.
+                        format: ipv4
+                        type: string
+                      source:
+                        description: |-
+                          Source is the source IP address for keepalive messages.
+                          This is the local IP address used to send keepalive packets to the peer.
+                        format: ipv4
+                        type: string
+                      vrfName:
+                        description: |-
+                          The name of the vrf used to send keepalive packets to the peer.
+                          Mutually exclusive with VrfRef.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      vrfRef:
+                        description: |-
+                          The reference to a VRF resource used to send keepalive packets to the peer.
+                          Mutually exclusive with VrfName.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - destination
+                    - source
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Exactly one of vrfName or vrfRef must be specified
+                      rule: has(self.vrfName) != has(self.vrfRef)
+                  l3router:
+                    default:
+                      enabled: false
+                    description: L3Router enables Layer 3 peer-router functionality
+                      on this peer.
+                    properties:
+                      enabled:
+                        description: Enabled indicates whether a configuration property
+                          is administratively enabled (true) or disabled (false).
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  switch:
+                    default:
+                      enabled: false
+                    description: |-
+                      Switch enables peer-switch functionality on this peer.
+                      When enabled, both vPC domain peers use the same spanning-tree bridge ID, allowing both
+                      to forward traffic for all VLANs without blocking any ports.
+                    properties:
+                      enabled:
+                        description: Enabled indicates whether a configuration property
+                          is administratively enabled (true) or disabled (false).
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                required:
+                - interfaceRef
+                - keepalive
+                type: object
+              rolePriority:
+                default: 32667
+                description: |-
+                  RolePriority is the role priority for this vPC domain (1-65535).
+                  The switch with the lower role priority becomes the operational primary.
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
+              systemPriority:
+                default: 32667
+                description: |-
+                  SystemPriority is the system priority for this vPC domain (1-65535).
+                  Used to ensure that the vPC domain devices are primary devices on LACP. Must match on both peers.
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
+            required:
+            - deviceRef
+            - domainId
+            - peer
+            type: object
+          status:
+            description: status defines the observed state of VPCDomain resource
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations about the vPCDomain state.
+                  Standard conditions include:
+                  - Ready: overall readiness of the vPC domain
+                  - Configured: whether the vPCDomain configuration was successfully applied to the device
+                  - Operational: whether the vPC domain is operationally up. This condition is true when
+                    the status fields `PeerLinkIfOperStatus`, `KeepAliveStatus`, and `PeerStatus` are all set
+                    to `UP`.
+
+                  For this Cisco model there is not one single unique operational property that reflects the
+                  operational status of the vPC domain. The combination of peer status, keepalive status, and
+                  the interface used as peer-link determine the overall health and operational condition of
+                  the vPC domain.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              keepaliveStatus:
+                description: KeepAliveStatus indicates the status of the peer via
+                  the keepalive link.
+                type: string
+              keepaliveStatusMsg:
+                description: KeepAliveStatusMsg provides additional information about
+                  the keepalive status, a list of strings reported by the device.
+                items:
+                  type: string
+                type: array
+              peerLinkIf:
+                description: PeerLinkIf is the name of the interface used as the vPC
+                  domain peer-link.
+                type: string
+              peerLinkIfOperStatus:
+                description: PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`.
+                type: string
+              peerStatus:
+                description: |-
+                  PeerStatus indicates the status of the vPC domain peer-link in the latest consistency check with the peer. This means that if
+                  the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status
+                  will remain unchanged (with the value of the last check).
+                type: string
+              peerStatusMsg:
+                description: PeerStatusMsg provides additional information about the
+                  peer status, a list of strings reported by the device.
+                items:
+                  type: string
+                type: array
+              peerUptime:
+                description: PeerUptime indicates how long the vPC domain peer has
+                  been up and reachable via keepalive.
+                type: string
+              role:
+                description: Role indicates the current operational role of this vPC
+                  domain peer.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/crd/vrfs.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/vrfs.networking.metal.ironcore.dev.yaml
@@ -2,260 +2,268 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        {{- if .Values.crd.keep }}
-        "helm.sh/resource-policy": keep
-        {{- end }}
-        controller-gen.kubebuilder.io/version: v0.20.1
-    name: vrfs.networking.metal.ironcore.dev
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: vrfs.networking.metal.ironcore.dev
 spec:
-    group: networking.metal.ironcore.dev
-    names:
-        kind: VRF
-        listKind: VRFList
-        plural: vrfs
-        singular: vrf
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .spec.name
-              name: VRF
-              type: string
-            - jsonPath: .spec.deviceRef.name
-              name: Device
-              type: string
-            - jsonPath: .spec.routeDistinguisher
-              name: Route Distinguisher
-              priority: 1
-              type: string
-            - jsonPath: .status.conditions[?(@.type=="Ready")].status
-              name: Ready
-              type: string
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                description: VRF is the Schema for the vrfs API
+  group: networking.metal.ironcore.dev
+  names:
+    kind: VRF
+    listKind: VRFList
+    plural: vrfs
+    singular: vrf
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: VRF
+      type: string
+    - jsonPath: .spec.deviceRef.name
+      name: Device
+      type: string
+    - jsonPath: .spec.routeDistinguisher
+      name: Route Distinguisher
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VRF is the Schema for the vrfs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              spec defines the desired state of VRF
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              description:
+                description: Description provides a human-readable description of
+                  the VRF.
+                maxLength: 255
+                minLength: 1
+                type: string
+              deviceRef:
+                description: |-
+                  DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
+                  Immutable.
                 properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            spec defines the desired state of VRF
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            description:
-                                description: Description provides a human-readable description of the VRF.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                            deviceRef:
-                                description: |-
-                                    DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
-                                    Immutable.
-                                properties:
-                                    name:
-                                        description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        maxLength: 63
-                                        minLength: 1
-                                        type: string
-                                required:
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                                x-kubernetes-validations:
-                                    - message: DeviceRef is immutable
-                                      rule: self == oldSelf
-                            name:
-                                description: |-
-                                    Name is the name of the VRF.
-                                    Immutable.
-                                maxLength: 32
-                                minLength: 1
-                                type: string
-                                x-kubernetes-validations:
-                                    - message: Name is immutable
-                                      rule: self == oldSelf
-                            providerConfigRef:
-                                description: |-
-                                    ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
-                                    This reference is used to link the VRF to its provider-specific configuration.
-                                properties:
-                                    apiVersion:
-                                        description: APIVersion is the api group version of the resource being referenced.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
-                                        type: string
-                                    kind:
-                                        description: |-
-                                            Kind of the resource being referenced.
-                                            Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                        type: string
-                                    name:
-                                        description: |-
-                                            Name of the resource being referenced.
-                                            Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
-                                        maxLength: 253
-                                        minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                        type: string
-                                required:
-                                    - apiVersion
-                                    - kind
-                                    - name
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            routeDistinguisher:
-                                description: |-
-                                    RouteDistinguisher is the route distinguisher for the VRF.
-                                    Formats supported:
-                                     - Type 0: ASN(0-65535):Number(0-4294967295)
-                                     - Type 1: IPv4:Number(0-65535)
-                                     - Type 2: ASN(65536-4294967295):Number(0-65535)
-
-                                    Validation via admission webhook for the VRF type.
-                                type: string
-                            routeTargets:
-                                description: RouteTargets is the list of route targets for the VRF.
-                                items:
-                                    properties:
-                                        action:
-                                            description: Action defines whether the route target is imported, exported, or both
-                                            enum:
-                                                - Import
-                                                - Export
-                                                - Both
-                                            type: string
-                                        addressFamilies:
-                                            description: AddressFamilies is the list of address families for the route target.
-                                            items:
-                                                description: RouteTargetAF represents a supported address family value.
-                                                enum:
-                                                    - IPv4
-                                                    - IPv6
-                                                    - IPv4EVPN
-                                                    - IPv6EVPN
-                                                type: string
-                                            minItems: 1
-                                            type: array
-                                            x-kubernetes-list-type: set
-                                        value:
-                                            description: |-
-                                                Value is the route target value, must have the format as VRFSpec.RouteDistinguisher. Validation via
-                                                admission webhook.
-                                            type: string
-                                    required:
-                                        - action
-                                        - addressFamilies
-                                        - value
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - value
-                                x-kubernetes-list-type: map
-                            vni:
-                                description: VNI is the VXLAN Network Identifier for the VRF (always an L3).
-                                format: int32
-                                maximum: 16777215
-                                minimum: 1
-                                type: integer
-                        required:
-                            - deviceRef
-                            - name
-                        type: object
-                    status:
-                        description: |-
-                            status of the resource. This is set and updated automatically.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            conditions:
-                                description: The conditions are a list of status objects that describe the state of the VRF.
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
                 required:
-                    - spec
+                - name
                 type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: DeviceRef is immutable
+                  rule: self == oldSelf
+              name:
+                description: |-
+                  Name is the name of the VRF.
+                  Immutable.
+                maxLength: 32
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: Name is immutable
+                  rule: self == oldSelf
+              providerConfigRef:
+                description: |-
+                  ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
+                  This reference is used to link the VRF to its provider-specific configuration.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the api group version of the resource
+                      being referenced.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/)?([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the resource being referenced.
+                      Kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: |-
+                      Name of the resource being referenced.
+                      Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              routeDistinguisher:
+                description: |-
+                  RouteDistinguisher is the route distinguisher for the VRF.
+                  Formats supported:
+                   - Type 0: ASN(0-65535):Number(0-4294967295)
+                   - Type 1: IPv4:Number(0-65535)
+                   - Type 2: ASN(65536-4294967295):Number(0-65535)
+
+                  Validation via admission webhook for the VRF type.
+                type: string
+              routeTargets:
+                description: RouteTargets is the list of route targets for the VRF.
+                items:
+                  properties:
+                    action:
+                      description: Action defines whether the route target is imported,
+                        exported, or both
+                      enum:
+                      - Import
+                      - Export
+                      - Both
+                      type: string
+                    addressFamilies:
+                      description: AddressFamilies is the list of address families
+                        for the route target.
+                      items:
+                        description: RouteTargetAF represents a supported address
+                          family value.
+                        enum:
+                        - IPv4
+                        - IPv6
+                        - IPv4EVPN
+                        - IPv6EVPN
+                        type: string
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: set
+                    value:
+                      description: |-
+                        Value is the route target value, must have the format as VRFSpec.RouteDistinguisher. Validation via
+                        admission webhook.
+                      type: string
+                  required:
+                  - action
+                  - addressFamilies
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - value
+                x-kubernetes-list-type: map
+              vni:
+                description: VNI is the VXLAN Network Identifier for the VRF (always
+                  an L3).
+                format: int32
+                maximum: 16777215
+                minimum: 1
+                type: integer
+            required:
+            - deviceRef
+            - name
+            type: object
+          status:
+            description: |-
+              status of the resource. This is set and updated automatically.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              conditions:
+                description: The conditions are a list of status objects that describe
+                  the state of the VRF.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/network-operator/templates/extras/controller-manager-provisioning-service.yaml
+++ b/charts/network-operator/templates/extras/controller-manager-provisioning-service.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 kind: Service
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        control-plane: controller-manager
-    name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-provisioning-service" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-provisioning-service" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    ports:
-        - name: https
-          port: 8080
-          protocol: TCP
-          targetPort: 8080
-    selector:
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        control-plane: controller-manager
-    type: ClusterIP
+  ports:
+  - name: https
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    control-plane: controller-manager
+  type: ClusterIP

--- a/charts/network-operator/templates/manager/manager.yaml
+++ b/charts/network-operator/templates/manager/manager.yaml
@@ -1,108 +1,108 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.manager.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "network-operator.name" . }}
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
         app.kubernetes.io/name: {{ include "network-operator.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
         control-plane: controller-manager
-    name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-    namespace: {{ .Release.Namespace }}
-spec:
-    replicas: 1
-    selector:
-        matchLabels:
-            app.kubernetes.io/name: {{ include "network-operator.name" . }}
-            control-plane: controller-manager
-    template:
-        metadata:
-            annotations:
-                kubectl.kubernetes.io/default-container: manager
-            labels:
-                app.kubernetes.io/name: {{ include "network-operator.name" . }}
-                helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-                app.kubernetes.io/instance: {{ .Release.Name }}
-                app.kubernetes.io/managed-by: {{ .Release.Service }}
-                control-plane: controller-manager
-        spec:
-            {{- with .Values.manager.tolerations }}
-            tolerations: {{ toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.manager.affinity }}
-            affinity: {{ toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.manager.nodeSelector }}
-            nodeSelector: {{ toYaml . | nindent 16 }}
-            {{- end }}
-            containers:
-                - args:
-                    {{- if .Values.metrics.enable }}
-                    - --metrics-bind-address=:{{ .Values.metrics.port }}
-                    {{- else }}
-                    # Bind to :0 to disable the controller-runtime managed metrics server
-                    - --metrics-bind-address=0
-                    {{- end }}
-                    - --health-probe-bind-address=:8081
-                    {{- range .Values.manager.args }}
-                    - {{ . }}
-                    {{- end }}
-                    {{- if .Values.certManager.enable }}
-                    - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-                    {{- end }}
-                  command:
-                    - /manager
-                  image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
-                  imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
-                  livenessProbe:
-                    httpGet:
-                        path: /healthz
-                        port: 8081
-                    initialDelaySeconds: 15
-                    periodSeconds: 20
-                  name: manager
-                  ports:
-                    - containerPort: {{ .Values.webhook.port }}
-                      name: webhook-server
-                      protocol: TCP
-                    - containerPort: 8080
-                      name: provisioning
-                      protocol: TCP
-                  readinessProbe:
-                    httpGet:
-                        path: /readyz
-                        port: 8081
-                    initialDelaySeconds: 5
-                    periodSeconds: 10
-                  resources:
-                    {{- if .Values.manager.resources }}
-                    {{- toYaml .Values.manager.resources | nindent 20 }}
-                    {{- else }}
-                    {}
-                    {{- end }}
-                  securityContext:
-                    {{- if .Values.manager.securityContext }}
-                    {{- toYaml .Values.manager.securityContext | nindent 20 }}
-                    {{- else }}
-                    {}
-                    {{- end }}
-                  volumeMounts:
-                    {{- if .Values.certManager.enable }}
-                    - mountPath: /tmp/k8s-webhook-server/serving-certs
-                      name: webhook-certs
-                      readOnly: true
-                    {{- end }}
-            securityContext:
-              {{- if .Values.manager.podSecurityContext }}
-              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
-              {{- else }}
-              {}
-              {{- end }}
-            serviceAccountName: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-            terminationGracePeriodSeconds: 10
-            volumes:
-                {{- if .Values.certManager.enable }}
-                - name: webhook-certs
-                  secret:
-                    secretName: webhook-server-cert
-                {{- end }}
+    spec:
+      {{- with .Values.manager.tolerations }}
+      tolerations: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.manager.affinity }}
+      affinity: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.manager.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 10 }}
+      {{- end }}
+      containers:
+      - args:
+        {{- if .Values.metrics.enable }}
+        - --metrics-bind-address=:{{ .Values.metrics.port }}
+        {{- else }}
+        # Bind to :0 to disable the controller-runtime managed metrics server
+        - --metrics-bind-address=0
+        {{- end }}
+        - --health-probe-bind-address=:8081
+        {{- range .Values.manager.args }}
+        - {{ . }}
+        {{- end }}
+        {{- if .Values.certManager.enable }}
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        {{- end }}
+        command:
+        - /manager
+        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+        imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: {{ .Values.webhook.port }}
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8080
+          name: provisioning
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- if .Values.manager.resources }}
+          {{- toYaml .Values.manager.resources | nindent 10 }}
+          {{- else }}
+          {}
+          {{- end }}
+        securityContext:
+          {{- if .Values.manager.securityContext }}
+          {{- toYaml .Values.manager.securityContext | nindent 10 }}
+          {{- else }}
+          {}
+          {{- end }}
+        volumeMounts:
+        {{- if .Values.certManager.enable }}
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
+          readOnly: true
+        {{- end }}
+      securityContext:
+        {{- if .Values.manager.podSecurityContext }}
+        {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
+        {{- else }}
+        {}
+        {{- end }}
+      serviceAccountName: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      {{- if .Values.certManager.enable }}
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      {{- end }}

--- a/charts/network-operator/templates/metrics/controller-manager-metrics-service.yaml
+++ b/charts/network-operator/templates/metrics/controller-manager-metrics-service.yaml
@@ -2,21 +2,21 @@
 apiVersion: v1
 kind: Service
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        control-plane: controller-manager
-    name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    ports:
-        - name: https
-          port: {{ .Values.metrics.port }}
-          protocol: TCP
-          targetPort: {{ .Values.metrics.port }}
-    selector:
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        control-plane: controller-manager
+  ports:
+  - name: https
+    port: {{ .Values.metrics.port }}
+    protocol: TCP
+    targetPort: {{ .Values.metrics.port }}
+  selector:
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    control-plane: controller-manager
 {{- end }}

--- a/charts/network-operator/templates/rbac/accesscontrollist-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/accesscontrollist-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "accesscontrollist-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "accesscontrollist-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/accesscontrollist-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/accesscontrollist-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "accesscontrollist-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "accesscontrollist-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/accesscontrollist-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/accesscontrollist-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "accesscontrollist-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "accesscontrollist-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/banner-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/banner-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "banner-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "banner-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - banners
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - banners/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - banners
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - banners/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/banner-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/banner-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "banner-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "banner-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - banners
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - banners/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - banners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - banners/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/banner-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/banner-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "banner-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "banner-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - banners
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - banners/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - banners
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - banners/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/certificate-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/certificate-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "certificate-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "certificate-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - certificates
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - certificates/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - certificates
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - certificates/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/certificate-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/certificate-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "certificate-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "certificate-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - certificates
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - certificates/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - certificates/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/certificate-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/certificate-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "certificate-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "certificate-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - certificates
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - certificates/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - certificates/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/controller-manager.yaml
+++ b/charts/network-operator/templates/rbac/controller-manager.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/network-operator/templates/rbac/core-bgp-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/core-bgp-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgp-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgp-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgp
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgp
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-bgp-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/core-bgp-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgp-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgp-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgp
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgp
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-bgp-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/core-bgp-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgp-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgp-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgp
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgp
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-bgppeer-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/core-bgppeer-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgppeer-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgppeer-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgppeers
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgppeers/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgppeers
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgppeers/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-bgppeer-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/core-bgppeer-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgppeer-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgppeer-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgppeers
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgppeers/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgppeers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgppeers/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-bgppeer-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/core-bgppeer-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgppeer-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-bgppeer-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgppeers
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - bgppeers/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgppeers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - bgppeers/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-ospf-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/core-ospf-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-ospf-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-ospf-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ospf
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ospf/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ospf
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ospf/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-ospf-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/core-ospf-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-ospf-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-ospf-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ospf
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ospf/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ospf
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ospf/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-ospf-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/core-ospf-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-ospf-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-ospf-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ospf
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ospf/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ospf
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ospf/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-pim-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/core-pim-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-pim-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-pim-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - pim
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - pim/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - pim
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - pim/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-pim-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/core-pim-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-pim-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-pim-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - pim
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - pim/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - pim
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - pim/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-pim-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/core-pim-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-pim-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-pim-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - pim
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - pim/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - pim
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - pim/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-vlan-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/core-vlan-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-vlan-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-vlan-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vlans
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vlans/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vlans
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vlans/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-vlan-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/core-vlan-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-vlan-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-vlan-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vlans
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vlans/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vlans
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vlans/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/core-vlan-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/core-vlan-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "core-vlan-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "core-vlan-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vlans
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vlans/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vlans
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vlans/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/device-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/device-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "device-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "device-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - devices
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - devices/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - devices
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - devices/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/device-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/device-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "device-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "device-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - devices
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - devices/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - devices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - devices/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/device-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/device-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "device-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "device-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - devices
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - devices/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - devices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - devices/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/dns-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/dns-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "dns-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "dns-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - dns
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - dns/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - dns
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - dns/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/dns-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/dns-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "dns-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "dns-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - dns
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - dns/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - dns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - dns/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/dns-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/dns-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "dns-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "dns-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - dns
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - dns/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - dns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - dns/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/evpninstance-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/evpninstance-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "evpninstance-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "evpninstance-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - evpninstances
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - evpninstances/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - evpninstances
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - evpninstances/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/evpninstance-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/evpninstance-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "evpninstance-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "evpninstance-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - evpninstances
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - evpninstances/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - evpninstances
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - evpninstances/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/evpninstance-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/evpninstance-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "evpninstance-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "evpninstance-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - evpninstances
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - evpninstances/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - evpninstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - evpninstances/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/interface-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/interface-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "interface-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "interface-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - interfaces
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - interfaces/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - interfaces
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - interfaces/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/interface-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/interface-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "interface-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "interface-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - interfaces
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - interfaces/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - interfaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - interfaces/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/interface-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/interface-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "interface-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "interface-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - interfaces
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - interfaces/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - interfaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - interfaces/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/isis-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/isis-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "isis-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "isis-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - isis
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - isis/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - isis
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - isis/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/isis-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/isis-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "isis-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "isis-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - isis
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - isis/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - isis
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - isis/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/isis-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/isis-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "isis-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "isis-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - isis
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - isis/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - isis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - isis/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/leader-election-role.yaml
+++ b/charts/network-operator/templates/rbac/leader-election-role.yaml
@@ -1,42 +1,42 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 rules:
-    - apiGroups:
-        - ""
-      resources:
-        - configmaps
-      verbs:
-        - get
-        - list
-        - watch
-        - create
-        - update
-        - patch
-        - delete
-    - apiGroups:
-        - coordination.k8s.io
-      resources:
-        - leases
-      verbs:
-        - get
-        - list
-        - watch
-        - create
-        - update
-        - patch
-        - delete
-    - apiGroups:
-        - ""
-      resources:
-        - events
-      verbs:
-        - create
-        - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/network-operator/templates/rbac/leader-election-rolebinding.yaml
+++ b/charts/network-operator/templates/rbac/leader-election-rolebinding.yaml
@@ -1,18 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: {{ include "network-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "network-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
 subjects:
-    - kind: ServiceAccount
-      name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-      namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/network-operator/templates/rbac/managementaccess-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/managementaccess-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "managementaccess-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "managementaccess-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - managementaccesses
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - managementaccesses/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - managementaccesses
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - managementaccesses/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/managementaccess-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/managementaccess-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "managementaccess-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "managementaccess-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - managementaccesses
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - managementaccesses/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - managementaccesses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - managementaccesses/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/managementaccess-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/managementaccess-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "managementaccess-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "managementaccess-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - managementaccesses
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - managementaccesses/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - managementaccesses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - managementaccesses/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/manager-role.yaml
+++ b/charts/network-operator/templates/rbac/manager-role.yaml
@@ -1,171 +1,171 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    name: {{ include "network-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
 rules:
-    - apiGroups:
-        - ""
-      resources:
-        - configmaps
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - ""
-      resources:
-        - events
-      verbs:
-        - create
-        - patch
-    - apiGroups:
-        - ""
-      resources:
-        - secrets
-      verbs:
-        - get
-        - list
-        - update
-        - watch
-    - apiGroups:
-        - coordination.k8s.io
-      resources:
-        - leases
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists
-        - banners
-        - bgp
-        - bgppeers
-        - certificates
-        - devices
-        - dns
-        - evpninstances
-        - interfaces
-        - isis
-        - managementaccesses
-        - networkvirtualizationedges
-        - ntp
-        - ospf
-        - pim
-        - prefixsets
-        - routingpolicies
-        - snmp
-        - syslogs
-        - users
-        - vlans
-        - vrfs
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists/finalizers
-        - banners/finalizers
-        - bgp/finalizers
-        - bgppeers/finalizers
-        - certificates/finalizers
-        - devices/finalizers
-        - dns/finalizers
-        - evpninstances/finalizers
-        - interfaces/finalizers
-        - isis/finalizers
-        - managementaccesses/finalizers
-        - networkvirtualizationedges/finalizers
-        - ntp/finalizers
-        - ospf/finalizers
-        - pim/finalizers
-        - prefixsets/finalizers
-        - routingpolicies/finalizers
-        - snmp/finalizers
-        - syslogs/finalizers
-        - users/finalizers
-        - vlans/finalizers
-        - vrfs/finalizers
-      verbs:
-        - update
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - accesscontrollists/status
-        - banners/status
-        - bgp/status
-        - bgppeers/status
-        - certificates/status
-        - devices/status
-        - dns/status
-        - evpninstances/status
-        - interfaces/status
-        - isis/status
-        - managementaccesses/status
-        - networkvirtualizationedges/status
-        - ntp/status
-        - ospf/status
-        - pim/status
-        - prefixsets/status
-        - routingpolicies/status
-        - snmp/status
-        - syslogs/status
-        - users/status
-        - vlans/status
-        - vrfs/status
-      verbs:
-        - get
-        - patch
-        - update
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways
-        - systems
-        - vpcdomains
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways/finalizers
-        - systems/finalizers
-        - vpcdomains/finalizers
-      verbs:
-        - update
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways/status
-        - systems/status
-        - vpcdomains/status
-      verbs:
-        - get
-        - patch
-        - update
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs
-        - managementaccessconfigs
-        - networkvirtualizationedgeconfigs
-      verbs:
-        - get
-        - list
-        - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists
+  - banners
+  - bgp
+  - bgppeers
+  - certificates
+  - devices
+  - dns
+  - evpninstances
+  - interfaces
+  - isis
+  - managementaccesses
+  - networkvirtualizationedges
+  - ntp
+  - ospf
+  - pim
+  - prefixsets
+  - routingpolicies
+  - snmp
+  - syslogs
+  - users
+  - vlans
+  - vrfs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists/finalizers
+  - banners/finalizers
+  - bgp/finalizers
+  - bgppeers/finalizers
+  - certificates/finalizers
+  - devices/finalizers
+  - dns/finalizers
+  - evpninstances/finalizers
+  - interfaces/finalizers
+  - isis/finalizers
+  - managementaccesses/finalizers
+  - networkvirtualizationedges/finalizers
+  - ntp/finalizers
+  - ospf/finalizers
+  - pim/finalizers
+  - prefixsets/finalizers
+  - routingpolicies/finalizers
+  - snmp/finalizers
+  - syslogs/finalizers
+  - users/finalizers
+  - vlans/finalizers
+  - vrfs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - accesscontrollists/status
+  - banners/status
+  - bgp/status
+  - bgppeers/status
+  - certificates/status
+  - devices/status
+  - dns/status
+  - evpninstances/status
+  - interfaces/status
+  - isis/status
+  - managementaccesses/status
+  - networkvirtualizationedges/status
+  - ntp/status
+  - ospf/status
+  - pim/status
+  - prefixsets/status
+  - routingpolicies/status
+  - snmp/status
+  - syslogs/status
+  - users/status
+  - vlans/status
+  - vrfs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways
+  - systems
+  - vpcdomains
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways/finalizers
+  - systems/finalizers
+  - vpcdomains/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways/status
+  - systems/status
+  - vpcdomains/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs
+  - managementaccessconfigs
+  - networkvirtualizationedgeconfigs
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/network-operator/templates/rbac/manager-rolebinding.yaml
+++ b/charts/network-operator/templates/rbac/manager-rolebinding.yaml
@@ -1,17 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
 roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: {{ include "network-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "network-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
 subjects:
-    - kind: ServiceAccount
-      name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-      namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/network-operator/templates/rbac/metrics-auth-role.yaml
+++ b/charts/network-operator/templates/rbac/metrics-auth-role.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-auth-role" "context" $) }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-auth-role" "context" $) }}
 rules:
-    - apiGroups:
-        - authentication.k8s.io
-      resources:
-        - tokenreviews
-      verbs:
-        - create
-    - apiGroups:
-        - authorization.k8s.io
-      resources:
-        - subjectaccessreviews
-      verbs:
-        - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 {{- end }}

--- a/charts/network-operator/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/charts/network-operator/templates/rbac/metrics-auth-rolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-    name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-auth-rolebinding" "context" $) }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-auth-rolebinding" "context" $) }}
 roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-auth-role" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-auth-role" "context" $) }}
 subjects:
-    - kind: ServiceAccount
-      name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-      namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/network-operator/templates/rbac/metrics-reader.yaml
+++ b/charts/network-operator/templates/rbac/metrics-reader.yaml
@@ -2,10 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-reader" "context" $) }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "metrics-reader" "context" $) }}
 rules:
-    - nonResourceURLs:
-        - /metrics
-      verbs:
-        - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/ntp-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/ntp-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "ntp-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "ntp-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ntp
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ntp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ntp
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ntp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/ntp-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/ntp-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "ntp-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "ntp-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ntp
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ntp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ntp
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ntp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/ntp-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/ntp-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "ntp-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "ntp-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ntp
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - ntp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ntp
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - ntp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nve-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nve-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nve-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nve-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - networkvirtualizationedges
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - networkvirtualizationedges/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - networkvirtualizationedges
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - networkvirtualizationedges/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nve-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nve-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nve-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nve-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - networkvirtualizationedges
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - networkvirtualizationedges/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - networkvirtualizationedges
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - networkvirtualizationedges/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nve-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nve-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nve-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nve-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - networkvirtualizationedges
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - networkvirtualizationedges/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - networkvirtualizationedges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - networkvirtualizationedges/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-bordergateway-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-bordergateway-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-bordergateway-admin-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-bordergateway-admin-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways
-      verbs:
-        - '*'
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways
+  verbs:
+  - '*'
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-bordergateway-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-bordergateway-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-bordergateway-editor-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-bordergateway-editor-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-bordergateway-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-bordergateway-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-bordergateway-viewer-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-bordergateway-viewer-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - bordergateways/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - bordergateways/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-interfaceconfig-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-interfaceconfig-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-interfaceconfig-admin-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-interfaceconfig-admin-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs
-      verbs:
-        - '*'
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs
+  verbs:
+  - '*'
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-interfaceconfig-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-interfaceconfig-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-interfaceconfig-editor-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-interfaceconfig-editor-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-interfaceconfig-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-interfaceconfig-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-interfaceconfig-viewer-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-interfaceconfig-viewer-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - interfaceconfigs/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - interfaceconfigs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-managementaccessconfig-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-managementaccessconfig-admin-role.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-managementaccessconfig-admin-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-managementaccessconfig-admin-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - managementaccessconfigs
-      verbs:
-        - '*'
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - managementaccessconfigs
+  verbs:
+  - '*'
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-managementaccessconfig-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-managementaccessconfig-editor-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-managementaccessconfig-editor-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-managementaccessconfig-editor-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - managementaccessconfigs
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - managementaccessconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-managementaccessconfig-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-managementaccessconfig-viewer-role.yaml
@@ -2,19 +2,19 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-managementaccessconfig-viewer-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-managementaccessconfig-viewer-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - managementaccessconfigs
-      verbs:
-        - get
-        - list
-        - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - managementaccessconfigs
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-nveconfig-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-nveconfig-admin-role.yaml
@@ -2,17 +2,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-nveconfig-admin-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-nveconfig-admin-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - nveconfigs
-      verbs:
-        - '*'
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - nveconfigs
+  verbs:
+  - '*'
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-nveconfig-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-nveconfig-editor-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-nveconfig-editor-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-nveconfig-editor-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - nveconfigs
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - nveconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-nveconfig-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-nveconfig-viewer-role.yaml
@@ -2,19 +2,19 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-nveconfig-viewer-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-nveconfig-viewer-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - nveconfigs
-      verbs:
-        - get
-        - list
-        - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - nveconfigs
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-system-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-system-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-system-admin-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-system-admin-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - systems
-      verbs:
-        - '*'
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - systems/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - systems
+  verbs:
+  - '*'
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - systems/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-system-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-system-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-system-editor-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-system-editor-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - systems
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - systems/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - systems
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - systems/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-system-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-system-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-system-viewer-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-system-viewer-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - systems
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - systems/status
-      verbs:
-        - get
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - systems
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - systems/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-vpcdomain-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-vpcdomain-admin-role.yaml
@@ -2,17 +2,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-vpcdomain-admin-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-vpcdomain-admin-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - vpcdomains
-      verbs:
-        - '*'
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - vpcdomains
+  verbs:
+  - '*'
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-vpcdomain-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-vpcdomain-editor-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-vpcdomain-editor-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-vpcdomain-editor-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - vpcdomains
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - vpcdomains
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- end }}

--- a/charts/network-operator/templates/rbac/nx.cisco-vpcdomain-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/nx.cisco-vpcdomain-viewer-role.yaml
@@ -2,28 +2,28 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-vpcdomain-viewer-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "nx" "context" $) }}.cisco-vpcdomain-viewer-role
 rules:
-    - apiGroups:
-        - nx.cisco.networking.metal.ironcore.dev
-      resources:
-        - vpcdomains
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs
-        - interfaces
-      verbs:
-        - get
-        - list
-        - watch
+- apiGroups:
+  - nx.cisco.networking.metal.ironcore.dev
+  resources:
+  - vpcdomains
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs
+  - interfaces
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/charts/network-operator/templates/rbac/prefixset-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/prefixset-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "prefixset-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "prefixset-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - prefixsets
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - prefixsets/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - prefixsets
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - prefixsets/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/prefixset-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/prefixset-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "prefixset-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "prefixset-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - prefixsets
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - prefixsets/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - prefixsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - prefixsets/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/prefixset-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/prefixset-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "prefixset-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "prefixset-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - prefixsets
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - prefixsets/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - prefixsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - prefixsets/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/routingpolicy-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/routingpolicy-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "routingpolicy-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "routingpolicy-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - routingpolicies
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - routingpolicies/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - routingpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - routingpolicies/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/routingpolicy-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/routingpolicy-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "routingpolicy-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "routingpolicy-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - routingpolicies
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - routingpolicies/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - routingpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - routingpolicies/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/routingpolicy-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/routingpolicy-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "routingpolicy-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "routingpolicy-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - routingpolicies
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - routingpolicies/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - routingpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - routingpolicies/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/snmp-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/snmp-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "snmp-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "snmp-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - snmp
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - snmp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - snmp
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - snmp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/snmp-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/snmp-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "snmp-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "snmp-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - snmp
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - snmp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - snmp
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - snmp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/snmp-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/snmp-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "snmp-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "snmp-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - snmp
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - snmp/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - snmp
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - snmp/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/syslog-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/syslog-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "syslog-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "syslog-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - syslogs
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - syslogs/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - syslogs
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - syslogs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/syslog-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/syslog-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "syslog-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "syslog-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - syslogs
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - syslogs/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - syslogs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - syslogs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/syslog-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/syslog-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "syslog-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "syslog-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - syslogs
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - syslogs/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - syslogs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - syslogs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/user-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/user-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "user-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "user-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - users
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - users/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - users
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - users/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/user-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/user-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "user-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "user-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - users
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - users/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - users
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - users/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/user-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/user-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "user-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "user-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - users
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - users/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - users
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - users/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/vrf-admin-role.yaml
+++ b/charts/network-operator/templates/rbac/vrf-admin-role.yaml
@@ -2,23 +2,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "vrf-admin-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "vrf-admin-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs
-      verbs:
-        - '*'
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/vrf-editor-role.yaml
+++ b/charts/network-operator/templates/rbac/vrf-editor-role.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "vrf-editor-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "vrf-editor-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs
-      verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/rbac/vrf-viewer-role.yaml
+++ b/charts/network-operator/templates/rbac/vrf-viewer-role.yaml
@@ -2,25 +2,25 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "vrf-viewer-role" "context" $) }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "vrf-viewer-role" "context" $) }}
 rules:
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs
-      verbs:
-        - get
-        - list
-        - watch
-    - apiGroups:
-        - networking.metal.ironcore.dev
-      resources:
-        - vrfs/status
-      verbs:
-        - get
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.metal.ironcore.dev
+  resources:
+  - vrfs/status
+  verbs:
+  - get
 {{- end }}

--- a/charts/network-operator/templates/webhook/validating-webhook-configuration.yaml
+++ b/charts/network-operator/templates/webhook/validating-webhook-configuration.yaml
@@ -2,130 +2,130 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-    annotations:
-        {{- if .Values.certManager.enable }}
-        cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "network-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
-        {{- end }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}
+  annotations:
+    {{- if .Values.certManager.enable }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "network-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
+    {{- end }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}
 webhooks:
-    - admissionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-            name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-            namespace: {{ .Release.Namespace }}
-            path: /validate-networking-metal-ironcore-dev-v1alpha1-bgp
-      failurePolicy: Fail
-      name: bgp-v1alpha1.kb.io
-      rules:
-        - apiGroups:
-            - networking.metal.ironcore.dev
-          apiVersions:
-            - v1alpha1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - bgp
-      sideEffects: None
-    - admissionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-            name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-            namespace: {{ .Release.Namespace }}
-            path: /validate-networking-metal-ironcore-dev-v1alpha1-bgppeer
-      failurePolicy: Fail
-      name: bgppeer-v1alpha1.kb.io
-      rules:
-        - apiGroups:
-            - networking.metal.ironcore.dev
-          apiVersions:
-            - v1alpha1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - bgppeers
-      sideEffects: None
-    - admissionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-            name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-            namespace: {{ .Release.Namespace }}
-            path: /validate-networking-metal-ironcore-dev-v1alpha1-interface
-      failurePolicy: Fail
-      name: interface-v1alpha1.kb.io
-      rules:
-        - apiGroups:
-            - networking.metal.ironcore.dev
-          apiVersions:
-            - v1alpha1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - interfaces
-      sideEffects: None
-    - admissionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-            name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-            namespace: {{ .Release.Namespace }}
-            path: /validate-nx-cisco-networking-metal-ironcore-dev-v1alpha1-networkvirtualizationedgeconfig
-      failurePolicy: Fail
-      name: networkvirtualizationedgeconfig-cisco-nx-v1alpha1.kb.io
-      rules:
-        - apiGroups:
-            - nx.cisco.networking.metal.ironcore.dev
-          apiVersions:
-            - v1alpha1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - networkvirtualizationedgeconfigs
-      sideEffects: None
-    - admissionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-            name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-            namespace: {{ .Release.Namespace }}
-            path: /validate-networking-metal-ironcore-dev-v1alpha1-prefixset
-      failurePolicy: Fail
-      name: prefixset-v1alpha1.kb.io
-      rules:
-        - apiGroups:
-            - networking.metal.ironcore.dev
-          apiVersions:
-            - v1alpha1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - prefixsets
-      sideEffects: None
-    - admissionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-            name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-            namespace: {{ .Release.Namespace }}
-            path: /validate-networking-metal-ironcore-dev-v1alpha1-vrf
-      failurePolicy: Fail
-      name: vrf-v1alpha1.kb.io
-      rules:
-        - apiGroups:
-            - networking.metal.ironcore.dev
-          apiVersions:
-            - v1alpha1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - vrfs
-      sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-bgp
+  failurePolicy: Fail
+  name: bgp-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bgp
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-bgppeer
+  failurePolicy: Fail
+  name: bgppeer-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bgppeers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-interface
+  failurePolicy: Fail
+  name: interface-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - interfaces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-nx-cisco-networking-metal-ironcore-dev-v1alpha1-networkvirtualizationedgeconfig
+  failurePolicy: Fail
+  name: networkvirtualizationedgeconfig-cisco-nx-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - nx.cisco.networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkvirtualizationedgeconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-prefixset
+  failurePolicy: Fail
+  name: prefixset-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - prefixsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-vrf
+  failurePolicy: Fail
+  name: vrf-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vrfs
+  sideEffects: None
 {{- end }}

--- a/charts/network-operator/templates/webhook/webhook-service.yaml
+++ b/charts/network-operator/templates/webhook/webhook-service.yaml
@@ -2,19 +2,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-    labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    ports:
-        - port: 443
-          protocol: TCP
-          targetPort: {{ .Values.webhook.port }}
-    selector:
-        app.kubernetes.io/name: {{ include "network-operator.name" . }}
-        control-plane: controller-manager
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: {{ .Values.webhook.port }}
+  selector:
+    app.kubernetes.io/name: {{ include "network-operator.name" . }}
+    control-plane: controller-manager
 {{- end }}


### PR DESCRIPTION
This change fixes the YAML indentation of the helm/v2-alpha plugin.

See https://github.com/kubernetes-sigs/kubebuilder/pull/5490