### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Go modules — root module
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    ignore:
+      # Ignore k8s.io/* and controller-runtime dependencies, as they are bumped together manually.
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+
+  # Go modules — test/gnmi module
+  - package-ecosystem: "gomod"
+    directory: "/test/gnmi"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # Docker — root Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # Docker — docs Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # Docker — test/gnmi Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/test/gnmi"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # Docker — test/lab Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/test/lab"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # npm — docs site
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # Helm — network-operator chart
+  - package-ecosystem: "helm"
+    directory: "/charts/network-operator"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
Enable Dependabot version updates for all package ecosystems in the repository: Go modules (root and test/gnmi), Docker, npm, Helm, and GitHub Actions. Schedule all checks weekly on Friday.

Ignore k8s.io/* and sigs.k8s.io/controller-runtime in the root Go module since they must be bumped manually.