### PR TITLE
Clean up Chart.yaml metadata

### DIFF
--- a/charts/network-operator/Chart.yaml
+++ b/charts/network-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-operator
 description: A Helm chart to distribute the project network-operator
 type: application
-version: 0.1.0
+version: 0.0.0+dev
 dependencies:
   # See: https://github.com/sapcc/helm-charts/pkgs/container/helm-charts%2Fowner-info
   - name: owner-info

--- a/charts/network-operator/Chart.yaml
+++ b/charts/network-operator/Chart.yaml
@@ -3,7 +3,6 @@ name: network-operator
 description: A Helm chart to distribute the project network-operator
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
 icon: "https://example.com/icon.png"
 dependencies:
   # See: https://github.com/sapcc/helm-charts/pkgs/container/helm-charts%2Fowner-info

--- a/charts/network-operator/Chart.yaml
+++ b/charts/network-operator/Chart.yaml
@@ -3,7 +3,6 @@ name: network-operator
 description: A Helm chart to distribute the project network-operator
 type: application
 version: 0.1.0
-icon: "https://example.com/icon.png"
 dependencies:
   # See: https://github.com/sapcc/helm-charts/pkgs/container/helm-charts%2Fowner-info
   - name: owner-info


### PR DESCRIPTION
### Summary

- Remove `appVersion` field — the app version is already user-controlled via `manager.image.tag` in `values.yaml`, making this field redundant and a potential source of drift
- Remove placeholder `icon` field — the URL pointed to `example.com` which is non-functional and would render as a broken image in Helm tooling (e.g. Artifact Hub, Helm Dashboard)
- Set chart `version` to `0.0.0+dev` as a development placeholder — the version will be overridden at publish time via `helm package --version <x.y.z>`, so the in-repo value signals to anyone installing directly from source that this is an unversioned dev build