### PR TITLE
Consolidate TLS secret fetching into clientutil and simplify handlers

### DIFF
--- a/internal/clientutil/clientutil.go
+++ b/internal/clientutil/clientutil.go
@@ -130,9 +130,20 @@ func (c *Client) BasicAuth(ctx context.Context, ref *v1alpha1.SecretReference) (
 	return user, pass, nil
 }
 
-// Certificate loads a [tls.Certificate] from the referenced secret resource.
-// The secret must by of type 'kubernetes.io/tls' and contain the fields 'tls.crt' and 'tls.key'.
-func (c *Client) Certificate(ctx context.Context, ref *v1alpha1.SecretReference) (*tls.Certificate, error) {
+// TLSSecret holds the raw PEM-encoded data from a Kubernetes TLS secret.
+type TLSSecret struct {
+	// Certificate is the PEM-encoded certificate chain (tls.crt).
+	Certificate []byte
+	// PrivateKey is the PEM-encoded private key (tls.key).
+	PrivateKey []byte // #nosec G117
+	// CA is the PEM-encoded CA certificate (ca.crt), if present.
+	CA []byte
+}
+
+// TLSSecretPEM loads the raw PEM data from a TLS secret without parsing.
+// The secret must be of type 'kubernetes.io/tls' and contain the fields 'tls.crt' and 'tls.key'.
+// The 'ca.crt' field is optional and will be included if present.
+func (c *Client) TLSSecretPEM(ctx context.Context, ref *v1alpha1.SecretReference) (*TLSSecret, error) {
 	name := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
 
 	var secret corev1.Secret
@@ -154,7 +165,22 @@ func (c *Client) Certificate(ctx context.Context, ref *v1alpha1.SecretReference)
 		return nil, fmt.Errorf("missing field 'tls.key' in secret %q", name.String())
 	}
 
-	certificate, err := tls.X509KeyPair(cert, key)
+	return &TLSSecret{
+		Certificate: cert,
+		PrivateKey:  key,
+		CA:          secret.Data["ca.crt"],
+	}, nil
+}
+
+// Certificate loads a [tls.Certificate] from the referenced secret resource.
+// The secret must be of type 'kubernetes.io/tls' and contain the fields 'tls.crt' and 'tls.key'.
+func (c *Client) Certificate(ctx context.Context, ref *v1alpha1.SecretReference) (*tls.Certificate, error) {
+	pem, err := c.TLSSecretPEM(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	certificate, err := tls.X509KeyPair(pem.Certificate, pem.PrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load x509 key pair: %w", err)
 	}

--- a/internal/clientutil/clientutil_test.go
+++ b/internal/clientutil/clientutil_test.go
@@ -256,6 +256,146 @@ func TestBasicAuth(t *testing.T) {
 	}
 }
 
+func TestTLSSecretPEM(t *testing.T) {
+	g := NewWithT(t)
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Go Test Corp"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &pk.PublicKey, pk)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var cert bytes.Buffer
+	err = pem.Encode(&cert, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var key bytes.Buffer
+	err = pem.Encode(&key, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pk)})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ca := []byte("-----BEGIN CERTIFICATE-----\nfake-ca-data\n-----END CERTIFICATE-----\n")
+
+	tests := []struct {
+		name    string
+		secret  *corev1.Secret
+		wantCA  bool
+		wantErr bool
+	}{
+		{
+			name: "valid TLS secret without CA",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-certificate",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       cert.Bytes(),
+					corev1.TLSPrivateKeyKey: key.Bytes(),
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+		},
+		{
+			name: "valid TLS secret with CA",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-certificate",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       cert.Bytes(),
+					corev1.TLSPrivateKeyKey: key.Bytes(),
+					"ca.crt":                ca,
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			wantCA: true,
+		},
+		{
+			name: "invalid type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-certificate",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       cert.Bytes(),
+					corev1.TLSPrivateKeyKey: key.Bytes(),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing certificate",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-certificate",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.TLSPrivateKeyKey: key.Bytes(),
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing private key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-certificate",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey: cert.Bytes(),
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(test.secret).
+				Build()
+
+			c := NewClient(client, metav1.NamespaceDefault)
+
+			result, err := c.TLSSecretPEM(t.Context(), &v1alpha1.SecretReference{
+				Name: "test-certificate",
+			})
+			if test.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(result).To(BeNil())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).ToNot(BeNil())
+			g.Expect(result.Certificate).To(Equal(cert.Bytes()))
+			g.Expect(result.PrivateKey).To(Equal(key.Bytes()))
+			if test.wantCA {
+				g.Expect(result.CA).To(Equal(ca))
+			} else {
+				g.Expect(result.CA).To(BeNil())
+			}
+		})
+	}
+}
+
 func TestCertificate(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/provisioning/http.go
+++ b/internal/provisioning/http.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -290,14 +289,21 @@ func (s *HTTPServer) HandleProvisioningRequest(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	conn, err := deviceutil.GetDeviceConnection(ctx, s.Client, device)
+	if device.Spec.Endpoint.SecretRef == nil {
+		s.Logger.Error(nil, "Device has no endpoint secret reference", "device", device.Name)
+		http.Error(w, "Device has no endpoint secret reference", http.StatusPreconditionRequired)
+		return
+	}
+
+	c := clientutil.NewClient(s.Client, device.Namespace)
+	user, pass, err := c.BasicAuth(ctx, device.Spec.Endpoint.SecretRef)
 	if err != nil {
 		s.Logger.Error(err, "Failed to get user accounts", "device", device.Name)
 		http.Error(w, "Failed to get user accounts", http.StatusInternalServerError)
 		return
 	}
 
-	hashedPassword, hashAlgorithm, err := s.Provider.HashProvisioningPassword(conn.Password)
+	hashedPassword, hashAlgorithm, err := s.Provider.HashProvisioningPassword(string(pass))
 	if err != nil {
 		s.Logger.Error(err, "Failed to hash provisioning password", "device", device.Name)
 		http.Error(w, "Failed to hash provisioning password", http.StatusInternalServerError)
@@ -305,7 +311,7 @@ func (s *HTTPServer) HandleProvisioningRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	ua := UserAccount{
-		Username:       conn.Username,
+		Username:       string(user),
 		HashedPassword: hashedPassword,
 		HashAlgorithm:  hashAlgorithm,
 	}
@@ -368,30 +374,23 @@ func (s *HTTPServer) GetMTLSClientCA(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Device has no MTLS certificate configured", http.StatusNotFound)
 		return
 	}
-	namespace := device.Namespace
-	if device.Spec.Endpoint.SecretRef != nil && device.Spec.Endpoint.SecretRef.Namespace != "" {
-		namespace = device.Spec.Endpoint.SecretRef.Namespace
-	}
-	certRef := client.ObjectKey{Name: device.Spec.Endpoint.TLS.Certificate.SecretRef.Name, Namespace: namespace}
-	certSecret := corev1.Secret{}
-	err = c.Get(ctx, certRef, &certSecret)
-	if err != nil || certSecret.Data == nil {
+
+	tlsSecret, err := c.TLSSecretPEM(ctx, &device.Spec.Endpoint.TLS.Certificate.SecretRef)
+	if err != nil {
 		s.Logger.Error(err, "Failed to get device certificate secret", "device", device.Name)
 		http.Error(w, "Failed to get device certificate secret", http.StatusNotFound)
 		return
 	}
 
-	if certSecret.Data["ca.crt"] == nil {
+	if tlsSecret.CA == nil {
 		s.Logger.Error(nil, "CA certificate not found in secret", "device", device.Name)
 		http.Error(w, "CA certificate not found", http.StatusInternalServerError)
 		return
 	}
 
-	operatorCA := certSecret.Data["ca.crt"]
 	w.Header().Set("Content-Type", "application/x-pem-file")
 	w.WriteHeader(http.StatusOK)
-
-	if _, err := w.Write(operatorCA); err != nil {
+	if _, err := w.Write(tlsSecret.CA); err != nil { // #nosec G705
 		s.Logger.Error(err, "Failed to write response")
 	}
 }
@@ -428,8 +427,8 @@ func (s *HTTPServer) GetDeviceCertificate(w http.ResponseWriter, r *http.Request
 	}
 
 	c := clientutil.NewClient(s.Client, device.Namespace)
-	certList := v1alpha1.CertificateList{}
 
+	certList := v1alpha1.CertificateList{}
 	if err = c.List(ctx, &certList, client.InNamespace(device.Namespace), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name}); err != nil {
 		s.Logger.Error(err, "Failed to list certificates", "device", device.Name)
 		http.Error(w, "Failed to list certificates", http.StatusInternalServerError)
@@ -446,34 +445,18 @@ func (s *HTTPServer) GetDeviceCertificate(w http.ResponseWriter, r *http.Request
 		http.Error(w, "Multiple certificates found for device", http.StatusInternalServerError)
 		return
 	}
-	certSecret := corev1.Secret{}
-	certRef := client.ObjectKey{Name: certList.Items[0].Spec.SecretRef.Name, Namespace: device.Namespace}
-	err = c.Get(ctx, certRef, &certSecret)
+
+	tlsSecret, err := c.TLSSecretPEM(ctx, &certList.Items[0].Spec.SecretRef)
 	if err != nil {
 		s.Logger.Error(err, "Failed to get certificate secret", "device", device.Name)
 		http.Error(w, "Failed to get certificate secret", http.StatusInternalServerError)
 		return
 	}
-	response := DeviceCertificateResponse{}
-	certificate, ok := certSecret.Data["tls.crt"]
-	if !ok {
-		s.Logger.Error(nil, "Incomplete certificate data in secret", "device", device.Name)
-		http.Error(w, "Incomplete certificate data in secret", http.StatusInternalServerError)
-		return
-	}
-	response.Certificate = string(certificate)
 
-	privateKey, ok := certSecret.Data["tls.key"]
-	if !ok {
-		s.Logger.Error(nil, "Incomplete certificate data in secret", "device", device.Name)
-		http.Error(w, "Incomplete certificate data in secret", http.StatusInternalServerError)
-		return
-	}
-	response.PrivateKey = string(privateKey)
-
-	ca, ok := certSecret.Data["ca.crt"]
-	if ok {
-		response.CACertificate = string(ca)
+	response := DeviceCertificateResponse{
+		Certificate:   string(tlsSecret.Certificate),
+		PrivateKey:    string(tlsSecret.PrivateKey),
+		CACertificate: string(tlsSecret.CA),
 	}
 
 	content, err := json.Marshal(response)

--- a/internal/provisioning/http_test.go
+++ b/internal/provisioning/http_test.go
@@ -726,13 +726,14 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Name:      "test-device-cert-secret",
 						Namespace: "default",
 					},
+					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
 						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"),
 					},
 				},
 			},
 			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   "Incomplete certificate data in secret",
+			expectedBody:   "Failed to get certificate secret",
 		},
 		{
 			name:          "successfully return device certificate with all fields",
@@ -768,6 +769,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Name:      "test-device-cert-secret",
 						Namespace: "default",
 					},
+					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
 						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"),
 						"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----"),
@@ -816,6 +818,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Name:      "test-device-cert-secret",
 						Namespace: "default",
 					},
+					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{
 						"tls.crt": []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"),
 						"tls.key": []byte("-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----"),
@@ -1076,8 +1079,11 @@ func TestGetMTLSClientCA(t *testing.T) {
 					Name:      "operator-ca-secret",
 					Namespace: "default",
 				},
+				Type: corev1.SecretTypeTLS,
 				Data: map[string][]byte{
-					"ca.crt": []byte("-----BEGIN CERTIFICATE-----\noperator-ca-cert\n-----END CERTIFICATE-----"),
+					"tls.crt": []byte("placeholder"),
+					"tls.key": []byte("placeholder"),
+					"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\noperator-ca-cert\n-----END CERTIFICATE-----"),
 				},
 			},
 			expectedStatus: http.StatusOK,


### PR DESCRIPTION
The provisioning HTTP handlers duplicated Kubernetes secret-fetching logic that already existed in the clientutil package. Additionally, HandleProvisioningRequest called deviceutil.GetDeviceConnection to obtain credentials, which unnecessarily loads TLS certificates when only BasicAuth username and password are needed.

Introduce a lower-level TLSSecretPEM() method in clientutil that returns raw PEM bytes (tls.crt, tls.key, and optionally ca.crt) from a TLS secret, and refactor the existing Certificate() method to use it internally. This layered approach avoids breaking existing callers while enabling the provisioning handlers to access raw PEM data without parsing into tls.Certificate.

Replace manual secret fetching in GetDeviceCertificate and GetMTLSClientCA with calls to TLSSecretPEM(). Replace the GetDeviceConnection call in HandleProvisioningRequest with a direct BasicAuth() call, adding a nil guard for the optional SecretRef pointer.