### PR TITLE
Use GenerateName in controller tests to avoid name collisions

### DIFF
--- a/internal/controller/cisco/nx/bordergateway_controller_test.go
+++ b/internal/controller/cisco/nx/bordergateway_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -19,66 +18,61 @@ import (
 
 var _ = Describe("BorderGateway Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-bgw"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgw-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind Interface")
-			intf := &v1alpha1.Interface{}
-			if err := k8sClient.Get(ctx, key, intf); errors.IsNotFound(err) {
-				resource := &v1alpha1.Interface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			intf := &v1alpha1.Interface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.InterfaceSpec{
+					DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
+					Name:        "lo100",
+					AdminState:  v1alpha1.AdminStateUp,
+					Description: "Test",
+					MTU:         1500,
+					Type:        v1alpha1.InterfaceTypeLoopback,
+					IPv4: &v1alpha1.InterfaceIPv4{
+						Addresses: []v1alpha1.IPPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}},
 					},
-					Spec: v1alpha1.InterfaceSpec{
-						DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
-						Name:        "lo100",
-						AdminState:  v1alpha1.AdminStateUp,
-						Description: "Test",
-						MTU:         1500,
-						Type:        v1alpha1.InterfaceTypeLoopback,
-						IPv4: &v1alpha1.InterfaceIPv4{
-							Addresses: []v1alpha1.IPPrefix{{Prefix: netip.MustParsePrefix("10.0.0.1/32")}},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, intf)).To(Succeed())
 
 			By("Creating the custom resource for the Kind BorderGateway")
-			bgw := &nxv1alpha1.BorderGateway{}
-			if err := k8sClient.Get(ctx, key, bgw); errors.IsNotFound(err) {
-				resource := &nxv1alpha1.BorderGateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1alpha1.BorderGatewaySpec{
-						DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
-						MultisiteID:        123,
-						SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			bgw := &nxv1alpha1.BorderGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: nxv1alpha1.BorderGatewaySpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					MultisiteID:        123,
+					SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name},
+				},
 			}
+			Expect(k8sClient.Create(ctx, bgw)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/cisco/nx/system_controller_test.go
+++ b/internal/controller/cisco/nx/system_controller_test.go
@@ -6,7 +6,6 @@ package nx
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -17,44 +16,42 @@ import (
 
 var _ = Describe("System Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-system"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-system-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind System")
-			system := &nxv1alpha1.System{}
-			if err := k8sClient.Get(ctx, key, system); errors.IsNotFound(err) {
-				resource := &nxv1alpha1.System{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1alpha1.SystemSpec{
-						DeviceRef:    v1alpha1.LocalObjectReference{Name: name},
-						JumboMTU:     9216,
-						ReservedVlan: 3986,
-						VlanLongName: true,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			resource := &nxv1alpha1.System{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: nxv1alpha1.SystemSpec{
+					DeviceRef:    v1alpha1.LocalObjectReference{Name: name},
+					JumboMTU:     9216,
+					ReservedVlan: 3986,
+					VlanLongName: true,
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/cisco/nx/vpcdomain_controller_test.go
+++ b/internal/controller/cisco/nx/vpcdomain_controller_test.go
@@ -6,7 +6,6 @@ package nx
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -19,146 +18,106 @@ import (
 
 var _ = Describe("VPCDomain Controller", func() {
 	Context("When reconciling a resource", func() {
-		const (
-			vpcdomainName = "vpc1"
-			deviceName    = "leaf1"
-			poName        = "po1"
-			vrfName       = "vrf1"
-			physName      = "eth1-1"
-		)
 		var (
-			deviceKey    = client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
-			vpcdomainKey = client.ObjectKey{Name: vpcdomainName, Namespace: metav1.NamespaceDefault}
-			poKey        = client.ObjectKey{Name: poName, Namespace: metav1.NamespaceDefault}
-			vrfKey       = client.ObjectKey{Name: vrfName, Namespace: metav1.NamespaceDefault}
-			physKey      = client.ObjectKey{Name: physName, Namespace: metav1.NamespaceDefault}
+			name string
+			key  client.ObjectKey
 		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &corev1.Device{}
-			if err := k8sClient.Get(ctx, deviceKey, device); errors.IsNotFound(err) {
-				resource := &corev1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceName,
-						Namespace: metav1.NamespaceDefault,
+			device := &corev1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vpcdomain-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: corev1.DeviceSpec{
+					Endpoint: corev1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: corev1.DeviceSpec{
-						Endpoint: corev1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind Interface (Physical)")
-			phyIf := &corev1.Interface{}
-			if err := k8sClient.Get(ctx, physKey, phyIf); errors.IsNotFound(err) {
-				resource := &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      physName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceName},
-						Name:       physName,
-						Type:       corev1.InterfaceTypePhysical,
-						AdminState: "Up",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-phys", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name},
+					Name:       name + "-phys",
+					Type:       corev1.InterfaceTypePhysical,
+					AdminState: "Up",
+				},
+			})).To(Succeed())
 
 			By("Creating the custom resource for the Kind Interface (Aggregate)")
-			aggIf := &corev1.Interface{}
-			if err := k8sClient.Get(ctx, poKey, aggIf); errors.IsNotFound(err) {
-				resource := &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      poName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceName},
-						Name:       poName,
-						Type:       corev1.InterfaceTypeAggregate,
-						AdminState: "Up",
-						Aggregation: &corev1.Aggregation{
-							ControlProtocol: corev1.ControlProtocol{Mode: corev1.LACPModeActive},
-							MemberInterfaceRefs: []corev1.LocalObjectReference{
-								{Name: physName},
-							},
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-po", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name},
+					Name:       name + "-po",
+					Type:       corev1.InterfaceTypeAggregate,
+					AdminState: "Up",
+					Aggregation: &corev1.Aggregation{
+						ControlProtocol: corev1.ControlProtocol{Mode: corev1.LACPModeActive},
+						MemberInterfaceRefs: []corev1.LocalObjectReference{
+							{Name: name + "-phys"},
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
+				},
+			})).To(Succeed())
 
 			By("Creating the custom resource for the Kind VRF")
-			vrf := &corev1.VRF{}
-			if err := k8sClient.Get(ctx, vrfKey, vrf); errors.IsNotFound(err) {
-				resource := &corev1.VRF{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vrfName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: corev1.VRFSpec{
-						DeviceRef: corev1.LocalObjectReference{Name: deviceName},
-						Name:      vrfName,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
+			Expect(k8sClient.Create(ctx, &corev1.VRF{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-vrf", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.VRFSpec{
+					DeviceRef: corev1.LocalObjectReference{Name: name},
+					Name:      name + "-vrf",
+				},
+			})).To(Succeed())
 
 			By("Creating the custom resource for the Kind VPCDomain")
-			vpc := &nxv1.VPCDomain{}
-			if err := k8sClient.Get(ctx, vpcdomainKey, vpc); errors.IsNotFound(err) {
-				resource := &nxv1.VPCDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vpcdomainName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1.VPCDomainSpec{
-						DeviceRef:       corev1.LocalObjectReference{Name: deviceName},
-						AdminState:      "Up",
-						DomainID:        2,
-						RolePriority:    100,
-						SystemPriority:  10,
-						DelayRestoreSVI: 140,
-						DelayRestoreVPC: 150,
-						Peer: nxv1.Peer{
-							AdminState:   "Up",
-							InterfaceRef: corev1.LocalObjectReference{Name: poName},
-							Switch:       nxv1.Enabled{Enabled: true},
-							Gateway:      nxv1.Enabled{Enabled: true},
-							KeepAlive: nxv1.KeepAlive{
-								Source:      "10.114.235.155",
-								Destination: "10.114.235.156",
-								VrfRef:      &corev1.LocalObjectReference{Name: vrfName},
-							},
-							AutoRecovery: &nxv1.AutoRecovery{
-								Enabled:     true,
-								ReloadDelay: 360,
-							},
+			Expect(k8sClient.Create(ctx, &nxv1.VPCDomain{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-vpc", Namespace: metav1.NamespaceDefault},
+				Spec: nxv1.VPCDomainSpec{
+					DeviceRef:       corev1.LocalObjectReference{Name: name},
+					AdminState:      "Up",
+					DomainID:        2,
+					RolePriority:    100,
+					SystemPriority:  10,
+					DelayRestoreSVI: 140,
+					DelayRestoreVPC: 150,
+					Peer: nxv1.Peer{
+						AdminState:   "Up",
+						InterfaceRef: corev1.LocalObjectReference{Name: name + "-po"},
+						Switch:       nxv1.Enabled{Enabled: true},
+						Gateway:      nxv1.Enabled{Enabled: true},
+						KeepAlive: nxv1.KeepAlive{
+							Source:      "10.114.235.155",
+							Destination: "10.114.235.156",
+							VrfRef:      &corev1.LocalObjectReference{Name: name + "-vrf"},
 						},
-						FastConvergence: nxv1.Enabled{Enabled: true},
+						AutoRecovery: &nxv1.AutoRecovery{
+							Enabled:     true,
+							ReloadDelay: 360,
+						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
+					FastConvergence: nxv1.Enabled{Enabled: true},
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
+			vpcdomainKey := client.ObjectKey{Name: name + "-vpc", Namespace: metav1.NamespaceDefault}
 			var resource client.Object = &nxv1.VPCDomain{}
-			err := k8sClient.Get(ctx, vpcdomainKey, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
 
 			By("Cleanup the specific resource instance VPCDomain")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
 			resource = &corev1.Device{}
-			err = k8sClient.Get(ctx, deviceKey, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 
 			By("Cleanup the specific resource instance Device")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
@@ -170,6 +129,9 @@ var _ = Describe("VPCDomain Controller", func() {
 		})
 
 		It("Should successfully reconcile the resource", func() {
+			vpcdomainKey := client.ObjectKey{Name: name + "-vpc", Namespace: metav1.NamespaceDefault}
+			poKey := client.ObjectKey{Name: name + "-po", Namespace: metav1.NamespaceDefault}
+
 			By("Adding a finalizer to the resource")
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
@@ -181,7 +143,7 @@ var _ = Describe("VPCDomain Controller", func() {
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
-				g.Expect(resource.Labels).To(HaveKeyWithValue(corev1.DeviceLabel, deviceName))
+				g.Expect(resource.Labels).To(HaveKeyWithValue(corev1.DeviceLabel, name))
 			}).Should(Succeed())
 
 			By("Adding the device as a owner reference")
@@ -190,10 +152,9 @@ var _ = Describe("VPCDomain Controller", func() {
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
 				g.Expect(resource.OwnerReferences).To(HaveLen(1))
 				g.Expect(resource.OwnerReferences[0].Kind).To(Equal("Device"))
-				g.Expect(resource.OwnerReferences[0].Name).To(Equal(deviceName))
+				g.Expect(resource.OwnerReferences[0].Name).To(Equal(name))
 			}).Should(Succeed())
 
-			// Set the peer-link port-channel interface status operational condition to True
 			By("Setting the peer-link interface operational status")
 			po := &corev1.Interface{}
 			Expect(k8sClient.Get(ctx, poKey, po)).To(Succeed())
@@ -230,197 +191,116 @@ var _ = Describe("VPCDomain Controller", func() {
 
 	Context("Dependency resolution", func() {
 		const (
-			vpcdomainName  = "vpc1"
-			deviceAName    = "leaf-a"
-			deviceBName    = "leaf-b"
-			vrfAName       = "leaf-a-vrf"
-			vrfBName       = "leaf-b-vrf"
-			physAName      = "leaf-a-eth-1-1"
-			physBName      = "leaf-b-eth-1-1"
-			lo0Name        = "leaf-a-lo0"
-			aggAName       = "leaf-a-po1"
-			aggBName       = "leaf-b-po1"
 			missingIfName  = "vpc-missing-if"
 			missingVrfName = "vpc-missing-vrf"
 		)
 		var (
-			deviceAKey   = client.ObjectKey{Name: deviceAName, Namespace: metav1.NamespaceDefault}
-			deviceBKey   = client.ObjectKey{Name: deviceBName, Namespace: metav1.NamespaceDefault}
-			vpcdomainKey = client.ObjectKey{Name: vpcdomainName, Namespace: metav1.NamespaceDefault}
+			name         string
+			vpcdomainKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
-			// Create devices A and B
-			deviceA := &corev1.Device{}
-			if err := k8sClient.Get(ctx, deviceAKey, deviceA); errors.IsNotFound(err) {
-				resource := &corev1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceAName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: corev1.DeviceSpec{
-						Endpoint: corev1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-			deviceB := &corev1.Device{}
-			if err := k8sClient.Get(ctx, deviceBKey, deviceB); errors.IsNotFound(err) {
-				resource := &corev1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceBName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: corev1.DeviceSpec{
-						Endpoint: corev1.Endpoint{
-							Address: "192.168.10.3:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-			// Create one physical interfaces on device A and B
-			physA := &corev1.Interface{
+			By("Creating Device A")
+			deviceA := &corev1.Device{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      physAName,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "vpc-dep-",
+					Namespace:    metav1.NamespaceDefault,
 				},
+				Spec: corev1.DeviceSpec{Endpoint: corev1.Endpoint{Address: "192.168.10.2:9339"}},
 			}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(physA), physA); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{Name: physAName, Namespace: metav1.NamespaceDefault},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceAName},
-						Name:       physAName,
-						Type:       corev1.InterfaceTypePhysical,
-						AdminState: "Up",
-					},
-				})).To(Succeed())
-			}
-			physB := &corev1.Interface{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      physBName,
-					Namespace: metav1.NamespaceDefault,
+			Expect(k8sClient.Create(ctx, deviceA)).To(Succeed())
+			name = deviceA.Name
+
+			By("Creating Device B")
+			Expect(k8sClient.Create(ctx, &corev1.Device{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-b", Namespace: metav1.NamespaceDefault},
+				Spec:       corev1.DeviceSpec{Endpoint: corev1.Endpoint{Address: "192.168.10.3:9339"}},
+			})).To(Succeed())
+
+			By("Creating physical interfaces on Device A and B")
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-phys-a", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name},
+					Name:       name + "-phys-a",
+					Type:       corev1.InterfaceTypePhysical,
+					AdminState: "Up",
 				},
-			}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(physB), physB); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{Name: physBName, Namespace: metav1.NamespaceDefault},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceBName},
-						Name:       physBName,
-						Type:       corev1.InterfaceTypePhysical,
-						AdminState: "Up",
-					},
-				})).To(Succeed())
-			}
-			// Create aggregate interfaces on device A and B
-			aggA := &corev1.Interface{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      aggAName,
-					Namespace: metav1.NamespaceDefault,
+			})).To(Succeed())
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-phys-b", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name + "-b"},
+					Name:       name + "-phys-b",
+					Type:       corev1.InterfaceTypePhysical,
+					AdminState: "Up",
 				},
-			}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(aggA), aggA); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{Name: aggAName, Namespace: metav1.NamespaceDefault},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceAName},
-						Name:       aggAName,
-						Type:       corev1.InterfaceTypeAggregate,
-						AdminState: "Up",
-						Aggregation: &corev1.Aggregation{
-							ControlProtocol: corev1.ControlProtocol{Mode: corev1.LACPModeActive},
-							MemberInterfaceRefs: []corev1.LocalObjectReference{
-								{Name: physAName},
-							},
-						},
+			})).To(Succeed())
+
+			By("Creating aggregate interfaces on Device A and B")
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-po-a", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name},
+					Name:       name + "-po-a",
+					Type:       corev1.InterfaceTypeAggregate,
+					AdminState: "Up",
+					Aggregation: &corev1.Aggregation{
+						ControlProtocol:     corev1.ControlProtocol{Mode: corev1.LACPModeActive},
+						MemberInterfaceRefs: []corev1.LocalObjectReference{{Name: name + "-phys-a"}},
 					},
-				})).To(Succeed())
-			}
-			aggB := &corev1.Interface{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      aggBName,
-					Namespace: metav1.NamespaceDefault,
 				},
-			}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(aggB), aggB); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{Name: aggBName, Namespace: metav1.NamespaceDefault},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceBName},
-						Name:       aggBName,
-						Type:       corev1.InterfaceTypeAggregate,
-						AdminState: "Up",
-						Aggregation: &corev1.Aggregation{
-							ControlProtocol: corev1.ControlProtocol{Mode: corev1.LACPModeActive},
-							MemberInterfaceRefs: []corev1.LocalObjectReference{
-								{Name: physBName},
-							},
-						},
+			})).To(Succeed())
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-po-b", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name + "-b"},
+					Name:       name + "-po-b",
+					Type:       corev1.InterfaceTypeAggregate,
+					AdminState: "Up",
+					Aggregation: &corev1.Aggregation{
+						ControlProtocol:     corev1.ControlProtocol{Mode: corev1.LACPModeActive},
+						MemberInterfaceRefs: []corev1.LocalObjectReference{{Name: name + "-phys-b"}},
 					},
-				})).To(Succeed())
-			}
-			// VRFs on A and B
-			vrfA := &corev1.VRF{ObjectMeta: metav1.ObjectMeta{Name: vrfAName, Namespace: metav1.NamespaceDefault}}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(vrfA), vrfA); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.VRF{
-					ObjectMeta: metav1.ObjectMeta{Name: vrfAName, Namespace: metav1.NamespaceDefault},
-					Spec:       corev1.VRFSpec{DeviceRef: corev1.LocalObjectReference{Name: deviceAName}, Name: vrfAName},
-				})).To(Succeed())
-			}
-			vrfB := &corev1.VRF{ObjectMeta: metav1.ObjectMeta{Name: vrfBName, Namespace: metav1.NamespaceDefault}}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(vrfB), vrfB); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.VRF{
-					ObjectMeta: metav1.ObjectMeta{Name: vrfBName, Namespace: metav1.NamespaceDefault},
-					Spec:       corev1.VRFSpec{DeviceRef: corev1.LocalObjectReference{Name: deviceBName}, Name: vrfBName},
-				})).To(Succeed())
-			}
-			// Loopback on A
-			loA := &corev1.Interface{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      lo0Name,
-					Namespace: metav1.NamespaceDefault,
 				},
-			}
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(loA), loA); errors.IsNotFound(err) {
-				Expect(k8sClient.Create(ctx, &corev1.Interface{
-					ObjectMeta: metav1.ObjectMeta{Name: lo0Name, Namespace: metav1.NamespaceDefault},
-					Spec: corev1.InterfaceSpec{
-						DeviceRef:  corev1.LocalObjectReference{Name: deviceAName},
-						Name:       lo0Name,
-						Type:       corev1.InterfaceTypeLoopback,
-						AdminState: "Up",
-					},
-				})).To(Succeed())
-			}
+			})).To(Succeed())
+
+			By("Creating a loopback interface on Device A")
+			Expect(k8sClient.Create(ctx, &corev1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				Spec: corev1.InterfaceSpec{
+					DeviceRef:  corev1.LocalObjectReference{Name: name},
+					Name:       name + "-lo0",
+					Type:       corev1.InterfaceTypeLoopback,
+					AdminState: "Up",
+				},
+			})).To(Succeed())
+
+			By("Creating VRFs on Device A and B")
+			Expect(k8sClient.Create(ctx, &corev1.VRF{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-vrf-a", Namespace: metav1.NamespaceDefault},
+				Spec:       corev1.VRFSpec{DeviceRef: corev1.LocalObjectReference{Name: name}, Name: name + "-vrf-a"},
+			})).To(Succeed())
+			Expect(k8sClient.Create(ctx, &corev1.VRF{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-vrf-b", Namespace: metav1.NamespaceDefault},
+				Spec:       corev1.VRFSpec{DeviceRef: corev1.LocalObjectReference{Name: name + "-b"}, Name: name + "-vrf-b"},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
 			var resource client.Object = &nxv1.VPCDomain{}
-			err := k8sClient.Get(ctx, vpcdomainKey, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
 
-			By("Cleanup the specific resource instance VPCDomain")
+			By("Cleanup the VPCDomain")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
-			resource = &corev1.Device{}
+			By("Cleanup all Interface and VRF resources")
+			Expect(k8sClient.DeleteAllOf(ctx, &corev1.Interface{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			Expect(k8sClient.DeleteAllOf(ctx, &corev1.VRF{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
 
-			// Device A
-			err = k8sClient.Get(ctx, deviceAKey, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device A")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			// Device B
-			err = k8sClient.Get(ctx, deviceBKey, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device B")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("Cleanup Device A and B")
+			Expect(k8sClient.Delete(ctx, &corev1.Device{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault}})).To(Succeed())
+			Expect(k8sClient.Delete(ctx, &corev1.Device{ObjectMeta: metav1.ObjectMeta{Name: name + "-b", Namespace: metav1.NamespaceDefault}})).To(Succeed())
 
 			By("Ensuring the resource is deleted from the provider")
 			Eventually(func(g Gomega) {
@@ -429,39 +309,33 @@ var _ = Describe("VPCDomain Controller", func() {
 		})
 
 		It("reports WaitingForDependencies when peer-link interface is missing", func() {
-			v := &nxv1.VPCDomain{}
-			if err := k8sClient.Get(ctx, vpcdomainKey, v); errors.IsNotFound(err) {
-				resource := &nxv1.VPCDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vpcdomainName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1.VPCDomainSpec{
-						DeviceRef:       corev1.LocalObjectReference{Name: deviceAName},
-						AdminState:      "Up",
-						DomainID:        2,
-						RolePriority:    100,
-						SystemPriority:  10,
-						DelayRestoreSVI: 140,
-						DelayRestoreVPC: 150,
-						Peer: nxv1.Peer{
-							AdminState:   "Up",
-							InterfaceRef: corev1.LocalObjectReference{Name: missingIfName},
-							Switch:       nxv1.Enabled{Enabled: true},
-							Gateway:      nxv1.Enabled{Enabled: true},
-							KeepAlive: nxv1.KeepAlive{
-								Source:      "10.114.235.155",
-								Destination: "10.114.235.156",
-								VrfRef:      &corev1.LocalObjectReference{Name: vrfAName},
-							},
+			vpc := &nxv1.VPCDomain{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "vpc-dep-", Namespace: metav1.NamespaceDefault},
+				Spec: nxv1.VPCDomainSpec{
+					DeviceRef:       corev1.LocalObjectReference{Name: name},
+					AdminState:      "Up",
+					DomainID:        2,
+					RolePriority:    100,
+					SystemPriority:  10,
+					DelayRestoreSVI: 140,
+					DelayRestoreVPC: 150,
+					Peer: nxv1.Peer{
+						AdminState:   "Up",
+						InterfaceRef: corev1.LocalObjectReference{Name: missingIfName},
+						Switch:       nxv1.Enabled{Enabled: true},
+						Gateway:      nxv1.Enabled{Enabled: true},
+						KeepAlive: nxv1.KeepAlive{
+							Source:      "10.114.235.155",
+							Destination: "10.114.235.156",
+							VrfRef:      &corev1.LocalObjectReference{Name: name + "-vrf-a"},
 						},
-						FastConvergence: nxv1.Enabled{Enabled: true},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					FastConvergence: nxv1.Enabled{Enabled: true},
+				},
 			}
+			Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+			vpcdomainKey = client.ObjectKey{Name: vpc.Name, Namespace: metav1.NamespaceDefault}
 
-			By("Updating the resource status")
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
@@ -474,40 +348,34 @@ var _ = Describe("VPCDomain Controller", func() {
 			}).Should(Succeed())
 		})
 
-		It("reports InvalidInterfaceType when peer-link reference is not aggregate or physical link", func() {
-			v := &nxv1.VPCDomain{}
-			if err := k8sClient.Get(ctx, vpcdomainKey, v); errors.IsNotFound(err) {
-				resource := &nxv1.VPCDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vpcdomainName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1.VPCDomainSpec{
-						DeviceRef:       corev1.LocalObjectReference{Name: deviceAName},
-						AdminState:      "Up",
-						DomainID:        2,
-						RolePriority:    100,
-						SystemPriority:  10,
-						DelayRestoreSVI: 140,
-						DelayRestoreVPC: 150,
-						Peer: nxv1.Peer{
-							AdminState:   "Up",
-							InterfaceRef: corev1.LocalObjectReference{Name: lo0Name},
-							Switch:       nxv1.Enabled{Enabled: true},
-							Gateway:      nxv1.Enabled{Enabled: true},
-							KeepAlive: nxv1.KeepAlive{
-								Source:      "10.114.235.155",
-								Destination: "10.114.235.156",
-								VrfRef:      &corev1.LocalObjectReference{Name: vrfAName},
-							},
+		It("reports InvalidInterfaceType when peer-link reference is not aggregate or physical", func() {
+			vpc := &nxv1.VPCDomain{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "vpc-dep-", Namespace: metav1.NamespaceDefault},
+				Spec: nxv1.VPCDomainSpec{
+					DeviceRef:       corev1.LocalObjectReference{Name: name},
+					AdminState:      "Up",
+					DomainID:        2,
+					RolePriority:    100,
+					SystemPriority:  10,
+					DelayRestoreSVI: 140,
+					DelayRestoreVPC: 150,
+					Peer: nxv1.Peer{
+						AdminState:   "Up",
+						InterfaceRef: corev1.LocalObjectReference{Name: name + "-lo0"},
+						Switch:       nxv1.Enabled{Enabled: true},
+						Gateway:      nxv1.Enabled{Enabled: true},
+						KeepAlive: nxv1.KeepAlive{
+							Source:      "10.114.235.155",
+							Destination: "10.114.235.156",
+							VrfRef:      &corev1.LocalObjectReference{Name: name + "-vrf-a"},
 						},
-						FastConvergence: nxv1.Enabled{Enabled: true},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					FastConvergence: nxv1.Enabled{Enabled: true},
+				},
 			}
+			Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+			vpcdomainKey = client.ObjectKey{Name: vpc.Name, Namespace: metav1.NamespaceDefault}
 
-			By("Updating the resource status")
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
@@ -521,39 +389,33 @@ var _ = Describe("VPCDomain Controller", func() {
 		})
 
 		It("reports CrossDeviceReference when peer-link deviceRef mismatches VPCDomain deviceRef", func() {
-			v := &nxv1.VPCDomain{}
-			if err := k8sClient.Get(ctx, vpcdomainKey, v); errors.IsNotFound(err) {
-				resource := &nxv1.VPCDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vpcdomainName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1.VPCDomainSpec{
-						DeviceRef:       corev1.LocalObjectReference{Name: deviceAName},
-						AdminState:      "Up",
-						DomainID:        2,
-						RolePriority:    100,
-						SystemPriority:  10,
-						DelayRestoreSVI: 140,
-						DelayRestoreVPC: 150,
-						Peer: nxv1.Peer{
-							AdminState:   "Up",
-							InterfaceRef: corev1.LocalObjectReference{Name: aggBName},
-							Switch:       nxv1.Enabled{Enabled: true},
-							Gateway:      nxv1.Enabled{Enabled: true},
-							KeepAlive: nxv1.KeepAlive{
-								Source:      "10.114.235.155",
-								Destination: "10.114.235.156",
-								VrfRef:      &corev1.LocalObjectReference{Name: vrfAName},
-							},
+			vpc := &nxv1.VPCDomain{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "vpc-dep-", Namespace: metav1.NamespaceDefault},
+				Spec: nxv1.VPCDomainSpec{
+					DeviceRef:       corev1.LocalObjectReference{Name: name},
+					AdminState:      "Up",
+					DomainID:        2,
+					RolePriority:    100,
+					SystemPriority:  10,
+					DelayRestoreSVI: 140,
+					DelayRestoreVPC: 150,
+					Peer: nxv1.Peer{
+						AdminState:   "Up",
+						InterfaceRef: corev1.LocalObjectReference{Name: name + "-po-b"},
+						Switch:       nxv1.Enabled{Enabled: true},
+						Gateway:      nxv1.Enabled{Enabled: true},
+						KeepAlive: nxv1.KeepAlive{
+							Source:      "10.114.235.155",
+							Destination: "10.114.235.156",
+							VrfRef:      &corev1.LocalObjectReference{Name: name + "-vrf-a"},
 						},
-						FastConvergence: nxv1.Enabled{Enabled: true},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					FastConvergence: nxv1.Enabled{Enabled: true},
+				},
 			}
+			Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+			vpcdomainKey = client.ObjectKey{Name: vpc.Name, Namespace: metav1.NamespaceDefault}
 
-			By("Updating the resource status")
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
@@ -566,40 +428,34 @@ var _ = Describe("VPCDomain Controller", func() {
 			}).Should(Succeed())
 		})
 
-		It("Sets status to WaitingForDependencies when KeepAlive VRF is missing", func() {
-			v := &nxv1.VPCDomain{}
-			if err := k8sClient.Get(ctx, vpcdomainKey, v); errors.IsNotFound(err) {
-				resource := &nxv1.VPCDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vpcdomainName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1.VPCDomainSpec{
-						DeviceRef:       corev1.LocalObjectReference{Name: deviceAName},
-						AdminState:      "Up",
-						DomainID:        2,
-						RolePriority:    100,
-						SystemPriority:  10,
-						DelayRestoreSVI: 140,
-						DelayRestoreVPC: 150,
-						Peer: nxv1.Peer{
-							AdminState:   "Up",
-							InterfaceRef: corev1.LocalObjectReference{Name: aggAName},
-							Switch:       nxv1.Enabled{Enabled: true},
-							Gateway:      nxv1.Enabled{Enabled: true},
-							KeepAlive: nxv1.KeepAlive{
-								Source:      "10.114.235.155",
-								Destination: "10.114.235.156",
-								VrfRef:      &corev1.LocalObjectReference{Name: missingVrfName},
-							},
+		It("reports WaitingForDependencies when KeepAlive VRF is missing", func() {
+			vpc := &nxv1.VPCDomain{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "vpc-dep-", Namespace: metav1.NamespaceDefault},
+				Spec: nxv1.VPCDomainSpec{
+					DeviceRef:       corev1.LocalObjectReference{Name: name},
+					AdminState:      "Up",
+					DomainID:        2,
+					RolePriority:    100,
+					SystemPriority:  10,
+					DelayRestoreSVI: 140,
+					DelayRestoreVPC: 150,
+					Peer: nxv1.Peer{
+						AdminState:   "Up",
+						InterfaceRef: corev1.LocalObjectReference{Name: name + "-po-a"},
+						Switch:       nxv1.Enabled{Enabled: true},
+						Gateway:      nxv1.Enabled{Enabled: true},
+						KeepAlive: nxv1.KeepAlive{
+							Source:      "10.114.235.155",
+							Destination: "10.114.235.156",
+							VrfRef:      &corev1.LocalObjectReference{Name: missingVrfName},
 						},
-						FastConvergence: nxv1.Enabled{Enabled: true},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					FastConvergence: nxv1.Enabled{Enabled: true},
+				},
 			}
+			Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+			vpcdomainKey = client.ObjectKey{Name: vpc.Name, Namespace: metav1.NamespaceDefault}
 
-			By("Updating the resource status")
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())
@@ -612,40 +468,34 @@ var _ = Describe("VPCDomain Controller", func() {
 			}).Should(Succeed())
 		})
 
-		It("Sets status to CrossDeviceReference when KeepAlive VRF deviceRef mismatches VPCDomain deviceRef", func() {
-			v := &nxv1.VPCDomain{}
-			if err := k8sClient.Get(ctx, vpcdomainKey, v); errors.IsNotFound(err) {
-				resource := &nxv1.VPCDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vpcdomainName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: nxv1.VPCDomainSpec{
-						DeviceRef:       corev1.LocalObjectReference{Name: deviceAName},
-						AdminState:      "Up",
-						DomainID:        2,
-						RolePriority:    100,
-						SystemPriority:  10,
-						DelayRestoreSVI: 140,
-						DelayRestoreVPC: 150,
-						Peer: nxv1.Peer{
-							AdminState:   "Up",
-							InterfaceRef: corev1.LocalObjectReference{Name: aggAName},
-							Switch:       nxv1.Enabled{Enabled: true},
-							Gateway:      nxv1.Enabled{Enabled: true},
-							KeepAlive: nxv1.KeepAlive{
-								Source:      "10.114.235.155",
-								Destination: "10.114.235.156",
-								VrfRef:      &corev1.LocalObjectReference{Name: vrfBName},
-							},
+		It("reports CrossDeviceReference when KeepAlive VRF deviceRef mismatches VPCDomain deviceRef", func() {
+			vpc := &nxv1.VPCDomain{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "vpc-dep-", Namespace: metav1.NamespaceDefault},
+				Spec: nxv1.VPCDomainSpec{
+					DeviceRef:       corev1.LocalObjectReference{Name: name},
+					AdminState:      "Up",
+					DomainID:        2,
+					RolePriority:    100,
+					SystemPriority:  10,
+					DelayRestoreSVI: 140,
+					DelayRestoreVPC: 150,
+					Peer: nxv1.Peer{
+						AdminState:   "Up",
+						InterfaceRef: corev1.LocalObjectReference{Name: name + "-po-a"},
+						Switch:       nxv1.Enabled{Enabled: true},
+						Gateway:      nxv1.Enabled{Enabled: true},
+						KeepAlive: nxv1.KeepAlive{
+							Source:      "10.114.235.155",
+							Destination: "10.114.235.156",
+							VrfRef:      &corev1.LocalObjectReference{Name: name + "-vrf-b"},
 						},
-						FastConvergence: nxv1.Enabled{Enabled: true},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					FastConvergence: nxv1.Enabled{Enabled: true},
+				},
 			}
+			Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+			vpcdomainKey = client.ObjectKey{Name: vpc.Name, Namespace: metav1.NamespaceDefault}
 
-			By("Updating the resource status")
 			Eventually(func(g Gomega) {
 				resource := &nxv1.VPCDomain{}
 				g.Expect(k8sClient.Get(ctx, vpcdomainKey, resource)).To(Succeed())

--- a/internal/controller/core/acl_controller_test.go
+++ b/internal/controller/core/acl_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -18,60 +17,58 @@ import (
 
 var _ = Describe("AccessControlList Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-acl"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-acl-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind AccessControlList")
-			acl := &v1alpha1.AccessControlList{}
-			if err := k8sClient.Get(ctx, key, acl); errors.IsNotFound(err) {
-				resource := &v1alpha1.AccessControlList{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.AccessControlListSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						Name:      name,
-						Entries: []v1alpha1.ACLEntry{
-							{
-								Sequence:           10,
-								Action:             v1alpha1.ActionPermit,
-								Protocol:           v1alpha1.ProtocolIP,
-								SourceAddress:      v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("10.0.0.0/8")},
-								DestinationAddress: v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("0.0.0.0/0")},
-								Description:        "Permit all from internal",
-							},
-							{
-								Sequence:           20,
-								Action:             v1alpha1.ActionDeny,
-								Protocol:           v1alpha1.ProtocolIP,
-								SourceAddress:      v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("0.0.0.0/0")},
-								DestinationAddress: v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("0.0.0.0/0")},
-								Description:        "Deny all other traffic",
-							},
+			resource := &v1alpha1.AccessControlList{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.AccessControlListSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					Name:      name,
+					Entries: []v1alpha1.ACLEntry{
+						{
+							Sequence:           10,
+							Action:             v1alpha1.ActionPermit,
+							Protocol:           v1alpha1.ProtocolIP,
+							SourceAddress:      v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("10.0.0.0/8")},
+							DestinationAddress: v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("0.0.0.0/0")},
+							Description:        "Permit all from internal",
+						},
+						{
+							Sequence:           20,
+							Action:             v1alpha1.ActionDeny,
+							Protocol:           v1alpha1.ProtocolIP,
+							SourceAddress:      v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("0.0.0.0/0")},
+							DestinationAddress: v1alpha1.IPPrefix{Prefix: netip.MustParsePrefix("0.0.0.0/0")},
+							Description:        "Deny all other traffic",
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/banner_controller_test.go
+++ b/internal/controller/core/banner_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,26 +15,27 @@ import (
 
 var _ = Describe("Banner Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-banner"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-banner-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/bgp_controller_test.go
+++ b/internal/controller/core/bgp_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,43 +16,41 @@ import (
 
 var _ = Describe("BGP Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-bgp"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind BGP")
-			bgp := &v1alpha1.BGP{}
-			if err := k8sClient.Get(ctx, key, bgp); errors.IsNotFound(err) {
-				resource := &v1alpha1.BGP{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.BGPSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						ASNumber:  intstr.FromInt(65000),
-						RouterID:  "10.0.0.10",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			resource := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.10",
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,27 +16,28 @@ import (
 
 var _ = Describe("BGPPeer Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-bgppeer"
 		const host = "10.0.0.1"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating a Device resource for testing")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/certificate_controller_test.go
+++ b/internal/controller/core/certificate_controller_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -27,63 +26,58 @@ import (
 
 var _ = Describe("Certificate Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-certificate"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-certificate-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			cert, priv, err := CreateSelfSignedCertificate()
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the custom resource for the Kind Secret")
-			secret := &corev1.Secret{}
-			if err := k8sClient.Get(ctx, key, secret); errors.IsNotFound(err) {
-				resource := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Data: map[string][]byte{
-						corev1.TLSCertKey:       cert,
-						corev1.TLSPrivateKeyKey: priv,
-					},
-					Type: corev1.SecretTypeTLS,
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       cert,
+					corev1.TLSPrivateKeyKey: priv,
+				},
+				Type: corev1.SecretTypeTLS,
 			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			By("Creating the custom resource for the Kind Certificate")
-			certificate := &v1alpha1.Certificate{}
-			if err := k8sClient.Get(ctx, key, certificate); errors.IsNotFound(err) {
-				resource := &v1alpha1.Certificate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.CertificateSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						ID:        "cert1",
-						SecretRef: v1alpha1.SecretReference{Name: name},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			certificate := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.CertificateSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					ID:        "cert1",
+					SecretRef: v1alpha1.SecretReference{Name: name},
+				},
 			}
+			Expect(k8sClient.Create(ctx, certificate)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,26 +18,27 @@ import (
 
 var _ = Describe("Device Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-device"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the endpoint credentials as a Secret")
-			secret := &corev1.Secret{}
-			if err := k8sClient.Get(ctx, key, secret); errors.IsNotFound(err) {
-				resource := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Data: map[string][]byte{
-						corev1.BasicAuthUsernameKey: []byte("user"),
-						corev1.BasicAuthPasswordKey: []byte("password"),
-					},
-					Type: corev1.SecretTypeBasicAuth,
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-device-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("user"),
+					corev1.BasicAuthPasswordKey: []byte("password"),
+				},
+				Type: corev1.SecretTypeBasicAuth,
 			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			name = secret.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {
@@ -87,24 +87,21 @@ var _ = Describe("Device Controller", func() {
 			}).Should(Succeed())
 
 			By("Creating the custom resource for the Kind Interface")
-			iface := &v1alpha1.Interface{}
-			if err := k8sClient.Get(ctx, key, iface); errors.IsNotFound(err) {
-				resource := &v1alpha1.Interface{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.InterfaceSpec{
-						DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
-						Name:        "eth1/1",
-						AdminState:  "Up",
-						Description: "Test",
-						MTU:         9000,
-						Type:        "Physical",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			iface := &v1alpha1.Interface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.InterfaceSpec{
+					DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
+					Name:        "eth1/1",
+					AdminState:  "Up",
+					Description: "Test",
+					MTU:         9000,
+					Type:        "Physical",
+				},
 			}
+			Expect(k8sClient.Create(ctx, iface)).To(Succeed())
 
 			By("Updating the resource status")
 			Eventually(func(g Gomega) {

--- a/internal/controller/core/dns_controller_test.go
+++ b/internal/controller/core/dns_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,48 +15,46 @@ import (
 
 var _ = Describe("DNS Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-dns"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-dns-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind DNS")
-			dns := &v1alpha1.DNS{}
-			if err := k8sClient.Get(ctx, key, dns); errors.IsNotFound(err) {
-				resource := &v1alpha1.DNS{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.DNSSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						Domain:    "example.com",
-						Servers: []v1alpha1.NameServer{
-							{
-								Address: "8.8.8.8",
-							},
+			resource := &v1alpha1.DNS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DNSSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					Domain:    "example.com",
+					Servers: []v1alpha1.NameServer{
+						{
+							Address: "8.8.8.8",
 						},
-						SourceInterfaceName: "mgmt",
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					SourceInterfaceName: "mgmt",
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/evpninstance_controller_test.go
+++ b/internal/controller/core/evpninstance_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,27 +15,28 @@ import (
 
 var _ = Describe("EVPNInstance Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-evi"
 		const vni = 100010
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating a Device resource for testing")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-evi-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/interface_controller_test.go
+++ b/internal/controller/core/interface_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -18,26 +17,27 @@ import (
 
 var _ = Describe("Interface Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-interface"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating a Device resource for testing")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-interface-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/isis_controller_test.go
+++ b/internal/controller/core/isis_controller_test.go
@@ -5,7 +5,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,49 +15,47 @@ import (
 
 var _ = Describe("ISIS Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-isis"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-isis-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind ISIS")
-			isis := &v1alpha1.ISIS{}
-			if err := k8sClient.Get(ctx, key, isis); errors.IsNotFound(err) {
-				resource := &v1alpha1.ISIS{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			resource := &v1alpha1.ISIS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.ISISSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					Instance:           "UNDERLAY",
+					NetworkEntityTitle: "49.0001.0000.0000.0001.00",
+					Type:               v1alpha1.ISISLevel1,
+					OverloadBit:        v1alpha1.OverloadBitOnStartup,
+					AddressFamilies: []v1alpha1.AddressFamily{
+						v1alpha1.AddressFamilyIPv4Unicast,
+						v1alpha1.AddressFamilyIPv6Unicast,
 					},
-					Spec: v1alpha1.ISISSpec{
-						DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
-						Instance:           "UNDERLAY",
-						NetworkEntityTitle: "49.0001.0000.0000.0001.00",
-						Type:               v1alpha1.ISISLevel1,
-						OverloadBit:        v1alpha1.OverloadBitOnStartup,
-						AddressFamilies: []v1alpha1.AddressFamily{
-							v1alpha1.AddressFamilyIPv4Unicast,
-							v1alpha1.AddressFamilyIPv6Unicast,
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -123,26 +120,27 @@ var _ = Describe("ISIS Controller", func() {
 	})
 
 	Context("When an interfaceRef does not exist", func() {
-		const name = "test-isis-missing-intf"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-isis-missing-intf-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/lldp_controller_test.go
+++ b/internal/controller/core/lldp_controller_test.go
@@ -18,36 +18,31 @@ import (
 
 var _ = Describe("LLDP Controller", func() {
 	Context("When reconciling a resource", func() {
-		const (
-			deviceName   = "testlldp-device"
-			resourceName = "testlldp-lldp"
-		)
-
-		resourceKey := client.ObjectKey{Name: resourceName, Namespace: metav1.NamespaceDefault}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
-
 		var (
-			device *v1alpha1.Device
-			lldp   *v1alpha1.LLDP
+			deviceName  string
+			resourceKey client.ObjectKey
+			deviceKey   client.ObjectKey
+			device      *v1alpha1.Device
+			lldp        *v1alpha1.LLDP
 		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device = &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, deviceKey, device); errors.IsNotFound(err) {
-				device = &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceName,
-						Namespace: metav1.NamespaceDefault,
+			device = &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "testlldp-device-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, device)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			deviceName = device.Name
+			deviceKey = client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
+			resourceKey = client.ObjectKey{Name: deviceName + "-lldp", Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {
@@ -77,20 +72,17 @@ var _ = Describe("LLDP Controller", func() {
 
 		It("Should successfully reconcile the resource", func() {
 			By("Creating the custom resource for the Kind LLDP")
-			lldp = &v1alpha1.LLDP{}
-			if err := k8sClient.Get(ctx, resourceKey, lldp); errors.IsNotFound(err) {
-				lldp = &v1alpha1.LLDP{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.LLDPSpec{
-						DeviceRef:  v1alpha1.LocalObjectReference{Name: deviceName},
-						AdminState: "Up",
-					},
-				}
-				Expect(k8sClient.Create(ctx, lldp)).To(Succeed())
+			lldp = &v1alpha1.LLDP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deviceName + "-lldp",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.LLDPSpec{
+					DeviceRef:  v1alpha1.LocalObjectReference{Name: deviceName},
+					AdminState: "Up",
+				},
 			}
+			Expect(k8sClient.Create(ctx, lldp)).To(Succeed())
 
 			By("Verifying the controller adds a finalizer")
 			Eventually(func(g Gomega) {
@@ -138,7 +130,7 @@ var _ = Describe("LLDP Controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).ToNot(BeNil(), "Provider LLDP should not be nil")
 				if testProvider.LLDP != nil {
-					g.Expect(testProvider.LLDP.GetName()).To(Equal(resourceName), "Provider should have LLDP configured")
+					g.Expect(testProvider.LLDP.GetName()).To(Equal(deviceName+"-lldp"), "Provider should have LLDP configured")
 				}
 			}).Should(Succeed())
 		})
@@ -147,7 +139,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating the custom resource for the Kind LLDP with AdminState Down")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -188,7 +180,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating the first LLDP resource")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -208,7 +200,7 @@ var _ = Describe("LLDP Controller", func() {
 			}).Should(Succeed())
 
 			By("Creating a second LLDP resource for the same device")
-			duplicateName := resourceName + "-duplicate"
+			duplicateName := deviceName + "-lldp-duplicate"
 			duplicateKey := client.ObjectKey{Name: duplicateName, Namespace: metav1.NamespaceDefault}
 			duplicateLLDP := &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
@@ -241,7 +233,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating the custom resource for the Kind LLDP")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -282,9 +274,9 @@ var _ = Describe("LLDP Controller", func() {
 	})
 
 	Context("When DeviceRef references non-existent Device", func() {
-		const resourceName = "testlldp-nodevice-lldp"
-
-		resourceKey := client.ObjectKey{Name: resourceName, Namespace: metav1.NamespaceDefault}
+		var (
+			resourceKey client.ObjectKey
+		)
 
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
@@ -304,8 +296,8 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP referencing a non-existent Device")
 			lldp := &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "testlldp-nodevice-lldp-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
 					DeviceRef:  v1alpha1.LocalObjectReference{Name: "non-existent-device"},
@@ -313,6 +305,7 @@ var _ = Describe("LLDP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, lldp)).To(Succeed())
+			resourceKey = client.ObjectKey{Name: lldp.Name, Namespace: metav1.NamespaceDefault}
 
 			By("Verifying the controller does not add a finalizer")
 			Consistently(func(g Gomega) {
@@ -324,36 +317,31 @@ var _ = Describe("LLDP Controller", func() {
 	})
 
 	Context("When Device is paused", func() {
-		const (
-			deviceName   = "testlldp-paused-device"
-			resourceName = "testlldp-paused-lldp"
-		)
-
-		resourceKey := client.ObjectKey{Name: resourceName, Namespace: metav1.NamespaceDefault}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
-
 		var (
-			device *v1alpha1.Device
-			lldp   *v1alpha1.LLDP
+			deviceName  string
+			resourceKey client.ObjectKey
+			deviceKey   client.ObjectKey
+			device      *v1alpha1.Device
+			lldp        *v1alpha1.LLDP
 		)
 
 		BeforeEach(func() {
 			By("Creating the Device resource")
-			device = &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, deviceKey, device); errors.IsNotFound(err) {
-				device = &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceName,
-						Namespace: metav1.NamespaceDefault,
+			device = &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "testlldp-paused-device-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.6:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.6:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, device)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			deviceName = device.Name
+			deviceKey = client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
+			resourceKey = client.ObjectKey{Name: deviceName + "-lldp", Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {
@@ -392,7 +380,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP resource")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -451,36 +439,31 @@ var _ = Describe("LLDP Controller", func() {
 	})
 
 	Context("When reconciling with ProviderConfigRef", func() {
-		const (
-			deviceName   = "testlldp-provider-device"
-			resourceName = "testlldp-provider-lldp"
-		)
-
-		resourceKey := client.ObjectKey{Name: resourceName, Namespace: metav1.NamespaceDefault}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
-
 		var (
-			device *v1alpha1.Device
-			lldp   *v1alpha1.LLDP
+			deviceName  string
+			resourceKey client.ObjectKey
+			deviceKey   client.ObjectKey
+			device      *v1alpha1.Device
+			lldp        *v1alpha1.LLDP
 		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device = &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, deviceKey, device); errors.IsNotFound(err) {
-				device = &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceName,
-						Namespace: metav1.NamespaceDefault,
+			device = &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "testlldp-provider-device-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, device)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			deviceName = device.Name
+			deviceKey = client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
+			resourceKey = client.ObjectKey{Name: deviceName + "-lldp", Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {
@@ -513,7 +496,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with a non-existent ProviderConfigRef")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -544,7 +527,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with invalid API version in ProviderConfigRef")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -575,7 +558,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with unsupported Kind in ProviderConfigRef")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -604,36 +587,31 @@ var _ = Describe("LLDP Controller", func() {
 	})
 
 	Context("When reconciling with InterfaceRefs", func() {
-		const (
-			deviceName   = "testlldp-intfref-device"
-			resourceName = "testlldp-intfref-lldp"
-		)
-
-		resourceKey := client.ObjectKey{Name: resourceName, Namespace: metav1.NamespaceDefault}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
-
 		var (
-			device *v1alpha1.Device
-			lldp   *v1alpha1.LLDP
+			deviceName  string
+			resourceKey client.ObjectKey
+			deviceKey   client.ObjectKey
+			device      *v1alpha1.Device
+			lldp        *v1alpha1.LLDP
 		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device = &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, deviceKey, device); errors.IsNotFound(err) {
-				device = &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceName,
-						Namespace: metav1.NamespaceDefault,
+			device = &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "testlldp-intfref-device-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.3:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.3:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, device)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			deviceName = device.Name
+			deviceKey = client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
+			resourceKey = client.ObjectKey{Name: deviceName + "-lldp", Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {
@@ -666,7 +644,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with a non-existent InterfaceRef")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -734,7 +712,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP referencing an Interface from a different device")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -803,7 +781,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with multiple InterfaceRefs")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -844,36 +822,31 @@ var _ = Describe("LLDP Controller", func() {
 	})
 
 	Context("When updating LLDP spec", func() {
-		const (
-			deviceName   = "testlldp-update-device"
-			resourceName = "testlldp-update-lldp"
-		)
-
-		resourceKey := client.ObjectKey{Name: resourceName, Namespace: metav1.NamespaceDefault}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
-
 		var (
-			device *v1alpha1.Device
-			lldp   *v1alpha1.LLDP
+			deviceName  string
+			resourceKey client.ObjectKey
+			deviceKey   client.ObjectKey
+			device      *v1alpha1.Device
+			lldp        *v1alpha1.LLDP
 		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device = &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, deviceKey, device); errors.IsNotFound(err) {
-				device = &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deviceName,
-						Namespace: metav1.NamespaceDefault,
+			device = &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "testlldp-update-device-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.4:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.4:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, device)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			deviceName = device.Name
+			deviceKey = client.ObjectKey{Name: deviceName, Namespace: metav1.NamespaceDefault}
+			resourceKey = client.ObjectKey{Name: deviceName + "-lldp", Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {
@@ -906,7 +879,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with AdminState Up")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -968,7 +941,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP without InterfaceRefs")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{
@@ -1036,7 +1009,7 @@ var _ = Describe("LLDP Controller", func() {
 			By("Creating LLDP with InterfaceRefs")
 			lldp = &v1alpha1.LLDP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      resourceName,
+					Name:      deviceName + "-lldp",
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.LLDPSpec{

--- a/internal/controller/core/managementaccess_controller_test.go
+++ b/internal/controller/core/managementaccess_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,46 +15,44 @@ import (
 
 var _ = Describe("ManagementAccess Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-managementaccess"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-managementaccess-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind ManagementAccess")
-			dns := &v1alpha1.ManagementAccess{}
-			if err := k8sClient.Get(ctx, key, dns); errors.IsNotFound(err) {
-				resource := &v1alpha1.ManagementAccess{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			resource := &v1alpha1.ManagementAccess{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.ManagementAccessSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					GRPC: v1alpha1.GRPC{
+						Enabled: true,
+						Port:    9339,
+						VrfName: "default",
 					},
-					Spec: v1alpha1.ManagementAccessSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						GRPC: v1alpha1.GRPC{
-							Enabled: true,
-							Port:    9339,
-							VrfName: "default",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/ntp_controller_test.go
+++ b/internal/controller/core/ntp_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,49 +15,47 @@ import (
 
 var _ = Describe("NTP Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-ntp"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-ntp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind NTP")
-			ntp := &v1alpha1.NTP{}
-			if err := k8sClient.Get(ctx, key, ntp); errors.IsNotFound(err) {
-				resource := &v1alpha1.NTP{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.NTPSpec{
-						DeviceRef:           v1alpha1.LocalObjectReference{Name: name},
-						SourceInterfaceName: "mgmt0",
-						Servers: []v1alpha1.NTPServer{
-							{
-								Address: "de.pool.ntp.org",
-								Prefer:  true,
-								VrfName: "management",
-							},
+			resource := &v1alpha1.NTP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.NTPSpec{
+					DeviceRef:           v1alpha1.LocalObjectReference{Name: name},
+					SourceInterfaceName: "mgmt0",
+					Servers: []v1alpha1.NTPServer{
+						{
+							Address: "de.pool.ntp.org",
+							Prefer:  true,
+							VrfName: "management",
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/nve_controller_test.go
+++ b/internal/controller/core/nve_controller_test.go
@@ -19,135 +19,96 @@ import (
 
 const testEndpointAddr = "192.168.10.2:9339"
 
-// Helpers
-func ensureDevice(deviceKey client.ObjectKey, spec v1alpha1.DeviceSpec) {
-	d := &v1alpha1.Device{}
-	if err := k8sClient.Get(ctx, deviceKey, d); errors.IsNotFound(err) {
-		d = &v1alpha1.Device{
-			ObjectMeta: metav1.ObjectMeta{Name: deviceKey.Name, Namespace: deviceKey.Namespace},
-			Spec:       spec,
-		}
-		Expect(k8sClient.Create(ctx, d)).To(Succeed())
-	} else {
-		Expect(err).NotTo(HaveOccurred())
-	}
-}
-
-func ensureInterface(ns, deviceName, ifName string, ifType v1alpha1.InterfaceType) *v1alpha1.Interface {
-	key := client.ObjectKey{Name: ifName, Namespace: ns}
-	ifObj := &v1alpha1.Interface{}
-	if err := k8sClient.Get(ctx, key, ifObj); errors.IsNotFound(err) {
-		ifObj = &v1alpha1.Interface{
-			ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: ns},
-			Spec: v1alpha1.InterfaceSpec{
-				DeviceRef:  v1alpha1.LocalObjectReference{Name: deviceName},
-				Name:       ifName,
-				Type:       ifType,
-				AdminState: v1alpha1.AdminStateUp,
-			},
-		}
-		Expect(k8sClient.Create(ctx, ifObj)).To(Succeed())
-	} else {
-		Expect(err).NotTo(HaveOccurred())
-	}
-	return ifObj
-}
-
-func ensureInterfaces(deviceName string, names []string, ifType v1alpha1.InterfaceType) {
-	for _, name := range names {
-		ensureInterface(metav1.NamespaceDefault, deviceName, name, ifType)
-	}
-}
-
-func ensureNVE(nveKey client.ObjectKey, spec v1alpha1.NetworkVirtualizationEdgeSpec) *v1alpha1.NetworkVirtualizationEdge {
-	n := &v1alpha1.NetworkVirtualizationEdge{}
-	if err := k8sClient.Get(ctx, nveKey, n); errors.IsNotFound(err) {
-		n = &v1alpha1.NetworkVirtualizationEdge{
-			ObjectMeta: metav1.ObjectMeta{Name: nveKey.Name, Namespace: nveKey.Namespace},
-			Spec:       spec,
-		}
-		Expect(k8sClient.Create(ctx, n)).To(Succeed())
-	} else {
-		Expect(err).NotTo(HaveOccurred())
-	}
-	return n
-}
-
-func cleanupNVEResources(nveKeys, interfaceKeys, deviceKeys []client.ObjectKey) {
-	By("Cleaning up created resources")
-	for _, nveKey := range nveKeys {
-		nve := &v1alpha1.NetworkVirtualizationEdge{}
-		Expect(k8sClient.Get(ctx, nveKey, nve)).NotTo(HaveOccurred())
-		Expect(k8sClient.Delete(ctx, nve)).To(Succeed())
-		Eventually(func() bool {
-			return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
-		}).Should(BeTrue(), "NVE should be fully deleted")
-	}
-
-	for _, ifKey := range interfaceKeys {
-		ifObj := &v1alpha1.Interface{}
-		Expect(k8sClient.Get(ctx, ifKey, ifObj)).NotTo(HaveOccurred())
-		Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
-		Eventually(func() bool {
-			return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
-		}).Should(BeTrue(), "Interface should be fully deleted")
-	}
-
-	for _, deviceKey := range deviceKeys {
-		device := &v1alpha1.Device{}
-		Expect(k8sClient.Get(ctx, deviceKey, device)).NotTo(HaveOccurred())
-		Expect(k8sClient.Delete(ctx, device)).To(Succeed())
-		Eventually(func() bool {
-			return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
-		}).Should(BeTrue(), "Device should be fully deleted")
-	}
-	By("Ensuring the resource is deleted from the provider")
-	Eventually(func(g Gomega) {
-		g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
-	}).Should(Succeed())
-}
-
 var _ = Describe("NVE Controller", func() {
 	Context("When reconciling a resource", func() {
-		const (
-			deviceName = "test-nve-device"
-			nveName    = "test-nve-nve"
-			nsName     = metav1.NamespaceDefault
+		var (
+			name          string
+			nveKey        client.ObjectKey
+			deviceKey     client.ObjectKey
+			interfaceKeys []client.ObjectKey
+			nve           *v1alpha1.NetworkVirtualizationEdge
 		)
-		var nve *v1alpha1.NetworkVirtualizationEdge
-		interfaceNames := []string{"lo0", "lo1"}
-
-		nveKey := client.ObjectKey{Name: nveName, Namespace: nsName}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: nsName}
-		interfaceKeys := make([]client.ObjectKey, len(interfaceNames))
-		for i, ifName := range interfaceNames {
-			interfaceKeys[i] = client.ObjectKey{Name: ifName, Namespace: nsName}
-		}
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
-			By("Ensuring loopback interfaces exist")
-			ensureInterfaces(deviceName, interfaceNames, v1alpha1.InterfaceTypeLoopback)
+			By("Creating loopback interfaces")
+			for _, ifName := range []string{name + "-lo0", name + "-lo1"} {
+				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+					ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: metav1.NamespaceDefault},
+					Spec: v1alpha1.InterfaceSpec{
+						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+						Name:       ifName,
+						Type:       v1alpha1.InterfaceTypeLoopback,
+						AdminState: v1alpha1.AdminStateUp,
+					},
+				})).To(Succeed())
+			}
+			interfaceKeys = []client.ObjectKey{
+				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
+			}
 
 			By("Creating the custom resource for the Kind NVE")
 			l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
-			nve = ensureNVE(nveKey, v1alpha1.NetworkVirtualizationEdgeSpec{
-				DeviceRef:                 v1alpha1.LocalObjectReference{Name: deviceName},
-				SuppressARP:               true,
-				HostReachability:          "BGP",
-				SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-				AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: interfaceNames[1]},
-				MulticastGroups:           &v1alpha1.MulticastGroups{L2: &l2Prefix},
-				AdminState:                v1alpha1.AdminStateUp,
-			})
+			nve = &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:                 v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:               true,
+					HostReachability:          "BGP",
+					SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: name + "-lo0"},
+					AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: name + "-lo1"},
+					MulticastGroups:           &v1alpha1.MulticastGroups{L2: &l2Prefix},
+					AdminState:                v1alpha1.AdminStateUp,
+				},
+			}
+			Expect(k8sClient.Create(ctx, nve)).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up interfaces")
+			for _, ifKey := range interfaceKeys {
+				ifObj := &v1alpha1.Interface{}
+				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -160,7 +121,7 @@ var _ = Describe("NVE Controller", func() {
 			By("Adding the device label to the resource")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, nveKey, nve)).To(Succeed())
-				g.Expect(nve.Labels).To(HaveKeyWithValue(v1alpha1.DeviceLabel, deviceName))
+				g.Expect(nve.Labels).To(HaveKeyWithValue(v1alpha1.DeviceLabel, name))
 			}).Should(Succeed())
 
 			By("Adding the device as a owner reference")
@@ -168,7 +129,7 @@ var _ = Describe("NVE Controller", func() {
 				g.Expect(k8sClient.Get(ctx, nveKey, nve)).To(Succeed())
 				g.Expect(nve.OwnerReferences).To(HaveLen(1))
 				g.Expect(nve.OwnerReferences[0].Kind).To(Equal("Device"))
-				g.Expect(nve.OwnerReferences[0].Name).To(Equal(deviceName))
+				g.Expect(nve.OwnerReferences[0].Name).To(Equal(name))
 			}).Should(Succeed())
 
 			By("Updating the resource status")
@@ -186,26 +147,26 @@ var _ = Describe("NVE Controller", func() {
 			By("Ensuring the NVE is created in the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.NVE).ToNot(BeNil(), "Provider NVE should not be nil")
-				g.Expect(testProvider.NVE.Spec.AdminState).To(BeEquivalentTo(v1alpha1.AdminStateUp), "Provider NVE Enabled should be true")
-				g.Expect(testProvider.NVE.Spec.SuppressARP).To(BeTrue(), "Provider NVE SuppressARP should be true")
-				g.Expect(testProvider.NVE.Spec.HostReachability).To(BeEquivalentTo("BGP"), "Provider NVE hostreachability should be BGP")
-				g.Expect(testProvider.NVE.Spec.SourceInterfaceRef.Name).To(Equal("lo0"), "Provider NVE primary interface should be lo0")
-				g.Expect(testProvider.NVE.Spec.MulticastGroups).ToNot(BeNil(), "Provider NVE multicast group should not be nil")
-				g.Expect(testProvider.NVE.Spec.MulticastGroups.L2).To(HaveValue(Equal(v1alpha1.MustParsePrefix("234.0.0.0/8"))), "Provider NVE multicast group prefix should be set")
+				g.Expect(testProvider.NVE.Spec.AdminState).To(BeEquivalentTo(v1alpha1.AdminStateUp))
+				g.Expect(testProvider.NVE.Spec.SuppressARP).To(BeTrue())
+				g.Expect(testProvider.NVE.Spec.HostReachability).To(BeEquivalentTo("BGP"))
+				g.Expect(testProvider.NVE.Spec.SourceInterfaceRef.Name).To(Equal(name + "-lo0"))
+				g.Expect(testProvider.NVE.Spec.MulticastGroups).ToNot(BeNil())
+				g.Expect(testProvider.NVE.Spec.MulticastGroups.L2).To(HaveValue(Equal(v1alpha1.MustParsePrefix("234.0.0.0/8"))))
 			}).Should(Succeed())
 
 			By("Verifying referenced interfaces exist and are loopbacks")
 			Eventually(func(g Gomega) {
 				primary := &v1alpha1.Interface{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nve.Spec.SourceInterfaceRef.Name, Namespace: nsName}, primary)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nve.Spec.SourceInterfaceRef.Name, Namespace: metav1.NamespaceDefault}, primary)).To(Succeed())
 				g.Expect(primary.Spec.Type).To(Equal(v1alpha1.InterfaceTypeLoopback))
-				g.Expect(primary.Spec.DeviceRef.Name).To(Equal(deviceName))
+				g.Expect(primary.Spec.DeviceRef.Name).To(Equal(name))
 
 				anycast := &v1alpha1.Interface{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nve.Spec.AnycastSourceInterfaceRef.Name, Namespace: nsName}, anycast)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nve.Spec.AnycastSourceInterfaceRef.Name, Namespace: metav1.NamespaceDefault}, anycast)).To(Succeed())
 				g.Expect(anycast.Spec.Type).To(Equal(v1alpha1.InterfaceTypeLoopback))
-				g.Expect(anycast.Spec.DeviceRef.Name).To(Equal(deviceName))
-				g.Expect(anycast.Name).NotTo(Equal(primary.Name)) // ensure different interfaces
+				g.Expect(anycast.Spec.DeviceRef.Name).To(Equal(name))
+				g.Expect(anycast.Name).NotTo(Equal(primary.Name))
 			}).Should(Succeed())
 
 			By("Verifying the controller sets valid reference status")
@@ -224,116 +185,181 @@ var _ = Describe("NVE Controller", func() {
 	})
 
 	Context("When updating referenced resources", func() {
-		const (
-			deviceName = "test-nvewithrefupdates-device"
-			nveName    = "test-nvewithrefupdates-nve"
-			nsName     = metav1.NamespaceDefault
+		var (
+			name          string
+			nveKey        client.ObjectKey
+			deviceKey     client.ObjectKey
+			interfaceKeys []client.ObjectKey
+			nve           *v1alpha1.NetworkVirtualizationEdge
 		)
-		var nve *v1alpha1.NetworkVirtualizationEdge
-
-		interfaceNames := []string{"lo10", "lo11", "lo12"}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nveKey := client.ObjectKey{Name: nveName, Namespace: nsName}
-		interfaceKeys := make([]client.ObjectKey, len(interfaceNames))
-		for i, ifName := range interfaceNames {
-			interfaceKeys[i] = client.ObjectKey{Name: ifName, Namespace: nsName}
-		}
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-refupdates-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
-			By("Ensuring loopback interfaces exist")
-			ensureInterfaces(deviceName, interfaceNames, v1alpha1.InterfaceTypeLoopback)
-
-			By("Creating the custom resource for the Kind NVE")
-			nve = &v1alpha1.NetworkVirtualizationEdge{}
-			if err := k8sClient.Get(ctx, nveKey, nve); errors.IsNotFound(err) {
-				l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
-				nve = &v1alpha1.NetworkVirtualizationEdge{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      nveName,
-						Namespace: nsName,
-					},
-					Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
-						DeviceRef:          v1alpha1.LocalObjectReference{Name: deviceName},
-						SuppressARP:        true,
-						HostReachability:   "BGP",
-						SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-						MulticastGroups: &v1alpha1.MulticastGroups{
-							L2: &l2Prefix,
-						},
+			By("Creating loopback interfaces")
+			for _, ifName := range []string{name + "-lo0", name + "-lo1", name + "-lo2"} {
+				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+					ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: metav1.NamespaceDefault},
+					Spec: v1alpha1.InterfaceSpec{
+						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+						Name:       ifName,
+						Type:       v1alpha1.InterfaceTypeLoopback,
 						AdminState: v1alpha1.AdminStateUp,
 					},
-				}
-				Expect(k8sClient.Create(ctx, nve)).To(Succeed())
+				})).To(Succeed())
 			}
+			interfaceKeys = []client.ObjectKey{
+				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo2", Namespace: metav1.NamespaceDefault},
+			}
+
+			By("Creating the custom resource for the Kind NVE")
+			l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
+			nve = &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:        true,
+					HostReachability:   "BGP",
+					SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name + "-lo0"},
+					MulticastGroups:    &v1alpha1.MulticastGroups{L2: &l2Prefix},
+					AdminState:         v1alpha1.AdminStateUp,
+				},
+			}
+			Expect(k8sClient.Create(ctx, nve)).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up interfaces")
+			for _, ifKey := range interfaceKeys {
+				ifObj := &v1alpha1.Interface{}
+				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should reconcile when SourceInterfaceRef is changed", func() {
-			By("Patching NVE: SourceInterfaceRef")
 			patch := client.MergeFrom(nve.DeepCopy())
-			nve.Spec.SourceInterfaceRef = v1alpha1.LocalObjectReference{Name: interfaceNames[1]}
+			nve.Spec.SourceInterfaceRef = v1alpha1.LocalObjectReference{Name: name + "-lo1"}
 			Expect(k8sClient.Patch(ctx, nve, patch)).To(Succeed())
 
 			By("Verifying reconciliation modifies provider and status")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.NVE).ToNot(BeNil())
-				g.Expect(testProvider.NVE.Spec.SourceInterfaceRef.Name).To(Equal(interfaceNames[1]))
-				g.Expect(testProvider.NVE.Status.SourceInterfaceName).To(Equal(interfaceNames[1]))
+				g.Expect(testProvider.NVE.Spec.SourceInterfaceRef.Name).To(Equal(name + "-lo1"))
+				g.Expect(testProvider.NVE.Status.SourceInterfaceName).To(Equal(name + "-lo1"))
 			}).Should(Succeed())
 		})
 
 		It("Should reconcile when AnycastSourceInterfaceRef is added", func() {
-			By("Patching NVE: AnycastSourceInterfaceRef")
 			patch := client.MergeFrom(nve.DeepCopy())
-			nve.Spec.AnycastSourceInterfaceRef = &v1alpha1.LocalObjectReference{Name: interfaceNames[2]}
+			nve.Spec.AnycastSourceInterfaceRef = &v1alpha1.LocalObjectReference{Name: name + "-lo2"}
 			Expect(k8sClient.Patch(ctx, nve, patch)).To(Succeed())
 
 			By("Verifying reconciliation modifies provider and status")
 			Eventually(func(g Gomega) {
 				if testProvider.NVE != nil {
 					g.Expect(testProvider.NVE).ToNot(BeNil())
-					g.Expect(testProvider.NVE.Spec.AnycastSourceInterfaceRef.Name).To(Equal(interfaceNames[2]))
-					g.Expect(testProvider.NVE.Status.AnycastSourceInterfaceName).To(Equal(interfaceNames[2]))
+					g.Expect(testProvider.NVE.Spec.AnycastSourceInterfaceRef.Name).To(Equal(name + "-lo2"))
+					g.Expect(testProvider.NVE.Status.AnycastSourceInterfaceName).To(Equal(name + "-lo2"))
 				}
 			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 		})
 	})
 
 	Context("When source interface is missing", func() {
-		const (
-			deviceName = "test-nvemissingif-device"
-			nveName    = "test-nvemissingif-nve"
-			nsName     = metav1.NamespaceDefault
+		var (
+			name      string
+			nveKey    client.ObjectKey
+			deviceKey client.ObjectKey
 		)
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nveKey := client.ObjectKey{Name: nveName, Namespace: nsName}
 
 		BeforeEach(func() {
 			By("Creating device only (no interfaces)")
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-missingif-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating an NVE object with a reference to a non-existent interface")
-			_ = ensureNVE(nveKey, v1alpha1.NetworkVirtualizationEdgeSpec{
-				DeviceRef:          v1alpha1.LocalObjectReference{Name: deviceName},
-				SuppressARP:        true,
-				HostReachability:   "BGP",
-				SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: "lo-missing"},
-				AdminState:         v1alpha1.AdminStateUp,
-			})
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:        true,
+					HostReachability:   "BGP",
+					SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name + "-lo-missing"},
+					AdminState:         v1alpha1.AdminStateUp,
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, nil, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should set Configured=False with WaitingForDependenciesReason", func() {
@@ -354,34 +380,79 @@ var _ = Describe("NVE Controller", func() {
 	})
 
 	Context("When AnycastSourceInterfaceRef is omitted", func() {
-		const (
-			deviceName = "test-nve-anycast-omit-device"
-			nveName    = "test-nve-anycast-omit"
-			nsName     = metav1.NamespaceDefault
+		var (
+			name      string
+			nveKey    client.ObjectKey
+			deviceKey client.ObjectKey
 		)
-		interfaceNames := []string{"lo30"}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nveKey := client.ObjectKey{Name: nveName, Namespace: nsName}
-		interfaceKeys := []client.ObjectKey{{Name: interfaceNames[0], Namespace: nsName}}
 
 		BeforeEach(func() {
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
-			ensureInterfaces(deviceName, interfaceNames, v1alpha1.InterfaceTypeLoopback)
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-anycast-omit-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
-			_ = ensureNVE(nveKey, v1alpha1.NetworkVirtualizationEdgeSpec{
-				DeviceRef:          v1alpha1.LocalObjectReference{Name: deviceName},
-				SuppressARP:        true,
-				HostReachability:   "BGP",
-				SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-				AdminState:         v1alpha1.AdminStateUp,
-				// AnycastSourceInterfaceRef: nil,
-			})
+			Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.InterfaceSpec{
+					DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+					Name:       name + "-lo0",
+					Type:       v1alpha1.InterfaceTypeLoopback,
+					AdminState: v1alpha1.AdminStateUp,
+				},
+			})).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:        true,
+					HostReachability:   "BGP",
+					SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name + "-lo0"},
+					AdminState:         v1alpha1.AdminStateUp,
+					// AnycastSourceInterfaceRef: nil,
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up interface")
+			ifObj := &v1alpha1.Interface{}
+			ifKey := client.ObjectKey{Name: name + "-lo0", Namespace: metav1.NamespaceDefault}
+			Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should reconcile with nil anycast and empty status AnycastSourceInterfaceName", func() {
@@ -402,45 +473,99 @@ var _ = Describe("NVE Controller", func() {
 	})
 
 	Context("When creating more than one NVE per device", func() {
-		const (
-			deviceName = "test-nve-uniqueness-device"
-			nve1Name   = "test-nve-uniqueness-1"
-			nve2Name   = "test-nve-uniqueness-2"
-			nsName     = metav1.NamespaceDefault
+		var (
+			name      string
+			nve1Key   client.ObjectKey
+			nve2Key   client.ObjectKey
+			deviceKey client.ObjectKey
 		)
-		interfaceNames := []string{"lo40", "lo41"}
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nve1Key := client.ObjectKey{Name: nve1Name, Namespace: nsName}
-		nve2Key := client.ObjectKey{Name: nve2Name, Namespace: nsName}
-		interfaceKeys := []client.ObjectKey{
-			{Name: interfaceNames[0], Namespace: nsName},
-			{Name: interfaceNames[1], Namespace: nsName},
-		}
 
 		BeforeEach(func() {
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
-			ensureInterfaces(deviceName, interfaceNames, v1alpha1.InterfaceTypeLoopback)
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-uniqueness-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
-			_ = ensureNVE(nve1Key, v1alpha1.NetworkVirtualizationEdgeSpec{
-				DeviceRef:          v1alpha1.LocalObjectReference{Name: deviceName},
-				SuppressARP:        true,
-				HostReachability:   "BGP",
-				SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-				AdminState:         v1alpha1.AdminStateUp,
-			})
-			_ = ensureNVE(nve2Key, v1alpha1.NetworkVirtualizationEdgeSpec{
-				DeviceRef:          v1alpha1.LocalObjectReference{Name: deviceName},
-				SuppressARP:        true,
-				HostReachability:   "BGP",
-				SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: interfaceNames[1]},
-				AdminState:         v1alpha1.AdminStateUp,
-			})
+			for _, ifName := range []string{name + "-lo0", name + "-lo1"} {
+				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+					ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: metav1.NamespaceDefault},
+					Spec: v1alpha1.InterfaceSpec{
+						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+						Name:       ifName,
+						Type:       v1alpha1.InterfaceTypeLoopback,
+						AdminState: v1alpha1.AdminStateUp,
+					},
+				})).To(Succeed())
+			}
+
+			nve1Key = client.ObjectKey{Name: name + "-nve1", Namespace: metav1.NamespaceDefault}
+			nve2Key = client.ObjectKey{Name: name + "-nve2", Namespace: metav1.NamespaceDefault}
+
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-nve1", Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:        true,
+					HostReachability:   "BGP",
+					SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name + "-lo0"},
+					AdminState:         v1alpha1.AdminStateUp,
+				},
+			})).To(Succeed())
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name + "-nve2", Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:        true,
+					HostReachability:   "BGP",
+					SourceInterfaceRef: v1alpha1.LocalObjectReference{Name: name + "-lo1"},
+					AdminState:         v1alpha1.AdminStateUp,
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nve1Key, nve2Key}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVEs")
+			for _, nveKey := range []client.ObjectKey{nve1Key, nve2Key} {
+				nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+				Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up interfaces")
+			for _, ifKey := range []client.ObjectKey{
+				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
+			} {
+				ifObj := &v1alpha1.Interface{}
+				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should set Configured=False with NVEAlreadyExistsReason on the second NVE", func() {
@@ -456,58 +581,90 @@ var _ = Describe("NVE Controller", func() {
 	})
 
 	Context("When using erroneous interface references (non loopback type)", func() {
-		const (
-			deviceName = "test-nvemisconfigurediftype-device"
-			nveName    = "test-nvemisconfigurediftype-nve"
-			nsName     = metav1.NamespaceDefault
+		var (
+			name      string
+			nveKey    client.ObjectKey
+			deviceKey client.ObjectKey
 		)
-		var nve *v1alpha1.NetworkVirtualizationEdge
-
-		interfaceNames := []string{"eth1", "eth2"}
-
-		deviceKey := client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nveKey := client.ObjectKey{Name: nveName, Namespace: nsName}
-		interfaceKeys := make([]client.ObjectKey, len(interfaceNames))
-		for i, ifName := range interfaceNames {
-			interfaceKeys[i] = client.ObjectKey{Name: ifName, Namespace: nsName}
-		}
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-wrongiftype-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
-			By("Ensuring loopback interfaces with wrong type exist")
-			ensureInterfaces(deviceName, interfaceNames, v1alpha1.InterfaceTypePhysical)
-
-			By("Creating the custom resource for the Kind NetworkVirtualizationEdge")
-			nve = &v1alpha1.NetworkVirtualizationEdge{}
-			if err := k8sClient.Get(ctx, nveKey, nve); errors.IsNotFound(err) {
-				l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
-				nve = &v1alpha1.NetworkVirtualizationEdge{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      nveName,
-						Namespace: nsName,
-					},
-					Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
-						DeviceRef:                 v1alpha1.LocalObjectReference{Name: deviceName},
-						SuppressARP:               true,
-						HostReachability:          "BGP",
-						SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-						AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: interfaceNames[1]},
-						MulticastGroups: &v1alpha1.MulticastGroups{
-							L2: &l2Prefix,
-						},
+			By("Creating interfaces with wrong type")
+			for _, ifName := range []string{name + "-eth0", name + "-eth1"} {
+				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+					ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: metav1.NamespaceDefault},
+					Spec: v1alpha1.InterfaceSpec{
+						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+						Name:       ifName,
+						Type:       v1alpha1.InterfaceTypePhysical,
 						AdminState: v1alpha1.AdminStateUp,
 					},
-				}
-				Expect(k8sClient.Create(ctx, nve)).To(Succeed())
+				})).To(Succeed())
 			}
+
+			By("Creating the custom resource for the Kind NetworkVirtualizationEdge")
+			l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:                 v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:               true,
+					HostReachability:          "BGP",
+					SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: name + "-eth0"},
+					AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: name + "-eth1"},
+					MulticastGroups:           &v1alpha1.MulticastGroups{L2: &l2Prefix},
+					AdminState:                v1alpha1.AdminStateUp,
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up interfaces")
+			for _, ifKey := range []client.ObjectKey{
+				{Name: name + "-eth0", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-eth1", Namespace: metav1.NamespaceDefault},
+			} {
+				ifObj := &v1alpha1.Interface{}
+				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should set Configured=False with InvalidInterfaceTypeReason", func() {
@@ -523,64 +680,110 @@ var _ = Describe("NVE Controller", func() {
 	})
 
 	Context("When using erroneous interface references (cross-device reference)", func() {
-		const (
-			deviceName  = "test-nvemisconfiguredcrossdevice-device"
-			device2Name = "test-nvemisconfiguredcrossdevice-device2" // device for interface reference
-			nveName     = "test-nvemisconfiguredcrossdevice-nve"
-			nsName      = metav1.NamespaceDefault
-		)
-
 		var (
-			nve               *v1alpha1.NetworkVirtualizationEdge
-			deviceKey, nveKey client.ObjectKey
-			interfaceKeys     []client.ObjectKey
+			name      string
+			nveKey    client.ObjectKey
+			deviceKey client.ObjectKey
 		)
-
-		interfaceNames := []string{"lo2", "lo3"}
-		deviceKey = client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nveKey = client.ObjectKey{Name: nveName, Namespace: nsName}
-		interfaceKeys = make([]client.ObjectKey, len(interfaceNames))
-		for i, ifName := range interfaceNames {
-			interfaceKeys[i] = client.ObjectKey{Name: ifName, Namespace: nsName}
-		}
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-crossdevice-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+
+			By("Creating a second device whose interfaces will be referenced cross-device")
+			device2 := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-nve-crossdevice-b-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device2)).To(Succeed())
+			DeferCleanup(func() {
+				d := &v1alpha1.Device{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: device2.Name, Namespace: metav1.NamespaceDefault}, d)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: device2.Name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
+				}).Should(BeTrue())
 			})
 
-			By("Ensuring loopback interfaces with created on a different device")
-			By("Ensuring loopback interfaces exist")
-			ensureInterfaces(device2Name, interfaceNames, v1alpha1.InterfaceTypeLoopback)
-
-			By("Creating the custom resource for the Kind NetworkVirtualizationEdge")
-			nve = &v1alpha1.NetworkVirtualizationEdge{}
-			if err := k8sClient.Get(ctx, nveKey, nve); errors.IsNotFound(err) {
-				l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
-				nve = &v1alpha1.NetworkVirtualizationEdge{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      nveName,
-						Namespace: nsName,
-					},
-					Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
-						DeviceRef:                 v1alpha1.LocalObjectReference{Name: deviceName},
-						SuppressARP:               true,
-						HostReachability:          "BGP",
-						SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-						AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: interfaceNames[1]},
-						MulticastGroups: &v1alpha1.MulticastGroups{
-							L2: &l2Prefix,
-						},
+			By("Creating loopback interfaces on the second device")
+			for _, ifName := range []string{name + "-lo0", name + "-lo1"} {
+				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+					ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: metav1.NamespaceDefault},
+					Spec: v1alpha1.InterfaceSpec{
+						DeviceRef:  v1alpha1.LocalObjectReference{Name: device2.Name},
+						Name:       ifName,
+						Type:       v1alpha1.InterfaceTypeLoopback,
 						AdminState: v1alpha1.AdminStateUp,
 					},
-				}
-				Expect(k8sClient.Create(ctx, nve)).To(Succeed())
+				})).To(Succeed())
 			}
+
+			By("Creating the custom resource for the Kind NetworkVirtualizationEdge")
+			l2Prefix := v1alpha1.MustParsePrefix("234.0.0.0/8")
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:                 v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:               true,
+					HostReachability:          "BGP",
+					SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: name + "-lo0"},
+					AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: name + "-lo1"},
+					MulticastGroups:           &v1alpha1.MulticastGroups{L2: &l2Prefix},
+					AdminState:                v1alpha1.AdminStateUp,
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up interfaces")
+			for _, ifKey := range []client.ObjectKey{
+				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
+			} {
+				ifObj := &v1alpha1.Interface{}
+				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should set Configured=False with CrossDeviceReferenceReason", func() {
@@ -596,58 +799,94 @@ var _ = Describe("NVE Controller", func() {
 	})
 
 	Context("When using a non registered dependency for providerConfigRef", func() {
-		const (
-			deviceName = "test-nvemisconfigured-providerconfigref-device"
-			nveName    = "test-nvemisconfigured-providerconfigref-nve"
-			nsName     = metav1.NamespaceDefault
-		)
 		var (
-			nve               *v1alpha1.NetworkVirtualizationEdge
-			deviceKey, nveKey client.ObjectKey
+			name      string
+			nveKey    client.ObjectKey
+			deviceKey client.ObjectKey
 		)
-
-		interfaceNames := []string{"lo6", "lo7", "lo8"}
-		deviceKey = client.ObjectKey{Name: deviceName, Namespace: nsName}
-		nveKey = client.ObjectKey{Name: nveName, Namespace: nsName}
-		interfaceKeys := make([]client.ObjectKey, len(interfaceNames))
-		for i, ifName := range interfaceNames {
-			interfaceKeys[i] = client.ObjectKey{Name: ifName, Namespace: nsName}
-		}
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			ensureDevice(deviceKey, v1alpha1.DeviceSpec{
-				Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
-			})
-
-			By("Ensuring loopback interfaces exist")
-			ensureInterfaces(deviceName, interfaceNames, v1alpha1.InterfaceTypeLoopback)
-
-			By("Ensuring an NVE with an invalid providerConfigRef")
-			nve = &v1alpha1.NetworkVirtualizationEdge{
+			device := &v1alpha1.Device{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      nveName,
-					Namespace: nsName,
+					GenerateName: "test-nve-badproviderref-",
+					Namespace:    metav1.NamespaceDefault,
 				},
-				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
-					DeviceRef:                 v1alpha1.LocalObjectReference{Name: deviceName},
-					SuppressARP:               true,
-					HostReachability:          "BGP",
-					SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: interfaceNames[0]},
-					AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: interfaceNames[1]},
-					AdminState:                v1alpha1.AdminStateUp,
-					ProviderConfigRef: &v1alpha1.TypedLocalObjectReference{
-						Name:       interfaceNames[2],
-						Kind:       "Interface",
-						APIVersion: "networking.metal.ironcore.dev/v1alpha1",
-					}, // invalid provider config ref
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{Address: testEndpointAddr},
 				},
 			}
-			Expect(k8sClient.Create(ctx, nve)).To(Succeed())
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+
+			By("Creating loopback interfaces")
+			for _, ifName := range []string{name + "-lo0", name + "-lo1", name + "-lo2"} {
+				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
+					ObjectMeta: metav1.ObjectMeta{Name: ifName, Namespace: metav1.NamespaceDefault},
+					Spec: v1alpha1.InterfaceSpec{
+						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+						Name:       ifName,
+						Type:       v1alpha1.InterfaceTypeLoopback,
+						AdminState: v1alpha1.AdminStateUp,
+					},
+				})).To(Succeed())
+			}
+
+			By("Creating an NVE with an invalid providerConfigRef")
+			Expect(k8sClient.Create(ctx, &v1alpha1.NetworkVirtualizationEdge{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+				Spec: v1alpha1.NetworkVirtualizationEdgeSpec{
+					DeviceRef:                 v1alpha1.LocalObjectReference{Name: name},
+					SuppressARP:               true,
+					HostReachability:          "BGP",
+					SourceInterfaceRef:        v1alpha1.LocalObjectReference{Name: name + "-lo0"},
+					AnycastSourceInterfaceRef: &v1alpha1.LocalObjectReference{Name: name + "-lo1"},
+					AdminState:                v1alpha1.AdminStateUp,
+					ProviderConfigRef: &v1alpha1.TypedLocalObjectReference{
+						Name:       name + "-lo2",
+						Kind:       "Interface",
+						APIVersion: "networking.metal.ironcore.dev/v1alpha1",
+					},
+				},
+			})).To(Succeed())
 		})
 
 		AfterEach(func() {
-			cleanupNVEResources([]client.ObjectKey{nveKey}, interfaceKeys, []client.ObjectKey{deviceKey})
+			By("Cleaning up NVE")
+			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
+			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
+			}).Should(BeTrue())
+
+			By("Cleaning up interfaces")
+			for _, ifKey := range []client.ObjectKey{
+				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
+				{Name: name + "-lo2", Namespace: metav1.NamespaceDefault},
+			} {
+				ifObj := &v1alpha1.Interface{}
+				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
+				}).Should(BeTrue())
+			}
+
+			By("Cleaning up Device")
+			d := &v1alpha1.Device{}
+			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+			}).Should(BeTrue())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.NVE).To(BeNil(), "Provider NVE should be empty")
+			}).Should(Succeed())
 		})
 
 		It("Should set Configured=False and an `IncompatibleProviderConfigRef` reason", func() {

--- a/internal/controller/core/ospf_controller_test.go
+++ b/internal/controller/core/ospf_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,43 +16,41 @@ import (
 
 var _ = Describe("OSPF Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-ospf"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-ospf-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind OSPF")
-			ospf := &v1alpha1.OSPF{}
-			if err := k8sClient.Get(ctx, key, ospf); errors.IsNotFound(err) {
-				resource := &v1alpha1.OSPF{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.OSPFSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						Instance:  "UNDERLAY",
-						RouterID:  "10.0.0.10",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			resource := &v1alpha1.OSPF{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.OSPFSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					Instance:  "UNDERLAY",
+					RouterID:  "10.0.0.10",
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -122,26 +119,27 @@ var _ = Describe("OSPF Controller", func() {
 	})
 
 	Context("When an interfaceRef does not exist", func() {
-		const name = "test-ospf-missing-intf"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the Device resource")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-ospf-missing-intf-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.3:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.3:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/pim_controller_test.go
+++ b/internal/controller/core/pim_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,41 +16,39 @@ import (
 
 var _ = Describe("PIM Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-pim"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-pim-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind PIM")
-			pim := &v1alpha1.PIM{}
-			if err := k8sClient.Get(ctx, key, pim); errors.IsNotFound(err) {
-				resource := &v1alpha1.PIM{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.PIMSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			resource := &v1alpha1.PIM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.PIMSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -116,26 +113,27 @@ var _ = Describe("PIM Controller", func() {
 	})
 
 	Context("When an interfaceRef does not exist", func() {
-		const name = "test-pim-missing-intf"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-pim-missing-intf-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/prefixset_controller_test.go
+++ b/internal/controller/core/prefixset_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,53 +15,51 @@ import (
 
 var _ = Describe("PrefixSet Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-prefixset"
 		const set = "CCLOUD"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-prefixset-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind PrefixSet")
-			prefixset := &v1alpha1.PrefixSet{}
-			if err := k8sClient.Get(ctx, key, prefixset); errors.IsNotFound(err) {
-				resource := &v1alpha1.PrefixSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.PrefixSetSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						Name:      set,
-						Entries: []v1alpha1.PrefixEntry{
-							{
-								Sequence: 10,
-								Prefix:   v1alpha1.MustParsePrefix("192.168.1.0/24"),
-							},
-							{
-								Sequence: 20,
-								Prefix:   v1alpha1.MustParsePrefix("10.0.0.0/8"),
-							},
+			resource := &v1alpha1.PrefixSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.PrefixSetSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					Name:      set,
+					Entries: []v1alpha1.PrefixEntry{
+						{
+							Sequence: 10,
+							Prefix:   v1alpha1.MustParsePrefix("192.168.1.0/24"),
+						},
+						{
+							Sequence: 20,
+							Prefix:   v1alpha1.MustParsePrefix("10.0.0.0/8"),
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/routingpolicy_controller_test.go
+++ b/internal/controller/core/routingpolicy_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -18,26 +17,27 @@ import (
 
 var _ = Describe("RoutingPolicy Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-routingpolicy"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating a Device resource for testing")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-routingpolicy-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/snmp_controller_test.go
+++ b/internal/controller/core/snmp_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,60 +15,58 @@ import (
 
 var _ = Describe("SNMP Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-snmp"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-snmp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind SNMP")
-			snmp := &v1alpha1.SNMP{}
-			if err := k8sClient.Get(ctx, key, snmp); errors.IsNotFound(err) {
-				resource := &v1alpha1.SNMP{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.SNMPSpec{
-						DeviceRef:           v1alpha1.LocalObjectReference{Name: name},
-						Contact:             "123",
-						Location:            "123",
-						SourceInterfaceName: "mgmt0",
-						Communities: []v1alpha1.SNMPCommunity{
-							{
-								Name:    name,
-								Group:   "network-operator",
-								ACLName: name,
-							},
-						},
-						Hosts: []v1alpha1.SNMPHosts{
-							{
-								Address:   "10.0.0.1",
-								Type:      "Informs",
-								Version:   "v2c",
-								Community: name,
-								VrfName:   "management",
-							},
+			resource := &v1alpha1.SNMP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.SNMPSpec{
+					DeviceRef:           v1alpha1.LocalObjectReference{Name: name},
+					Contact:             "123",
+					Location:            "123",
+					SourceInterfaceName: "mgmt0",
+					Communities: []v1alpha1.SNMPCommunity{
+						{
+							Name:    "snmp-community",
+							Group:   "network-operator",
+							ACLName: "snmp-acl",
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					Hosts: []v1alpha1.SNMPHosts{
+						{
+							Address:   "10.0.0.1",
+							Type:      "Informs",
+							Version:   "v2c",
+							Community: "snmp-community",
+							VrfName:   "management",
+						},
+					},
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/syslog_controller_test.go
+++ b/internal/controller/core/syslog_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,55 +15,53 @@ import (
 
 var _ = Describe("Syslog Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-syslog"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-syslog-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind Syslog")
-			syslog := &v1alpha1.Syslog{}
-			if err := k8sClient.Get(ctx, key, syslog); errors.IsNotFound(err) {
-				resource := &v1alpha1.Syslog{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.SyslogSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						Servers: []v1alpha1.LogServer{
-							{
-								Address:  "192.168.55.55",
-								Severity: v1alpha1.SeverityInfo,
-								VrfName:  "management",
-								Port:     514,
-							},
-						},
-						Facilities: []v1alpha1.LogFacility{
-							{
-								Name:     "user",
-								Severity: v1alpha1.SeverityWarning,
-							},
+			resource := &v1alpha1.Syslog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.SyslogSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					Servers: []v1alpha1.LogServer{
+						{
+							Address:  "192.168.55.55",
+							Severity: v1alpha1.SeverityInfo,
+							VrfName:  "management",
+							Port:     514,
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					Facilities: []v1alpha1.LogFacility{
+						{
+							Name:     "user",
+							Severity: v1alpha1.SeverityWarning,
+						},
+					},
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/user_controller_test.go
+++ b/internal/controller/core/user_controller_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -17,67 +16,62 @@ import (
 
 var _ = Describe("User Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-user"
 		const username = "apiuser"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-user-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind Secret")
-			secret := &corev1.Secret{}
-			if err := k8sClient.Get(ctx, key, secret); errors.IsNotFound(err) {
-				resource := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					StringData: map[string]string{
-						corev1.BasicAuthPasswordKey: "P@ssw0rd!",
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			resource := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				StringData: map[string]string{
+					corev1.BasicAuthPasswordKey: "P@ssw0rd!",
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			By("Creating the custom resource for the Kind User")
-			user := &v1alpha1.User{}
-			if err := k8sClient.Get(ctx, key, user); errors.IsNotFound(err) {
-				resource := &v1alpha1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.UserSpec{
-						DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-						Username:  username,
-						Password: v1alpha1.PasswordSource{
-							SecretKeyRef: v1alpha1.SecretKeySelector{
-								SecretReference: v1alpha1.SecretReference{
-									Name: name,
-								},
-								Key: "password",
+			user := &v1alpha1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.UserSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					Username:  username,
+					Password: v1alpha1.PasswordSource{
+						SecretKeyRef: v1alpha1.SecretKeySelector{
+							SecretReference: v1alpha1.SecretReference{
+								Name: name,
 							},
+							Key: "password",
 						},
-						Roles: []v1alpha1.UserRole{{Name: "network-admin"}},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					Roles: []v1alpha1.UserRole{{Name: "network-admin"}},
+				},
 			}
+			Expect(k8sClient.Create(ctx, user)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/vlan_controller_test.go
+++ b/internal/controller/core/vlan_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -17,44 +16,42 @@ import (
 var _ = Describe("VLAN Controller", func() {
 	Context("When reconciling a resource", func() {
 		const id = 10
-		const name = "test-vlan"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		var (
+			name string
+			key  client.ObjectKey
+		)
 
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				resource := &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vlan-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind VLAN")
-			vlan := &v1alpha1.VLAN{}
-			if err := k8sClient.Get(ctx, key, vlan); errors.IsNotFound(err) {
-				resource := &v1alpha1.VLAN{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.VLANSpec{
-						DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
-						ID:         id,
-						Name:       "Scrum",
-						AdminState: v1alpha1.AdminStateUp,
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			resource := &v1alpha1.VLAN{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.VLANSpec{
+					DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+					ID:         id,
+					Name:       "Scrum",
+					AdminState: v1alpha1.AdminStateUp,
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/core/vrf_controller_test.go
+++ b/internal/controller/core/vrf_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -17,65 +16,60 @@ import (
 
 var _ = Describe("VRF Controller", func() {
 	Context("When reconciling a resource", func() {
-		const name = "test-vrf"
-		key := client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
-
 		var (
+			name   string
+			key    client.ObjectKey
 			device *v1alpha1.Device
 			vrf    *v1alpha1.VRF
 		)
 		BeforeEach(func() {
 			By("Creating the custom resource for the Kind Device")
-			device = &v1alpha1.Device{}
-			if err := k8sClient.Get(ctx, key, device); errors.IsNotFound(err) {
-				device = &v1alpha1.Device{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
+			device = &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vrf-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
 					},
-					Spec: v1alpha1.DeviceSpec{
-						Endpoint: v1alpha1.Endpoint{
-							Address: "192.168.10.2:9339",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, device)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			name = device.Name
+			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating the custom resource for the Kind VRF")
-			vrf = &v1alpha1.VRF{}
-			if err := k8sClient.Get(ctx, key, vrf); errors.IsNotFound(err) {
-				vrf = &v1alpha1.VRF{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: metav1.NamespaceDefault,
-					},
-					Spec: v1alpha1.VRFSpec{
-						DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
-						Name:               "CC-ADMIN-TEST",
-						VNI:                100,
-						RouteDistinguisher: "127.0.0.1:30004",
-						RouteTargets: []v1alpha1.RouteTarget{
-							{
-								Value:           "1.2.3.4:100",
-								AddressFamilies: []v1alpha1.RouteTargetAF{v1alpha1.IPv4, v1alpha1.IPv6, v1alpha1.IPv4EVPN, v1alpha1.IPv6EVPN},
-								Action:          v1alpha1.RouteTargetActionImport,
-							},
-							{
-								Value:           "231231:100",
-								AddressFamilies: []v1alpha1.RouteTargetAF{v1alpha1.IPv4, v1alpha1.IPv6},
-								Action:          v1alpha1.RouteTargetActionExport,
-							},
-							{
-								Value:           "65000:100",
-								AddressFamilies: []v1alpha1.RouteTargetAF{v1alpha1.IPv4, v1alpha1.IPv6},
-								Action:          v1alpha1.RouteTargetActionBoth,
-							},
+			vrf = &v1alpha1.VRF{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.VRFSpec{
+					DeviceRef:          v1alpha1.LocalObjectReference{Name: name},
+					Name:               "CC-ADMIN-TEST",
+					VNI:                100,
+					RouteDistinguisher: "127.0.0.1:30004",
+					RouteTargets: []v1alpha1.RouteTarget{
+						{
+							Value:           "1.2.3.4:100",
+							AddressFamilies: []v1alpha1.RouteTargetAF{v1alpha1.IPv4, v1alpha1.IPv6, v1alpha1.IPv4EVPN, v1alpha1.IPv6EVPN},
+							Action:          v1alpha1.RouteTargetActionImport,
+						},
+						{
+							Value:           "231231:100",
+							AddressFamilies: []v1alpha1.RouteTargetAF{v1alpha1.IPv4, v1alpha1.IPv6},
+							Action:          v1alpha1.RouteTargetActionExport,
+						},
+						{
+							Value:           "65000:100",
+							AddressFamilies: []v1alpha1.RouteTargetAF{v1alpha1.IPv4, v1alpha1.IPv6},
+							Action:          v1alpha1.RouteTargetActionBoth,
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, vrf)).To(Succeed())
+				},
 			}
+			Expect(k8sClient.Create(ctx, vrf)).To(Succeed())
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Replace hardcoded resource names with GenerateName-based dynamic names in all envtest controller tests. This eliminates occasional 409 conflict errors.