### PR TITLE
Ensure consistent spacing in marker annotations

### DIFF
--- a/api/cisco/nx/v1alpha1/bordergateway_types.go
+++ b/api/cisco/nx/v1alpha1/bordergateway_types.go
@@ -146,11 +146,11 @@ const (
 // BorderGatewayStatus defines the observed state of BorderGateway.
 type BorderGatewayStatus struct {
 	// The conditions are a list of status objects that describe the state of the Banner.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/cisco/nx/v1alpha1/system_types.go
+++ b/api/cisco/nx/v1alpha1/system_types.go
@@ -45,11 +45,11 @@ type SystemSpec struct {
 // SystemStatus defines the observed state of System.
 type SystemStatus struct {
 	// The conditions are a list of status objects that describe the state of the Banner.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/cisco/nx/v1alpha1/vpcdomain_types.go
+++ b/api/cisco/nx/v1alpha1/vpcdomain_types.go
@@ -185,11 +185,11 @@ type VPCDomainStatus struct {
 	// the interface used as peer-link determine the overall health and operational condition of
 	// the vPC domain.
 	//
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Role indicates the current operational role of this vPC domain peer.

--- a/api/core/v1alpha1/acl_types.go
+++ b/api/core/v1alpha1/acl_types.go
@@ -104,11 +104,11 @@ type AccessControlListStatus struct {
 	EntriesSummary string `json:"entriesSummary,omitempty"`
 
 	// The conditions are a list of status objects that describe the state of the AccessControlList.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/banner_types.go
+++ b/api/core/v1alpha1/banner_types.go
@@ -51,11 +51,11 @@ const (
 // BannerStatus defines the observed state of Banner.
 type BannerStatus struct {
 	// The conditions are a list of status objects that describe the state of the Banner.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/certificate_types.go
+++ b/api/core/v1alpha1/certificate_types.go
@@ -40,11 +40,11 @@ type CertificateSpec struct {
 // CertificateStatus defines the observed state of Certificate.
 type CertificateStatus struct {
 	// The conditions are a list of status objects that describe the state of the Certificate.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/device_types.go
+++ b/api/core/v1alpha1/device_types.go
@@ -144,11 +144,11 @@ type DeviceStatus struct {
 	FirmwareVersion string `json:"firmwareVersion,omitempty"`
 
 	// Provisioning is the list of provisioning attempts for the Device.
-	//+listType=map
-	//+listMapKey=startTime
-	//+patchStrategy=merge
-	//+patchMergeKey=startTime
-	//+optional
+	// +listType=map
+	// +listMapKey=startTime
+	// +patchStrategy=merge
+	// +patchMergeKey=startTime
+	// +optional
 	Provisioning []ProvisioningInfo `json:"provisioning,omitempty"`
 
 	// Ports is the list of ports on the Device.
@@ -160,22 +160,22 @@ type DeviceStatus struct {
 	PortSummary string `json:"portSummary,omitempty"`
 
 	// The conditions are a list of status objects that describe the state of the Device.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ProvisioningInfo struct {
 	StartTime metav1.Time `json:"startTime"`
 	Token     string      `json:"token"`
-	//+optional
+	// +optional
 	EndTime metav1.Time `json:"endTime,omitzero"`
-	//+optional
+	// +optional
 	RebootTime metav1.Time `json:"reboot,omitzero"`
-	//+optional
+	// +optional
 	Error string `json:"error,omitempty"`
 }
 

--- a/api/core/v1alpha1/dns_types.go
+++ b/api/core/v1alpha1/dns_types.go
@@ -67,11 +67,11 @@ type NameServer struct {
 // DNSStatus defines the observed state of DNS.
 type DNSStatus struct {
 	// The conditions are a list of status objects that describe the state of the DNS.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -317,11 +317,11 @@ type MultiChassis struct {
 // InterfaceStatus defines the observed state of Interface.
 type InterfaceStatus struct {
 	// The conditions are a list of status objects that describe the state of the Interface.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// MemberOf references the aggregate interface this interface is a member of, if any.

--- a/api/core/v1alpha1/isis_types.go
+++ b/api/core/v1alpha1/isis_types.go
@@ -94,11 +94,11 @@ const (
 // ISISStatus defines the observed state of ISIS.
 type ISISStatus struct {
 	// The conditions are a list of status objects that describe the state of the ISIS.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/managementaccess_types.go
+++ b/api/core/v1alpha1/managementaccess_types.go
@@ -121,11 +121,11 @@ type SSH struct {
 // ManagementAccessStatus defines the observed state of ManagementAccess.
 type ManagementAccessStatus struct {
 	// The conditions are a list of status objects that describe the state of the ManagementAccess.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/ntp_types.go
+++ b/api/core/v1alpha1/ntp_types.go
@@ -64,11 +64,11 @@ type NTPServer struct {
 // NTPStatus defines the observed state of NTP.
 type NTPStatus struct {
 	// The conditions are a list of status objects that describe the state of the NTP.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/nve_types.go
+++ b/api/core/v1alpha1/nve_types.go
@@ -106,11 +106,11 @@ type NetworkVirtualizationEdgeStatus struct {
 	// - "Degraded": the resource failed to reach or maintain its desired state
 	//
 	// The conditions are a list of status objects that describe the state of the NVE.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// SourceInterfaceName is the resolved source interface IP address used for NVE encapsulation.

--- a/api/core/v1alpha1/pim_types.go
+++ b/api/core/v1alpha1/pim_types.go
@@ -81,11 +81,11 @@ const (
 // PIMStatus defines the observed state of PIM.
 type PIMStatus struct {
 	// The conditions are a list of status objects that describe the state of the PIM.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/prefixset_types.go
+++ b/api/core/v1alpha1/prefixset_types.go
@@ -79,11 +79,11 @@ type PrefixSetStatus struct {
 	EntriesSummary string `json:"entriesSummary,omitempty"`
 
 	// The conditions are a list of status objects that describe the state of the PrefixSet.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/routingpolicy_types.go
+++ b/api/core/v1alpha1/routingpolicy_types.go
@@ -134,11 +134,11 @@ type RoutingPolicyStatus struct {
 	StatementsSummary string `json:"statementsSummary,omitempty"`
 
 	// The conditions are a list of status objects that describe the state of the RoutingPolicy.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/snmp_types.go
+++ b/api/core/v1alpha1/snmp_types.go
@@ -119,11 +119,11 @@ type SNMPHosts struct {
 // SNMPStatus defines the observed state of SNMP.
 type SNMPStatus struct {
 	// The conditions are a list of status objects that describe the state of the SNMP.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/syslog_types.go
+++ b/api/core/v1alpha1/syslog_types.go
@@ -94,11 +94,11 @@ type SyslogStatus struct {
 	ServersSummary string `json:"serversSummary,omitempty"`
 
 	// The conditions are a list of status objects that describe the state of the Banner.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/user_types.go
+++ b/api/core/v1alpha1/user_types.go
@@ -74,11 +74,11 @@ type UserRole struct {
 // UserStatus defines the observed state of User.
 type UserStatus struct {
 	// The conditions are a list of status objects that describe the state of the User.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/core/v1alpha1/vlan_types.go
+++ b/api/core/v1alpha1/vlan_types.go
@@ -47,11 +47,11 @@ type VLANSpec struct {
 // VLANStatus defines the observed state of VLAN.
 type VLANStatus struct {
 	// The conditions are a list of status objects that describe the state of the VLAN.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// RoutedBy references the interface that provides Layer 3 routing for this VLAN, if any.

--- a/api/core/v1alpha1/vrf_types.go
+++ b/api/core/v1alpha1/vrf_types.go
@@ -103,11 +103,11 @@ type RouteTarget struct {
 // VRFStatus defines the observed state of VRF.
 type VRFStatus struct {
 	// The conditions are a list of status objects that describe the state of the VRF.
-	//+listType=map
-	//+listMapKey=type
-	//+patchStrategy=merge
-	//+patchMergeKey=type
-	//+optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/internal/provider/cisco/gnmiext/v2/client.go
+++ b/internal/provider/cisco/gnmiext/v2/client.go
@@ -88,7 +88,7 @@ func New(ctx context.Context, conn grpc.ClientConnInterface, opts ...Option) (Cl
 		return nil, fmt.Errorf("gnmiext: failed to retrieve capabilities: %w", err)
 	}
 	encoding := gpb.Encoding(-1)
-	for _, e := range res.SupportedEncodings {
+	for _, e := range res.GetSupportedEncodings() {
 		switch e {
 		case gpb.Encoding_JSON, gpb.Encoding_JSON_IETF:
 			encoding = e
@@ -97,14 +97,14 @@ func New(ctx context.Context, conn grpc.ClientConnInterface, opts ...Option) (Cl
 		}
 	}
 	if encoding == -1 {
-		return nil, fmt.Errorf("gnmiext: unsupported encoding: %v", res.SupportedEncodings)
+		return nil, fmt.Errorf("gnmiext: unsupported encoding: %v", res.GetSupportedEncodings())
 	}
 	capabilities := &Capabilities{SupportedModels: make([]Model, len(res.GetSupportedModels()))}
 	for i, model := range res.GetSupportedModels() {
 		capabilities.SupportedModels[i] = Model{
-			Name:         model.Name,
-			Organization: model.Organization,
-			Version:      model.Version,
+			Name:         model.GetName(),
+			Organization: model.GetOrganization(),
+			Version:      model.GetVersion(),
 		}
 	}
 	logger := logr.FromSlogHandler(slog.Default().Handler())
@@ -219,21 +219,22 @@ func (c *client) get(ctx context.Context, dt gpb.GetRequest_DataType, conf ...Co
 	// for each path in the request.
 	//
 	// [gNMI spec]: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#332-the-getresponse-message
-	if len(res.Notification) != len(conf) {
+	notifications := res.GetNotification()
+	if len(notifications) != len(conf) {
 		// This should never happen. If it does, it indicates a bug in the
 		// gNMI server.
-		return fmt.Errorf("gnmiext: unexpected number of notifications: got %d, want %d", len(res.Notification), len(conf))
+		return fmt.Errorf("gnmiext: unexpected number of notifications: got %d, want %d", len(notifications), len(conf))
 	}
 	// prevent bounds check in for the range loop below
 	// [Bounds Check Elimination]: https://go101.org/optimizations/5-bce.html
-	_ = res.Notification[len(conf)-1]
+	_ = notifications[len(conf)-1]
 	for i, cf := range conf {
-		n := res.Notification[i]
-		switch len(n.Update) {
+		n := notifications[i]
+		switch len(n.GetUpdate()) {
 		case 0:
 			return ErrNil
 		case 1:
-			b, err := c.Decode(n.Update[0].Val)
+			b, err := c.Decode(n.GetUpdate()[0].GetVal())
 			if err != nil {
 				return err
 			}
@@ -250,7 +251,7 @@ func (c *client) get(ctx context.Context, dt gpb.GetRequest_DataType, conf ...Co
 				return err
 			}
 		default:
-			return fmt.Errorf("gnmiext: unexpected number of updates: %d", len(n.Update))
+			return fmt.Errorf("gnmiext: unexpected number of updates: %d", len(n.GetUpdate()))
 		}
 	}
 	return nil
@@ -297,7 +298,7 @@ func (c *client) set(ctx context.Context, patch bool, conf ...Configurable) erro
 		}
 		r.Replace = append(r.Replace, u)
 	}
-	if len(r.Update) == 0 && len(r.Replace) == 0 {
+	if len(r.GetUpdate()) == 0 && len(r.GetReplace()) == 0 {
 		// All configurations are already up-to-date.
 		return nil
 	}
@@ -407,15 +408,15 @@ func (c *client) Encode(b []byte) *gpb.TypedValue {
 func (c *client) Decode(val *gpb.TypedValue) ([]byte, error) {
 	switch c.encoding {
 	case gpb.Encoding_JSON:
-		v, ok := val.Value.(*gpb.TypedValue_JsonVal)
+		v, ok := val.GetValue().(*gpb.TypedValue_JsonVal)
 		if !ok {
-			return nil, fmt.Errorf("gnmiext: unexpected value type: expected JsonVal, got %T", val.Value)
+			return nil, fmt.Errorf("gnmiext: unexpected value type: expected JsonVal, got %T", val.GetValue())
 		}
 		return v.JsonVal, nil
 	case gpb.Encoding_JSON_IETF:
-		v, ok := val.Value.(*gpb.TypedValue_JsonIetfVal)
+		v, ok := val.GetValue().(*gpb.TypedValue_JsonIetfVal)
 		if !ok {
-			return nil, fmt.Errorf("gnmiext: unexpected value type: expected JsonIetfVal, got %T", val.Value)
+			return nil, fmt.Errorf("gnmiext: unexpected value type: expected JsonIetfVal, got %T", val.GetValue())
 		}
 		return v.JsonIetfVal, nil
 	default:


### PR DESCRIPTION
Add a space between `//` and `+` in all kubebuilder and controller-tools marker annotations across API types to align with the upstream convention established in kubernetes-sigs/kubebuilder[^1].

Previously, markers like `//+listType=map` did not include a space, which was inconsistent with controller-tools and controller-runtime. All markers are now formatted as `// +listType=map` for uniformity.

[^1]: https://github.com/kubernetes-sigs/kubebuilder/commit/19bf0c7