### PR TITLE
fix: delete PIM rp-items before multicast group replace

### DIFF
--- a/internal/provider/cisco/nxos/pim.go
+++ b/internal/provider/cisco/nxos/pim.go
@@ -9,6 +9,8 @@ var (
 	_ gnmiext.Configurable = (*PIM)(nil)
 	_ gnmiext.Configurable = (*PIMDom)(nil)
 	_ gnmiext.Configurable = (*StaticRPItems)(nil)
+	_ gnmiext.Configurable = (*StaticRP)(nil)
+	_ gnmiext.Configurable = (*StaticRPGrp)(nil)
 	_ gnmiext.Configurable = (*AnycastPeerItems)(nil)
 	_ gnmiext.Configurable = (*PIMIfItems)(nil)
 )
@@ -63,9 +65,17 @@ type StaticRPGrp struct {
 	Bidir       bool   `json:"bidir"`
 	GrpListName string `json:"grpListName"`
 	Override    bool   `json:"override"`
+
+	// RpAddr is the parent StaticRP address, used to construct the XPath.
+	// It is not serialized to JSON.
+	RpAddr string `json:"-"`
 }
 
 func (g *StaticRPGrp) Key() string { return g.GrpListName }
+
+func (g *StaticRPGrp) XPath() string {
+	return "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items/StaticRP-list[addr=" + g.RpAddr + "]/rpgrplist-items/RPGrpList-list[grpListName=" + g.GrpListName + "]"
+}
 
 type AnycastPeerItems struct {
 	AcastRPPeerList gnmiext.List[AnycastPeerAddr, *AnycastPeerAddr] `json:"AcastRPPeer-list,omitzero"`

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -1705,7 +1705,39 @@ func (p *Provider) EnsurePIM(ctx context.Context, req *provider.EnsurePIMRequest
 	del := make([]gnmiext.Configurable, 0, 3)
 
 	if len(rpItems.StaticRPList) > 0 {
-		conf = append(conf, rpItems)
+		// Diff group-to-RP bindings individually; replacing entire StaticRP entries fails on NX-OS
+		// with "child (Rn) cannot be added to deleted object Rn=rpgrplist-[...], Commit Failed".
+		current := new(StaticRPItems)
+		if err := p.client.GetConfig(ctx, current); err != nil && !errors.Is(err, gnmiext.ErrNil) {
+			return err
+		}
+		for _, rp := range rpItems.StaticRPList {
+			got, ok := current.StaticRPList.Get(rp.Key())
+			if !ok {
+				// StaticRP does not exist yet — add the entire entry.
+				conf = append(conf, rp)
+				continue
+			}
+			for _, grp := range rp.RpgrplistItems.RPGrpListList {
+				if gotGrp, ok := got.RpgrplistItems.RPGrpListList.Get(grp.Key()); !ok || !reflect.DeepEqual(gotGrp, grp) {
+					g := *grp
+					g.RpAddr = rp.Addr
+					conf = append(conf, &g)
+				}
+			}
+			for _, grp := range got.RpgrplistItems.RPGrpListList {
+				if _, ok := rp.RpgrplistItems.RPGrpListList.Get(grp.Key()); !ok {
+					g := *grp
+					g.RpAddr = rp.Addr
+					del = append(del, &g)
+				}
+			}
+		}
+		for _, rp := range current.StaticRPList {
+			if _, ok := rpItems.StaticRPList.Get(rp.Key()); !ok {
+				del = append(del, rp)
+			}
+		}
 	} else {
 		del = append(del, rpItems)
 	}


### PR DESCRIPTION
## Fix

In `EnsurePIM`, before calling `Update` (gNMI Replace), check if the current `StaticRPItems` config differs from the desired config. If it does, delete the existing items first in a separate transaction — then the Replace only adds new entries.

**File:** `internal/provider/cisco/nxos/provider.go`

## Live Device Testing

### Setup

```bash
kubernikusctl auth init --username I521907 --user-domain-name ora \
  --project-id 2cb8a03edaa444a19b56a04dec88d9db \
  --auth-url https://identity-3.eu-de-1.cloud.sap/v3 \
  --url https://kubernikus.eu-de-1.cloud.sap --name clabernetes

kubectl port-forward -n lab--i521907v1-c058dde2aecf49f1821054ef877eabcf \
  pod/switch-54749479d8-9r6l9 9339:60009
```

### Reproduce the bug (old behavior)

Enable PIM feature:
```bash
gnmic -a localhost:9339 --skip-verify -u admin -p admin set \
  --replace-path "System/fm-items/pim-items" \
  --replace-value '{"adminSt":"enabled"}'
```

Push initial RP with group `225.0.0.0/8`:
```bash
gnmic -a localhost:9339 --skip-verify -u admin -p admin set \
  --replace-path "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items" \
  --replace-value '{"StaticRP-list":[{"addr":"10.0.0.1/32","rpgrplist-items":{"RPGrpList-list":[{"grpListName":"225.0.0.0/8","bidir":false,"override":false}]}}]}'
```

Change group to `226.0.0.0/8` — fails with the bug:
```bash
gnmic -a localhost:9339 --skip-verify -u admin -p admin set \
  --replace-path "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items" \
  --replace-value '{"StaticRP-list":[{"addr":"10.0.0.1/32","rpgrplist-items":{"RPGrpList-list":[{"grpListName":"226.0.0.0/8","bidir":false,"override":false}]}}]}'
# ERROR: child (Rn) cannot be added to deleted objectRn=rpgrplist-[226.0.0.0/8], Commit Failed
```

### Verify the fix (delete first, then replace)

```bash
gnmic -a localhost:9339 --skip-verify -u admin -p admin set \
  --delete "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items"

gnmic -a localhost:9339 --skip-verify -u admin -p admin set \
  --replace-path "System/pim-items/inst-items/dom-items/Dom-list[name=default]/staticrp-items/rp-items" \
  --replace-value '{"StaticRP-list":[{"addr":"10.0.0.1/32","rpgrplist-items":{"RPGrpList-list":[{"grpListName":"226.0.0.0/8","bidir":false,"override":false}]}}]}'
# OK
```

### Results

| Step | Result |
|------|--------|
| Push initial RP with `225.0.0.0/8` | ✅ |
| Replace directly with `226.0.0.0/8` (old behavior) | ❌ `rpgrplist` error |
| Delete `rp-items` + replace with `226.0.0.0/8` (fix) | ✅ |
| Verify `226.0.0.0/8` on device | ✅ |
| Replay same config (idempotency) | ✅ No unnecessary delete |
