### PR TITLE
feat: add SpanningTreePortTypeTrunk to InterfaceConfig API

### DIFF
--- a/api/cisco/nx/v1alpha1/interfaceconfig_types.go
+++ b/api/cisco/nx/v1alpha1/interfaceconfig_types.go
@@ -49,7 +49,7 @@ type BufferBoost struct {
 }
 
 // SpanningTreePortType represents the spanning tree port type.
-// +kubebuilder:validation:Enum=Normal;Edge;Network
+// +kubebuilder:validation:Enum=Normal;Edge;Network;Trunk
 type SpanningTreePortType string
 
 const (
@@ -57,6 +57,8 @@ const (
 	SpanningTreePortTypeNormal SpanningTreePortType = "Normal"
 	// SpanningTreePortTypeEdge indicates an edge port (connects to end devices).
 	SpanningTreePortTypeEdge SpanningTreePortType = "Edge"
+	// SpanningTreePortTypeTrunk indicates a trunk port performing spanning tree calculations for multiple VLANs (connects to end devices and carries multiple VLANs).
+	SpanningTreePortTypeTrunk SpanningTreePortType = "Trunk"
 	// SpanningTreePortTypeNetwork indicates a network port (connects to other switches).
 	SpanningTreePortTypeNetwork SpanningTreePortType = "Network"
 )

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_interfaceconfigs.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_interfaceconfigs.yaml
@@ -76,6 +76,7 @@ spec:
                     - Normal
                     - Edge
                     - Network
+                    - Trunk
                     type: string
                 required:
                 - portType

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -935,6 +935,8 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 				stp.Mode = SpanningTreeModeEdge
 			case nxv1alpha1.SpanningTreePortTypeNetwork:
 				stp.Mode = SpanningTreeModeNetwork
+			case nxv1alpha1.SpanningTreePortTypeTrunk:
+				stp.Mode = SpanningTreeModeTrunk
 			}
 			if cfg.Spec.SpanningTree.BPDUFilter != nil {
 				stp.BPDUfilter = AdminStDisable


### PR DESCRIPTION
Add support for trunk port type in spanning tree configuration API.
This was already supported by the Configurable but missing from the
InterfaceConfig API definition.
