### PR TITLE
Add NX-API JSON-RPC client and hack/nxapi helper

### DIFF
--- a/hack/nxapi/main.go
+++ b/hack/nxapi/main.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// nxapi is a minimal CLI tool for sending NX-API JSON-RPC commands to a
+// Cisco NX-OS device and printing the results.
+//
+// Usage:
+//
+//	go run ./hack/nxapi [flags] <cmd> [<cmd> ...]
+//
+// Example:
+//
+//	go run ./hack/nxapi -address 10.0.0.1:443 "show version" "show interface brief"
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/ironcore-dev/network-operator/internal/deviceutil"
+	"github.com/ironcore-dev/network-operator/internal/transport/nxapi"
+)
+
+var fs = flag.NewFlagSet("nxapi", flag.ContinueOnError)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: nxapi [flags] <cmd> [<cmd> ...]\n\n")
+	fmt.Fprintf(os.Stderr, "Sends NX-API JSON-RPC commands to a Cisco NX-OS device.\n\n")
+	fmt.Fprintf(os.Stderr, "Flags:\n")
+	fs.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nExample:\n")
+	fmt.Fprintf(os.Stderr, "  nxapi -address 10.0.0.1:8080 \"show version\" \"show interface brief\"\n")
+}
+
+func main() {
+	fs.Usage = usage
+
+	address := fs.String("address", "localhost:8080", "device address (host:port)")
+	username := fs.String("username", "admin", "NX-API username")
+	password := fs.String("password", "admin", "NX-API password")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		// flag.ContinueOnError: -h/--help prints usage and returns ErrHelp;
+		// other parse errors are already printed by the FlagSet.
+		return
+	}
+
+	cmds := fs.Args()
+	if len(cmds) == 0 {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	conn := &deviceutil.Connection{
+		Address:  *address,
+		Username: *username,
+		Password: *password,
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt /* == syscall.SIGINT */, syscall.SIGTERM)
+	defer cancel()
+
+	c, err := nxapi.NewClient(conn, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return
+	}
+
+	res, err := c.Do(ctx, nxapi.NewRequest(cmds...))
+	if err != nil {
+		if errs, ok := errors.AsType[nxapi.RPCErrors](err); ok {
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "RPC error %d: %s\n", e.Code, e.Message)
+				if len(e.Data) > 0 {
+					fmt.Fprintf(os.Stderr, "  data: %s\n", e.Data)
+				}
+			}
+			return
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return
+	}
+
+	for i, r := range res {
+		fmt.Printf("=== [%d] %s ===\n", i+1, cmds[i])
+		var pretty any
+		if err := json.Unmarshal(r, &pretty); err != nil {
+			fmt.Println(string(r))
+			continue
+		}
+		out, err := json.MarshalIndent(pretty, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to pretty-print JSON: %v\n", err)
+			fmt.Println(string(r))
+			continue
+		}
+		fmt.Println(string(out))
+	}
+}

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider"
 	"github.com/ironcore-dev/network-operator/internal/transport/gnmiext"
 	"github.com/ironcore-dev/network-operator/internal/transport/grpcext"
+	"github.com/ironcore-dev/network-operator/internal/transport/nxapi"
 )
 
 var (
@@ -65,6 +66,7 @@ var (
 type Provider struct {
 	conn   *grpc.ClientConn
 	client gnmiext.Client
+	nxapi  *nxapi.Client
 }
 
 func NewProvider() provider.Provider {
@@ -72,7 +74,9 @@ func NewProvider() provider.Provider {
 }
 
 func (p *Provider) Connect(ctx context.Context, conn *deviceutil.Connection) (err error) {
-	p.conn, err = grpcext.NewClient(ctx, conn, grpcext.WithDefaultTimeout(30*time.Second))
+	// timeout is the default timeout for all HTTP/gRPC requests made by the provider.
+	const timeout = 30 * time.Second
+	p.conn, err = grpcext.NewClient(ctx, conn, grpcext.WithDefaultTimeout(timeout))
 	if err != nil {
 		return fmt.Errorf("failed to create grpc connection: %w", err)
 	}
@@ -81,7 +85,17 @@ func (p *Provider) Connect(ctx context.Context, conn *deviceutil.Connection) (er
 		opts = append(opts, gnmiext.WithLogger(logger))
 	}
 	p.client, err = gnmiext.New(ctx, p.conn, opts...)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to create gnmi client: %w", err)
+	}
+	// NXAPI only uses the address for URI construction.
+	c := *conn
+	c.Address = netip.MustParseAddrPort(conn.Address).String()
+	p.nxapi, err = nxapi.NewClient(&c, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to create nxapi client: %w", err)
+	}
+	return nil
 }
 
 func (p *Provider) Disconnect(_ context.Context, _ *deviceutil.Connection) error {

--- a/internal/transport/nxapi/doc.go
+++ b/internal/transport/nxapi/doc.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nxapi provides a JSON-RPC client for Cisco NX-OS devices via NX-API.
+//
+// Use [NewClient] to create a client for a given [deviceutil.Connection].
+// The client supports both HTTP and HTTPS (selected automatically based on
+// whether a TLS configuration is present) and authenticates with HTTP Basic Auth.
+//
+// Commands are expressed as plain NX-OS CLI strings and grouped into a [Request]
+// using [NewRequest]. A single HTTP POST is made per [Request], which may contain
+// one or more commands. Each command in a batch gets its own result in the
+// returned slice.
+//
+// Errors are surfaced as [RPCErrors] when NX-OS reports one or more command
+// failures, or as [HTTPError] for non-2xx responses whose body cannot be parsed
+// as JSON-RPC (for example, a 401 Authorization Required).
+package nxapi

--- a/internal/transport/nxapi/nxapi.go
+++ b/internal/transport/nxapi/nxapi.go
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package nxapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/ironcore-dev/network-operator/internal/deviceutil"
+)
+
+// The RoundTripFunc type is an adapter to allow the use of
+// ordinary functions as [http.RoundTripper]. If f is a function
+// with the appropriate signature, RoundTripFunc(f) is a
+// [http.RoundTripper] that calls f.
+type RoundTripFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip returns f(r).
+func (f RoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+// Client sends JSON-RPC requests to a Cisco NX-OS device via NX-API.
+// Use [NewClient] to construct one.
+type Client struct {
+	client *http.Client
+	uri    string
+}
+
+// NewClient creates a new [Client] for the given connection.
+// If the connection has a TLS configuration set, HTTPS is used; otherwise HTTP.
+// The underlying HTTP client uses timeout for all requests; a value of 0
+// means no timeout.
+func NewClient(c *deviceutil.Connection, timeout time.Duration) (*Client, error) {
+	proto := "http"
+	if c.TLS != nil {
+		proto = "https"
+	}
+	uri, err := url.JoinPath(proto+"://"+c.Address, "ins")
+	if err != nil {
+		return nil, fmt.Errorf("nxapi: failed to join path: %w", err)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if c.TLS != nil {
+		transport.TLSClientConfig = c.TLS
+	}
+	return &Client{
+		client: &http.Client{
+			Transport: RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				r.Header.Set("Content-Type", "application/json-rpc")
+				r.Header.Set("Cache-Control", "no-cache")
+				r.SetBasicAuth(c.Username, c.Password)
+				return transport.RoundTrip(r)
+			}),
+			Timeout: timeout,
+		},
+		uri: uri,
+	}, nil
+}
+
+// Do sends a Request to the device and returns one [json.RawMessage] per
+// command, in the same order as the request. If any command fails, Do returns
+// an [RPCErrors] containing one [RPCError] per failed command; transport and
+// HTTP errors are returned directly.
+func (c *Client) Do(ctx context.Context, r Request) ([]json.RawMessage, error) {
+	b, err := r.Encode()
+	if err != nil {
+		return nil, fmt.Errorf("nxapi: failed to encode request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.uri, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("nxapi: failed to create request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("nxapi: failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("nxapi: failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Try to extract JSON-RPC errors from the body, but fall back to a
+		// plain HTTPError if the response is not valid JSON-RPC (e.g. a 401
+		// from an nginx reverse proxy).
+		if res, err := decode(body); err == nil {
+			var errs RPCErrors
+			for _, r := range res {
+				if r.Error != nil {
+					errs = append(errs, r.Error)
+				}
+			}
+			if len(errs) > 0 {
+				return nil, errs
+			}
+		}
+		return nil, &HTTPError{Code: resp.StatusCode, Body: body}
+	}
+
+	res, err := decode(body)
+	if err != nil {
+		return nil, fmt.Errorf("nxapi: failed to decode response: %w", err)
+	}
+
+	msg := make([]json.RawMessage, len(res))
+	for i, r := range res {
+		msg[i] = r.Body.Data
+	}
+
+	return msg, nil
+}
+
+// Request is an ordered list of commands to send in a single JSON-RPC batch.
+type Request []cmd
+
+// NewRequest creates a Request from plain CLI command strings.
+func NewRequest(cmds ...string) Request {
+	r := make(Request, len(cmds))
+	for i, c := range cmds {
+		r[i] = cmd{
+			Jsonrpc: "2.0",
+			// Other possible values are "cli_ascii" and "cli_array".
+			// For now, we only support "cli" which is the default.
+			Method: "cli",
+			Params: params{
+				Cmd: c,
+				// Static NX-API version.
+				Version: 1,
+			},
+			ID: i + 1,
+		}
+	}
+	return r
+}
+
+// WithRollback sets the error action on each command in the request,
+// controlling what NX-OS does if that individual command fails.
+func (r Request) WithRollback(a ErrorAction) Request {
+	for i := range r {
+		r[i].Rollback = a
+	}
+	return r
+}
+
+// Encode serialises the request to JSON.
+func (r Request) Encode() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// cmd represents a single JSON-RPC command within a [Request].
+type cmd struct {
+	Jsonrpc  string      `json:"jsonrpc"`
+	Method   string      `json:"method"`
+	Params   params      `json:"params"`
+	ID       int         `json:"id"`
+	Rollback ErrorAction `json:"rollback,omitempty"`
+}
+
+// params holds the NX-API specific parameters for a [cmd].
+type params struct {
+	Cmd     string `json:"cmd"`
+	Version int    `json:"version"`
+}
+
+// ErrorAction controls how NX-OS responds when an individual command fails.
+type ErrorAction string
+
+const (
+	Stop     ErrorAction = "stop-on-error"
+	Continue ErrorAction = "continue-on-error"
+	Rollback ErrorAction = "rollback-on-error"
+)
+
+// res is the shared JSON-RPC response envelope.
+type res struct {
+	Error *RPCError `json:"error"`
+	Body  struct {
+		Data json.RawMessage `json:"body"`
+	} `json:"result"`
+}
+
+// decode attempts to parse the response body as either a single JSON-RPC response
+// or a batch of responses, returning a slice of [res] values in either case.
+func decode(body []byte) ([]res, error) {
+	if len(body) > 0 && body[0] == '{' {
+		var r res
+		if err := json.Unmarshal(body, &r); err != nil {
+			return nil, err
+		}
+		return []res{r}, nil
+	}
+	var r []res
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// RPCError represents a single JSON-RPC error returned by NX-OS.
+type RPCError struct {
+	// Code is the JSON-RPC error code.
+	Code int `json:"code"`
+	// Message is the human-readable error description.
+	Message string `json:"message"`
+	// Data contains additional error context as raw JSON, if present.
+	Data json.RawMessage `json:"data"`
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("nxapi: RPC error %d: %s", e.Code, e.Message)
+}
+
+// RPCErrors is a slice of [RPCError] values returned when one or more commands
+// in a request fail. It implements the error interface.
+type RPCErrors []*RPCError
+
+// Error implements the built-in error interface.
+func (e RPCErrors) Error() string {
+	errs := make([]error, len(e))
+	for i, err := range e {
+		errs[i] = err
+	}
+	return errors.Join(errs...).Error()
+}
+
+// Unwrap returns the individual RPC errors for use with errors.Is and errors.As.
+func (e RPCErrors) Unwrap() []error {
+	errs := make([]error, len(e))
+	for i, err := range e {
+		errs[i] = err
+	}
+	return errs
+}
+
+// HTTPError is returned when the NX-API endpoint responds with a non-2xx
+// status and the body cannot be parsed as a JSON-RPC error.
+type HTTPError struct {
+	// Code is the HTTP status code.
+	Code int
+	// Body contains the raw response body.
+	Body []byte
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("nxapi: non-2xx status code: %d - %s", e.Code, string(e.Body))
+}

--- a/internal/transport/nxapi/nxapi_test.go
+++ b/internal/transport/nxapi/nxapi_test.go
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package nxapi
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ironcore-dev/network-operator/internal/deviceutil"
+)
+
+func TestUri(t *testing.T) {
+	tests := []struct {
+		desc      string
+		conn      *deviceutil.Connection
+		wantProto string
+	}{
+		{
+			desc:      "no TLS uses http",
+			conn:      &deviceutil.Connection{Address: "10.0.0.1:80"},
+			wantProto: "http",
+		},
+		{
+			desc:      "with TLS uses https",
+			conn:      &deviceutil.Connection{Address: "10.0.0.1:443", TLS: &tls.Config{}},
+			wantProto: "https",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			c, err := NewClient(test.conn, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			wantPrefix := test.wantProto + "://"
+			if !strings.HasPrefix(c.uri, wantPrefix) {
+				t.Errorf("uri = %q, want prefix %q", c.uri, wantPrefix)
+			}
+			if !strings.HasSuffix(c.uri, "/ins") {
+				t.Errorf("uri = %q, want suffix %q", c.uri, "/ins")
+			}
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		desc string
+		cmds []string
+		want string
+	}{
+		{
+			desc: "single show command",
+			cmds: []string{"show crypto ca certificates"},
+			want: `
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "cli",
+    "params": {
+      "cmd": "show crypto ca certificates",
+      "version": 1
+    },
+    "id": 1
+  }
+]`,
+		},
+		{
+			desc: "multiple conf commands",
+			cmds: []string{"crypto ca trustpoint mytrustpoint", "crypto ca import mytrustpoint pkcs12 bootflash:server.pfx cisco123"},
+			want: `
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "cli",
+    "params": {
+      "cmd": "crypto ca trustpoint mytrustpoint",
+      "version": 1
+    },
+    "id": 1
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "cli",
+    "params": {
+      "cmd": "crypto ca import mytrustpoint pkcs12 bootflash:server.pfx cisco123",
+      "version": 1
+    },
+    "id": 2
+  }
+]`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			r := NewRequest(test.cmds...)
+			b, err := r.Encode()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var got bytes.Buffer
+			if err := json.Compact(&got, b); err != nil {
+				t.Fatalf("json.Compact error: %v", err)
+			}
+			var want bytes.Buffer
+			if err := json.Compact(&want, []byte(test.want)); err != nil {
+				t.Fatalf("json.Compact error: %v", err)
+			}
+			if got.String() != want.String() {
+				t.Errorf("Encode() = %s, want %s", got.String(), want.String())
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		desc    string
+		body    string
+		wantLen int
+		wantErr bool
+	}{
+		{
+			desc:    "single object normalized to slice",
+			body:    `{"jsonrpc":"2.0","result":{"body":{"key":"val"}},"id":1}`,
+			wantLen: 1,
+		},
+		{
+			desc:    "array decoded as-is",
+			body:    `[{"jsonrpc":"2.0","result":{"body":{"a":1}},"id":1},{"jsonrpc":"2.0","result":{"body":{"b":2}},"id":2}]`,
+			wantLen: 2,
+		},
+		{
+			desc:    "invalid JSON returns error",
+			body:    `not json`,
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := decode([]byte(test.body))
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != test.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), test.wantLen)
+			}
+		})
+	}
+}
+
+func TestDo(t *testing.T) {
+	tests := []struct {
+		desc           string
+		statusCode     int
+		serverResponse string
+		wantResultLen  int
+		wantRPCErrors  int
+		wantHTTPError  bool
+	}{
+		{
+			desc:           "2xx single command",
+			statusCode:     http.StatusOK,
+			serverResponse: `{"jsonrpc":"2.0","result":{"body":{"version":"9.3(5)"}},"id":1}`,
+			wantResultLen:  1,
+		},
+		{
+			desc:       "2xx multiple commands",
+			statusCode: http.StatusOK,
+			serverResponse: `[
+				{"jsonrpc":"2.0","result":{"body":{"a":1}},"id":1},
+				{"jsonrpc":"2.0","result":{"body":{"b":2}},"id":2}
+			]`,
+			wantResultLen: 2,
+		},
+		{
+			desc:           "2xx null result for config command",
+			statusCode:     http.StatusOK,
+			serverResponse: `{"jsonrpc":"2.0","result":null,"id":1}`,
+			wantResultLen:  1,
+		},
+		{
+			desc:           "non-2xx single RPC error",
+			statusCode:     http.StatusBadRequest,
+			serverResponse: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":{"msg":"bad\n"}},"id":1}`,
+			wantRPCErrors:  1,
+		},
+		{
+			desc:       "non-2xx multiple RPC errors",
+			statusCode: http.StatusBadRequest,
+			serverResponse: `[
+				{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":1},
+				{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid command"},"id":2}
+			]`,
+			wantRPCErrors: 2,
+		},
+		{
+			desc:       "non-2xx with no error fields falls back to HTTPError",
+			statusCode: http.StatusBadRequest,
+			serverResponse: `[
+				{"jsonrpc":"2.0","result":{"body":{}},"id":1}
+			]`,
+			wantHTTPError: true,
+		},
+		{
+			desc:       "401 HTML from nginx proxy returns HTTPError",
+			statusCode: http.StatusUnauthorized,
+			serverResponse: `<html>
+<head><title>401 Authorization Required</title></head>
+<body>
+<center><h1>401 Authorization Required</h1></center>
+<hr><center>nginx/1.25.4</center>
+</body>
+</html>`,
+			wantHTTPError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if ct := r.Header.Get("Content-Type"); ct != "application/json-rpc" {
+					t.Errorf("Content-Type = %q, want %q", ct, "application/json-rpc")
+				}
+				if cc := r.Header.Get("Cache-Control"); cc != "no-cache" {
+					t.Errorf("Cache-Control = %q, want %q", cc, "no-cache")
+				}
+				user, pass, ok := r.BasicAuth()
+				if !ok {
+					t.Error("Basic auth header not set")
+				} else if user != "admin" || pass != "secret" {
+					t.Errorf("BasicAuth = (%q, %q), want (\"admin\", \"secret\")", user, pass)
+				}
+				w.Header().Set("Content-Type", "application/json-rpc")
+				w.WriteHeader(test.statusCode)
+				fmt.Fprint(w, test.serverResponse)
+			}))
+			defer srv.Close()
+
+			conn := &deviceutil.Connection{
+				Address:  srv.Listener.Addr().String(),
+				Username: "admin",
+				Password: "secret",
+			}
+			c, err := NewClient(conn, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			results, err := c.Do(t.Context(), NewRequest("show version"))
+			if test.wantRPCErrors > 0 || test.wantHTTPError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if test.wantRPCErrors > 0 {
+					var rpcErrs RPCErrors
+					if !errors.As(err, &rpcErrs) {
+						t.Fatalf("expected RPCErrors, got %T: %v", err, err)
+					}
+					if len(rpcErrs) != test.wantRPCErrors {
+						t.Errorf("len(RPCErrors) = %d, want %d", len(rpcErrs), test.wantRPCErrors)
+					}
+				}
+				if test.wantHTTPError {
+					var httpErr *HTTPError
+					if !errors.As(err, &httpErr) {
+						t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+					}
+					if httpErr.Code != test.statusCode {
+						t.Errorf("HTTPError.Code = %d, want %d", httpErr.Code, test.statusCode)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != test.wantResultLen {
+				t.Fatalf("len(results) = %d, want %d", len(results), test.wantResultLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce a new `nxapi` package in `internal/transport`, which includes a thin HTTP client for the Cisco NX-OS NX-API JSON-RPC endpoint.

Add `hack/nxapi`, a minimal CLI that sends one or more NX-API commands to a device and pretty-prints the JSON results.