### PR TITLE
Require BGP resource on device before reconciling BGPPeer

### DIFF
--- a/api/core/v1alpha1/groupversion_info.go
+++ b/api/core/v1alpha1/groupversion_info.go
@@ -210,6 +210,14 @@ const (
 	PrefixSetNotFoundReason = "PrefixSetNotFound"
 )
 
+// Reasons that are specific to [BGPPeer] objects.
+const (
+	// BGPNotFoundReason indicates that no BGP resource was found for the device
+	// referenced by the BGPPeer. A BGPPeer cannot function without a BGP process
+	// running on the same device.
+	BGPNotFoundReason = "BGPNotFound"
+)
+
 // Reasons that are specific to [BorderGateway] objects.
 const (
 	// BGPPeerNotFoundReason indicates that a referenced BGPPeer was not found.

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -65,6 +65,7 @@ type BGPPeerReconciler struct {
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgppeers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgppeers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgppeers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgp,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -259,6 +260,24 @@ func (r *BGPPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				},
 			}),
 		).
+		// Watches enqueues BGPPeers for updates in BGP resources on the same device.
+		// Triggers on create, delete, and update events. For updates, only triggers
+		// when the BGP transitions from not-ready to ready.
+		Watches(
+			&v1alpha1.BGP{},
+			handler.EnqueueRequestsFromMapFunc(r.bgpToBGPPeers),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldBGP := e.ObjectOld.(*v1alpha1.BGP)
+					newBGP := e.ObjectNew.(*v1alpha1.BGP)
+					// Only trigger when the BGP transitions from not-ready to ready.
+					return !conditions.IsReady(oldBGP) && conditions.IsReady(newBGP)
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -288,6 +307,39 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 	defer func() {
 		conditions.RecomputeReady(s.BGPPeer)
 	}()
+
+	// Check that at least one BGP resource exists for the device.
+	// A BGPPeer cannot function without a BGP process running on the same device.
+	bgpList := new(v1alpha1.BGPList)
+	if err := r.List(ctx, bgpList,
+		client.InNamespace(s.BGPPeer.Namespace),
+		client.MatchingLabels{v1alpha1.DeviceLabel: s.Device.Name},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list BGP resources for device %q: %w", s.Device.Name, err)
+	}
+
+	if len(bgpList.Items) == 0 {
+		conditions.Set(s.BGPPeer, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.BGPNotFoundReason,
+			Message: fmt.Sprintf("no BGP resource found for device %q", s.Device.Name),
+		})
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("no BGP resource found for device %q", s.Device.Name))
+	}
+
+	// Ensure at least one BGP resource on the device is ready before
+	// establishing peers. BGP has no operational condition, so its ready
+	// condition reflects only successful configuration.
+	if !slices.ContainsFunc(bgpList.Items, func(bgp v1alpha1.BGP) bool { return conditions.IsReady(&bgp) }) {
+		conditions.Set(s.BGPPeer, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.WaitingForDependenciesReason,
+			Message: fmt.Sprintf("BGP resource for device %q is not yet ready", s.Device.Name),
+		})
+		return ctrl.Result{}, nil
+	}
 
 	var sourceInterface string
 	if addr := s.BGPPeer.Spec.LocalAddress; addr != nil {
@@ -427,6 +479,39 @@ func (r *BGPPeerReconciler) deviceToBGPPeers(ctx context.Context, obj client.Obj
 	requests := make([]ctrl.Request, 0, len(list.Items))
 	for _, i := range list.Items {
 		log.V(2).Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&i))
+		requests = append(requests, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      i.Name,
+				Namespace: i.Namespace,
+			},
+		})
+	}
+
+	return requests
+}
+
+// bgpToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for BGPPeers when a BGP resource is created, deleted or updated on the same device.
+func (r *BGPPeerReconciler) bgpToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
+	bgp, ok := obj.(*v1alpha1.BGP)
+	if !ok {
+		panic(fmt.Sprintf("Expected a BGP but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "BGP", klog.KObj(bgp))
+
+	list := new(v1alpha1.BGPPeerList)
+	if err := r.List(ctx, list,
+		client.InNamespace(bgp.Namespace),
+		client.MatchingLabels{v1alpha1.DeviceLabel: bgp.Spec.DeviceRef.Name},
+	); err != nil {
+		log.Error(err, "Failed to list BGPPeers")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(list.Items))
+	for _, i := range list.Items {
+		log.Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&i))
 		requests = append(requests, ctrl.Request{
 			NamespacedName: client.ObjectKey{
 				Name:      i.Name,

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -12,14 +12,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/conditions"
 )
 
 var _ = Describe("BGPPeer Controller", func() {
 	Context("When reconciling a resource", func() {
 		const host = "10.0.0.1"
 		var (
-			name string
-			key  client.ObjectKey
+			name   string
+			key    client.ObjectKey
+			bgpKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -38,11 +40,38 @@ var _ = Describe("BGPPeer Controller", func() {
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
 			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+
+			By("Creating a BGP resource for the Device")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.10",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			bgpKey = client.ObjectKey{Name: bgp.Name, Namespace: metav1.NamespaceDefault}
+
+			By("Waiting for the BGP resource to be fully configured")
+			Eventually(func(g Gomega) {
+				bgp := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, bgpKey, bgp)).To(Succeed())
+				g.Expect(conditions.IsReady(bgp)).To(BeTrue())
+			}).Should(Succeed())
 		})
 
 		AfterEach(func() {
 			By("Cleaning up all BGPPeer resources")
 			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.BGPPeer{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+
+			By("Cleaning up the BGP resource")
+			bgp := &v1alpha1.BGP{}
+			Expect(k8sClient.Get(ctx, bgpKey, bgp)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
 
 			By("Cleaning up all Interface resources")
 			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.Interface{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
@@ -256,6 +285,139 @@ var _ = Describe("BGPPeer Controller", func() {
 				g.Expect(resource.Status.Conditions[3].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[3].Status).To(Equal(metav1.ConditionFalse))
 			}).Should(Succeed())
+		})
+
+		It("Should set Configured=False with BGPNotFoundReason when no BGP resource exists on device", func() {
+			By("Creating a separate Device without a BGP resource")
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-nobgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.3:9339",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+			key := client.ObjectKey{Name: device.Name, Namespace: metav1.NamespaceDefault}
+
+			By("Creating a BGPPeer on the device that has no BGP")
+			bgppeer := &v1alpha1.BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      device.Name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPPeerSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					Address:   "10.0.0.2",
+					ASNumber:  intstr.FromInt(65001),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+
+			By("Verifying the controller sets ConfiguredCondition to False with BGPNotFoundReason")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGPPeer{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).To(HaveLen(4))
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.ConfiguredCondition))
+				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[1].Reason).To(Equal(v1alpha1.BGPNotFoundReason))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.OperationalCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(resource.Status.Conditions[3].Type).To(Equal(v1alpha1.PausedCondition))
+				g.Expect(resource.Status.Conditions[3].Status).To(Equal(metav1.ConditionFalse))
+			}).Should(Succeed())
+
+			By("Verifying the BGP peer is NOT configured in the provider")
+			Consistently(func(g Gomega) {
+				g.Expect(testProvider.BGPPeers.Has("10.0.0.2")).To(BeFalse(), "Provider should not have BGP peer configured")
+			}).Should(Succeed())
+
+			By("Cleaning up test-specific resources")
+			Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+		})
+
+		It("Should set Configured=False with WaitingForDependenciesReason when BGP exists but is not configured", func() {
+			By("Creating a separate Device")
+			unconfiguredDevice := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-uncfg-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.4:9339",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, unconfiguredDevice)).To(Succeed())
+			unconfiguredKey := client.ObjectKey{Name: unconfiguredDevice.Name, Namespace: metav1.NamespaceDefault}
+
+			By("Creating a paused BGP resource with DeviceLabel pre-set (will not be configured)")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-uncfg-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+					Labels: map[string]string{
+						v1alpha1.DeviceLabel: unconfiguredDevice.Name,
+					},
+					Annotations: map[string]string{
+						v1alpha1.PausedAnnotation: "",
+					},
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: unconfiguredDevice.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.11",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+
+			By("Creating a BGPPeer on the device with the unconfigured BGP")
+			bgppeer := &v1alpha1.BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      unconfiguredDevice.Name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPPeerSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: unconfiguredDevice.Name},
+					Address:   "10.0.0.3",
+					ASNumber:  intstr.FromInt(65002),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+
+			By("Verifying the controller sets ConfiguredCondition to False with WaitingForDependenciesReason")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGPPeer{}
+				g.Expect(k8sClient.Get(ctx, unconfiguredKey, resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).To(HaveLen(4))
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.ConfiguredCondition))
+				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[1].Reason).To(Equal(v1alpha1.WaitingForDependenciesReason))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.OperationalCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(resource.Status.Conditions[3].Type).To(Equal(v1alpha1.PausedCondition))
+				g.Expect(resource.Status.Conditions[3].Status).To(Equal(metav1.ConditionFalse))
+			}).Should(Succeed())
+
+			By("Verifying the BGP peer is NOT configured in the provider")
+			Consistently(func(g Gomega) {
+				g.Expect(testProvider.BGPPeers.Has("10.0.0.3")).To(BeFalse(), "Provider should not have BGP peer configured")
+			}).Should(Succeed())
+
+			By("Cleaning up test-specific resources")
+			Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, unconfiguredDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
The BGPPeer controller now validates that at least one BGP resource exists and is ready on the same device before proceeding with reconciliation. Without a configured BGP process, a peer session cannot be established.

Two new checks are added to the reconcile loop:
- BGPNotFound: no BGP resource with the DeviceLabel exists (terminal)
- WaitingForDependencies: BGP exists but is not yet ready (waits for the BGP watch to re-trigger once the BGP becomes ready)

A watch on BGP resources enqueues related BGPPeers on create, delete, and when the Ready condition transitions from not-ready to ready.

This makes a dependency from the bgppeer to the bgp resource, without requiring a direct reference in the spec, which will be helpful later, when there are different operators potentially creating a bgppeer resources, without needing the kubernetes resource name of a bgp process.