### PR TITLE
Suppress spurious "Unpausing" log on newly created resources

### DIFF
--- a/internal/paused/paused.go
+++ b/internal/paused/paused.go
@@ -37,7 +37,7 @@ func EnsureCondition(ctx context.Context, c client.Client, device *v1alpha1.Devi
 	switch {
 	case statusChanged && isPaused:
 		log.Info("Pausing reconciliation for this object", "reason", newCondition.Message)
-	case statusChanged && !isPaused:
+	case statusChanged && !isPaused && oldCondition != nil:
 		log.Info("Unpausing reconciliation for this object")
 	case !statusChanged && isPaused:
 		log.V(4).Info("Reconciliation is paused for this object", "reason", newCondition.Message)


### PR DESCRIPTION
When a resource has no prior Paused condition (e.g. on first creation), the "Unpausing reconciliation" log line was incorrectly emitted because `oldCondition == nil` caused `statusChanged` to be `true`. Guard the log with an `oldCondition != nil` check so it only fires on a real paused to unpaused transition.