### PR TITLE
Use strings in DeviceCertificateResponse to avoid b64 encode during marshalling (#203)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -12,7 +12,7 @@ allow_k8s_contexts(['minikube', 'kind-network'])
 load('ext://cert_manager', 'deploy_cert_manager')
 deploy_cert_manager(version='v1.18.2')
 
-docker_build('controller:latest', '.', ignore=['**/*/zz_generated.deepcopy.go', 'config/crd/bases/*'], only=[
+docker_build('ghcr.io/ironcore-dev/network-operator', '.', ignore=['**/*/zz_generated.deepcopy.go', 'config/crd/bases/*'], only=[
     'api/', 'cmd/', 'hack/', 'internal/', 'go.mod', 'go.sum', 'Makefile',
 ])
 

--- a/internal/provisioning/http.go
+++ b/internal/provisioning/http.go
@@ -397,9 +397,9 @@ func (s *HTTPServer) GetMTLSClientCA(w http.ResponseWriter, r *http.Request) {
 }
 
 type DeviceCertificateResponse struct {
-	Certificate   []byte `json:"certificate"`
-	PrivateKey    []byte `json:"privateKey"` // #nosec G117
-	CACertificate []byte `json:"caCertificate"`
+	Certificate   string `json:"certificate"`
+	PrivateKey    string `json:"privateKey"` // #nosec G117
+	CACertificate string `json:"caCertificate"`
 }
 
 func (s *HTTPServer) GetDeviceCertificate(w http.ResponseWriter, r *http.Request) {
@@ -461,7 +461,7 @@ func (s *HTTPServer) GetDeviceCertificate(w http.ResponseWriter, r *http.Request
 		http.Error(w, "Incomplete certificate data in secret", http.StatusInternalServerError)
 		return
 	}
-	response.Certificate = certificate
+	response.Certificate = string(certificate)
 
 	privateKey, ok := certSecret.Data["tls.key"]
 	if !ok {
@@ -469,11 +469,11 @@ func (s *HTTPServer) GetDeviceCertificate(w http.ResponseWriter, r *http.Request
 		http.Error(w, "Incomplete certificate data in secret", http.StatusInternalServerError)
 		return
 	}
-	response.PrivateKey = privateKey
+	response.PrivateKey = string(privateKey)
 
 	ca, ok := certSecret.Data["ca.crt"]
 	if ok {
-		response.CACertificate = ca
+		response.CACertificate = string(ca)
 	}
 
 	content, err := json.Marshal(response)

--- a/internal/provisioning/http_test.go
+++ b/internal/provisioning/http_test.go
@@ -777,9 +777,9 @@ func TestGetDeviceCertificate(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			validateResponse: func(t *testing.T, response *DeviceCertificateResponse) {
-				assert.Equal(t, []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"), response.Certificate)
-				assert.Equal(t, []byte("-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----"), response.PrivateKey)
-				assert.Equal(t, []byte("-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----"), response.CACertificate)
+				assert.Equal(t, "-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----", response.Certificate)
+				assert.Equal(t, "-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----", response.PrivateKey)
+				assert.Equal(t, "-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----", response.CACertificate)
 			},
 		},
 		{
@@ -824,8 +824,8 @@ func TestGetDeviceCertificate(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			validateResponse: func(t *testing.T, response *DeviceCertificateResponse) {
-				assert.Equal(t, []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"), response.Certificate)
-				assert.Equal(t, []byte("-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----"), response.PrivateKey)
+				assert.Equal(t, "-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----", response.Certificate)
+				assert.Equal(t, "-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----", response.PrivateKey)
 				assert.Empty(t, response.CACertificate)
 			},
 		},


### PR DESCRIPTION
- Use strings in DeviceCertificateResponse to avoid b64 encode during marshalling
- Use correct image in tiltfile
