### PR TITLE
Pause child resources based on device reachability and phase

### DIFF
--- a/api/core/v1alpha1/groupversion_info.go
+++ b/api/core/v1alpha1/groupversion_info.go
@@ -123,6 +123,11 @@ const (
 	// intended (e.g., a interface is up). It corresponds to the "oper-status" commonly found
 	// in the OpenConfig models (or "operSt" on Cisco).
 	OperationalCondition = "Operational"
+
+	// ReachableCondition indicates whether the controller can reach the device.
+	// This condition is set to True when the controller successfully connects to
+	// the device, and False when the connection attempt fails.
+	ReachableCondition = "Reachable"
 )
 
 // Reasons that are used across different objects.
@@ -138,6 +143,9 @@ const (
 
 	// NotPausedReason indicates that reconciliation is not paused.
 	NotPausedReason = "NotPaused"
+
+	// ReachableReason indicates that the controller can reach the device.
+	ReachableReason = "Reachable"
 
 	// UnreachableReason indicates that the controller cannot reach the device.
 	UnreachableReason = "Unreachable"

--- a/api/core/v1alpha1/groupversion_info.go
+++ b/api/core/v1alpha1/groupversion_info.go
@@ -40,6 +40,10 @@ const FinalizerName = "networking.metal.ironcore.dev/finalizer"
 // based on the device they are intended for.
 const DeviceLabel = "networking.metal.ironcore.dev/device-name"
 
+// DeviceRefIndexKey is the field index key for Spec.DeviceRef.Name, registered by
+// each resource controller so it can list its resources by device name.
+const DeviceRefIndexKey = ".spec.deviceRef.name"
+
 // DeviceSerialLabel is a label applied to any Network API object to indicate the serial number
 // of the device it is associated with. This label is used by the http provisioning server
 // to find the device when a provisioning request is received.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,6 +82,7 @@ func main() {
 	var watchFilterValue string
 	var providerName string
 	var requeueInterval time.Duration
+	var heartbeatInterval time.Duration
 	var tftpPort int
 	var tftpValidateSourceIP bool
 	var maxConcurrentReconciles int
@@ -105,6 +106,7 @@ func main() {
 	flag.StringVar(&watchFilterValue, "watch-filter", "", fmt.Sprintf("Label value that the controller watches to reconcile api objects. Label key is always %q. If unspecified, the controller watches for all api objects.", v1alpha1.WatchLabel))
 	flag.StringVar(&providerName, "provider", "openconfig", "The provider to use for the controller. If not specified, the default provider is used. Available providers: "+strings.Join(provider.Providers(), ", "))
 	flag.DurationVar(&requeueInterval, "requeue-interval", time.Hour, "The interval after which Kubernetes resources should be reconciled again regardless of whether they have changed.")
+	flag.DurationVar(&heartbeatInterval, "heartbeat-interval", 30*time.Second, "The interval after which the controller retries a reachability check on each device.")
 	flag.IntVar(&tftpPort, "tftp-port", 1069, "The port on which the inline TFTP server listens. Set to 0 to disable the TFTP server.")
 	flag.BoolVar(&tftpValidateSourceIP, "tftp-validate-source-ip", false, "If set, the TFTP server validates the source IP and requested serial-based filename against the same Device.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "The maximum number of concurrent reconciles per controller. Defaults to 1.")
@@ -279,12 +281,12 @@ func main() {
 	}
 
 	if err := (&corecontroller.DeviceReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		Recorder:         mgr.GetEventRecorder("device-controller"),
-		WatchFilterValue: watchFilterValue,
-		Provider:         prov,
-		RequeueInterval:  requeueInterval,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Recorder:          mgr.GetEventRecorder("device-controller"),
+		WatchFilterValue:  watchFilterValue,
+		Provider:          prov,
+		HeartbeatInterval: heartbeatInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Device")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -312,7 +312,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Banner")
 		os.Exit(1)
 	}
@@ -324,7 +324,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "User")
 		os.Exit(1)
 	}
@@ -336,7 +336,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DNS")
 		os.Exit(1)
 	}
@@ -348,7 +348,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NTP")
 		os.Exit(1)
 	}
@@ -360,7 +360,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AccessControlList")
 		os.Exit(1)
 	}
@@ -372,7 +372,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Certificate")
 		os.Exit(1)
 	}
@@ -384,7 +384,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SNMP")
 		os.Exit(1)
 	}
@@ -396,7 +396,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Syslog")
 		os.Exit(1)
 	}
@@ -408,7 +408,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ManagementAccess")
 		os.Exit(1)
 	}
@@ -421,7 +421,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ISIS")
 		os.Exit(1)
 	}
@@ -434,7 +434,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PIM")
 		os.Exit(1)
 	}
@@ -447,7 +447,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BGP")
 		os.Exit(1)
 	}
@@ -460,7 +460,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BGPPeer")
 		os.Exit(1)
 	}
@@ -486,7 +486,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OSPF")
 		os.Exit(1)
 	}
@@ -499,7 +499,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VLAN")
 		os.Exit(1)
 	}
@@ -512,7 +512,7 @@ func main() {
 		Provider:         prov,
 		Locker:           locker,
 		RequeueInterval:  requeueInterval,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VRF")
 		os.Exit(1)
 	}
@@ -550,7 +550,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "System")
 		os.Exit(1)
 	}
@@ -574,7 +574,7 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PrefixSet")
 		os.Exit(1)
 	}

--- a/internal/controller/cisco/nx/bordergateway_controller.go
+++ b/internal/controller/cisco/nx/bordergateway_controller.go
@@ -212,6 +212,13 @@ func (r *BorderGatewayReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1alpha1.BorderGateway{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		bg := obj.(*nxv1alpha1.BorderGateway)
+		return []string{bg.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1alpha1.BorderGateway{}, borderGatewaySourceInterfaceRefKey, func(obj client.Object) []string {
 		bg := obj.(*nxv1alpha1.BorderGateway)
 		return []string{bg.Spec.SourceInterfaceRef.Name}
@@ -621,7 +628,7 @@ func (r *BorderGatewayReconciler) deviceToBorderGateways(ctx context.Context, ob
 	list := new(nxv1alpha1.BorderGatewayList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list BorderGateways")
 		return nil

--- a/internal/controller/cisco/nx/bordergateway_controller.go
+++ b/internal/controller/cisco/nx/bordergateway_controller.go
@@ -288,16 +288,13 @@ func (r *BorderGatewayReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			}),
 		).
 		// Watches enqueues BorderGateways for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToBorderGateways),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -612,7 +609,7 @@ func (r *BorderGatewayReconciler) bgpPeerToBorderGateway(ctx context.Context, ob
 }
 
 // deviceToBorderGateways is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for BorderGateways when their referenced Device's Paused spec field changes.
+// for BorderGateways when their referenced Device's effective pause state changes.
 func (r *BorderGatewayReconciler) deviceToBorderGateways(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/cisco/nx/suite_test.go
+++ b/internal/controller/cisco/nx/suite_test.go
@@ -121,7 +121,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&VPCDomainReconciler{

--- a/internal/controller/cisco/nx/system_controller.go
+++ b/internal/controller/cisco/nx/system_controller.go
@@ -192,7 +192,7 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *SystemReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *SystemReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -201,6 +201,13 @@ func (r *SystemReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1alpha1.System{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*nxv1alpha1.System)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -292,7 +299,7 @@ func (r *SystemReconciler) deviceToSystems(ctx context.Context, obj client.Objec
 	list := new(nxv1alpha1.SystemList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list Systems")
 		return nil

--- a/internal/controller/cisco/nx/system_controller.go
+++ b/internal/controller/cisco/nx/system_controller.go
@@ -208,16 +208,13 @@ func (r *SystemReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("system").
 		WithEventFilter(filter).
 		// Watches enqueues Systems for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToSystems),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -283,7 +280,7 @@ func (r *SystemReconciler) finalize(ctx context.Context, s *systemScope) (reterr
 }
 
 // deviceToSystems is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for Systems when their referenced Device's Paused spec field changes.
+// for Systems when their referenced Device's effective pause state changes.
 func (r *SystemReconciler) deviceToSystems(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/cisco/nx/vpcdomain_controller.go
+++ b/internal/controller/cisco/nx/vpcdomain_controller.go
@@ -422,7 +422,7 @@ func (r *VPCDomainReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// Index vPCs by their device reference
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1.VPCDomain{}, ".spec.deviceRef.name", func(obj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1.VPCDomain{}, corev1.DeviceRefIndexKey, func(obj client.Object) []string {
 		vpc := obj.(*nxv1.VPCDomain)
 		return []string{vpc.Spec.DeviceRef.Name}
 	}); err != nil {
@@ -486,7 +486,7 @@ func (r *VPCDomainReconciler) mapInterfaceToVPCDomain(ctx context.Context, obj c
 		client.InNamespace(vpc.Namespace),
 		client.MatchingFields{
 			".spec.peer.interfaceRef.name": iface.Name,
-			".spec.deviceRef.name":         iface.Spec.DeviceRef.Name,
+			corev1.DeviceRefIndexKey:       iface.Spec.DeviceRef.Name,
 		},
 	); err != nil {
 		return nil
@@ -526,7 +526,7 @@ func (r *VPCDomainReconciler) deviceToVPCDomains(ctx context.Context, obj client
 	list := new(nxv1.VPCDomainList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{corev1.DeviceLabel: device.Name},
+		client.MatchingFields{corev1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list VPCDomains")
 		return nil

--- a/internal/controller/cisco/nx/vpcdomain_controller.go
+++ b/internal/controller/cisco/nx/vpcdomain_controller.go
@@ -458,16 +458,13 @@ func (r *VPCDomainReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			}),
 		).
 		// Watches enqueues VPCDomains for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&corev1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToVPCDomains),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*corev1.Device)
-					newDevice := e.ObjectNew.(*corev1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -517,7 +514,7 @@ func (r *VPCDomainReconciler) finalize(ctx context.Context, s *vpcdomainScope) (
 }
 
 // deviceToVPCDomains is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for VPCDomains when their referenced Device's Paused spec field changes.
+// for VPCDomains when their referenced Device's effective pause state changes.
 func (r *VPCDomainReconciler) deviceToVPCDomains(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*corev1.Device)
 	if !ok {

--- a/internal/controller/core/acl_controller.go
+++ b/internal/controller/core/acl_controller.go
@@ -231,16 +231,13 @@ func (r *AccessControlListReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues AccessControlLists for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToAccessControlLists),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -319,7 +316,7 @@ func (r *AccessControlListReconciler) finalize(ctx context.Context, s *aclScope)
 }
 
 // deviceToAccessControlLists is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for AccessControlLists when their referenced Device's Paused spec field changes.
+// for AccessControlLists when their referenced Device's effective pause state changes.
 func (r *AccessControlListReconciler) deviceToAccessControlLists(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/acl_controller.go
+++ b/internal/controller/core/acl_controller.go
@@ -202,7 +202,7 @@ func (r *AccessControlListReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *AccessControlListReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *AccessControlListReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *AccessControlListReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.AccessControlList{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.AccessControlList)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -328,7 +335,7 @@ func (r *AccessControlListReconciler) deviceToAccessControlLists(ctx context.Con
 	list := new(v1alpha1.AccessControlListList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list AccessControlLists")
 		return nil

--- a/internal/controller/core/banner_controller.go
+++ b/internal/controller/core/banner_controller.go
@@ -247,16 +247,13 @@ func (r *BannerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues Banners for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToBanners),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -334,7 +331,7 @@ func (r *BannerReconciler) finalize(ctx context.Context, s *bannerScope) (reterr
 }
 
 // deviceToBanners is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for Banners when their referenced Device's Paused spec field changes.
+// for Banners when their referenced Device's effective pause state changes.
 func (r *BannerReconciler) deviceToBanners(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/banner_controller.go
+++ b/internal/controller/core/banner_controller.go
@@ -206,7 +206,7 @@ func (r *BannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *BannerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *BannerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -215,6 +215,13 @@ func (r *BannerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Banner{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.Banner)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -343,7 +350,7 @@ func (r *BannerReconciler) deviceToBanners(ctx context.Context, obj client.Objec
 	list := new(v1alpha1.BannerList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list Banners")
 		return nil

--- a/internal/controller/core/bgp_controller.go
+++ b/internal/controller/core/bgp_controller.go
@@ -207,7 +207,7 @@ func (r *BGPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *BGPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *BGPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -220,6 +220,13 @@ func (r *BGPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.BGP{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.BGP)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -331,7 +338,7 @@ func (r *BGPReconciler) deviceToBGPs(ctx context.Context, obj client.Object) []c
 	list := new(v1alpha1.BGPList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list BGPs")
 		return nil

--- a/internal/controller/core/bgp_controller.go
+++ b/internal/controller/core/bgp_controller.go
@@ -240,16 +240,13 @@ func (r *BGPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues BGPs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToBGPs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -322,7 +319,7 @@ func (r *BGPReconciler) finalize(ctx context.Context, s *bgpScope) (reterr error
 }
 
 // deviceToBGPs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for BGPs when their referenced Device's Paused spec field changes.
+// for BGPs when their referenced Device's effective pause state changes.
 func (r *BGPReconciler) deviceToBGPs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -211,7 +211,7 @@ func (r *BGPPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *BGPPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *BGPPeerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -224,6 +224,13 @@ func (r *BGPPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.BGPPeer{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.BGPPeer)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -445,6 +452,40 @@ func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (rete
 	})
 }
 
+// reconcileBGP resolves the referenced BGP instance.
+// Sets ConfiguredCondition and returns a terminal error when the BGP is not found
+// or belongs to a different device.
+func (r *BGPPeerReconciler) reconcileBGP(ctx context.Context, peer *v1alpha1.BGPPeer, device *v1alpha1.Device) (*v1alpha1.BGP, error) {
+	bgp := new(v1alpha1.BGP)
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      peer.Spec.BgpRef.Name,
+		Namespace: peer.Namespace,
+	}, bgp); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(peer, metav1.Condition{
+				Type:    v1alpha1.ConfiguredCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.BGPNotFoundReason,
+				Message: fmt.Sprintf("BGP %s not found", peer.Spec.BgpRef.Name),
+			})
+			return nil, reconcile.TerminalError(fmt.Errorf("bgp %s not found", peer.Spec.BgpRef.Name))
+		}
+		return nil, fmt.Errorf("failed to get BGP %s: %w", peer.Spec.BgpRef.Name, err)
+	}
+
+	if bgp.Spec.DeviceRef.Name != device.Name {
+		conditions.Set(peer, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("BGP %s belongs to device %s, not %s", peer.Spec.BgpRef.Name, bgp.Spec.DeviceRef.Name, device.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("bgp %s belongs to different device", peer.Spec.BgpRef.Name))
+	}
+
+	return bgp, nil
+}
+
 // deviceToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
 // for BGPPeers when their referenced Device's effective pause state changes.
 func (r *BGPPeerReconciler) deviceToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
@@ -458,7 +499,7 @@ func (r *BGPPeerReconciler) deviceToBGPPeers(ctx context.Context, obj client.Obj
 	list := new(v1alpha1.BGPPeerList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list BGPPeers")
 		return nil
@@ -508,40 +549,6 @@ func (r *BGPPeerReconciler) bgpToBGPPeers(ctx context.Context, obj client.Object
 	}
 
 	return requests
-}
-
-// reconcileBGP resolves the referenced BGP instance.
-// Sets ConfiguredCondition and returns a terminal error when the BGP is not found
-// or belongs to a different device.
-func (r *BGPPeerReconciler) reconcileBGP(ctx context.Context, peer *v1alpha1.BGPPeer, device *v1alpha1.Device) (*v1alpha1.BGP, error) {
-	bgp := new(v1alpha1.BGP)
-	if err := r.Get(ctx, types.NamespacedName{
-		Name:      peer.Spec.BgpRef.Name,
-		Namespace: peer.Namespace,
-	}, bgp); err != nil {
-		if apierrors.IsNotFound(err) {
-			conditions.Set(peer, metav1.Condition{
-				Type:    v1alpha1.ConfiguredCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  v1alpha1.BGPNotFoundReason,
-				Message: fmt.Sprintf("BGP %s not found", peer.Spec.BgpRef.Name),
-			})
-			return nil, reconcile.TerminalError(fmt.Errorf("bgp %s not found", peer.Spec.BgpRef.Name))
-		}
-		return nil, fmt.Errorf("failed to get BGP %s: %w", peer.Spec.BgpRef.Name, err)
-	}
-
-	if bgp.Spec.DeviceRef.Name != device.Name {
-		conditions.Set(peer, metav1.Condition{
-			Type:    v1alpha1.ConfiguredCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  v1alpha1.CrossDeviceReferenceReason,
-			Message: fmt.Sprintf("BGP %s belongs to device %s, not %s", peer.Spec.BgpRef.Name, bgp.Spec.DeviceRef.Name, device.Name),
-		})
-		return nil, reconcile.TerminalError(fmt.Errorf("bgp %s belongs to different device", peer.Spec.BgpRef.Name))
-	}
-
-	return bgp, nil
 }
 
 // bgpPeersForProviderConfig is a [handler.MapFunc] to be used to enqueue requests for reconciliation

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -244,16 +244,13 @@ func (r *BGPPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues BGPPeers for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToBGPPeers),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -449,7 +446,7 @@ func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (rete
 }
 
 // deviceToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for BGPPeers when their referenced Device's Paused spec field changes.
+// for BGPPeers when their referenced Device's effective pause state changes.
 func (r *BGPPeerReconciler) deviceToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/certificate_controller.go
+++ b/internal/controller/core/certificate_controller.go
@@ -205,7 +205,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *CertificateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *CertificateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -214,6 +214,13 @@ func (r *CertificateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Certificate{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.Certificate)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -337,7 +344,7 @@ func (r *CertificateReconciler) deviceToCertificates(ctx context.Context, obj cl
 	list := new(v1alpha1.CertificateList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list Certificates")
 		return nil

--- a/internal/controller/core/certificate_controller.go
+++ b/internal/controller/core/certificate_controller.go
@@ -240,16 +240,13 @@ func (r *CertificateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		// Watches enqueues Certificates for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToCertificates),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -328,7 +325,7 @@ func (r *CertificateReconciler) finalize(ctx context.Context, s *certificateScop
 }
 
 // deviceToCertificates is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for Certificates when their referenced Device's Paused spec field changes.
+// for Certificates when their referenced Device's effective pause state changes.
 func (r *CertificateReconciler) deviceToCertificates(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -50,9 +50,9 @@ type DeviceReconciler struct {
 	// Provider is the driver that will be used to create & delete the interface.
 	Provider provider.ProviderFunc
 
-	// RequeueInterval is the duration after which the controller should requeue the reconciliation,
+	// HeartbeatInterval is the duration after which the controller requeues the reconciliation,
 	// regardless of changes.
-	RequeueInterval time.Duration
+	HeartbeatInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=devices,verbs=get;list;watch;create;update;patch;delete
@@ -104,7 +104,7 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	}
 
 	orig := obj.DeepCopy()
-	if conditions.InitializeConditions(obj, v1alpha1.ReadyCondition) {
+	if conditions.InitializeConditions(obj, v1alpha1.ReadyCondition, v1alpha1.ReachableCondition) {
 		log.V(1).Info("Initializing status conditions")
 		return ctrl.Result{}, r.Status().Update(ctx, obj)
 	}
@@ -182,7 +182,7 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		log.Info("Device provisioning completed, running post provisioning checks")
 		prov, _ := r.Provider().(provider.ProvisioningProvider)
 		if ok := prov.VerifyProvisioned(ctx, conn, obj); !ok {
-			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: r.HeartbeatInterval}, nil
 		}
 		activeProv.EndTime = metav1.Now()
 		r.Recorder.Eventf(obj, nil, "Normal", "Provisioned", "Reconcile", "Device provisioning has completed successfully")
@@ -212,13 +212,13 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		return ctrl.Result{}, reconcile.TerminalError(err)
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: r.HeartbeatInterval}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DeviceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if r.RequeueInterval == 0 {
-		return errors.New("requeue interval must not be 0")
+	if r.HeartbeatInterval == 0 {
+		return errors.New("heartbeat interval must not be 0")
 	}
 
 	labelSelector := metav1.LabelSelector{}
@@ -253,18 +253,31 @@ func (r *DeviceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Device, prov provider.DeviceProvider, conn *deviceutil.Connection) (reterr error) {
 	if err := prov.Connect(ctx, conn); err != nil {
 		conditions.Set(device, metav1.Condition{
-			Type:    v1alpha1.ReadyCondition,
+			Type:    v1alpha1.ReachableCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  v1alpha1.UnreachableReason,
-			Message: fmt.Sprintf("Failed to connect to provider: %v", err),
+			Message: fmt.Sprintf("Failed to connect to device: %v", err),
 		})
-		return fmt.Errorf("failed to connect to provider: %w", err)
+		conditions.Set(device, metav1.Condition{
+			Type:    v1alpha1.ReadyCondition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  v1alpha1.UnreachableReason,
+			Message: "Device is not reachable",
+		})
+		return nil
 	}
 	defer func() {
 		if err := prov.Disconnect(ctx, conn); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
+
+	conditions.Set(device, metav1.Condition{
+		Type:    v1alpha1.ReachableCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.ReachableReason,
+		Message: "Device is reachable",
+	})
 
 	ports, err := prov.ListPorts(ctx)
 	if err != nil {
@@ -282,12 +295,10 @@ func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Devic
 	}
 
 	device.Status.Ports = make([]v1alpha1.DevicePort, len(ports))
-	n := int32(0)
 	for i, p := range ports {
 		var ref *v1alpha1.LocalObjectReference
 		if name, ok := m[p.ID]; ok {
 			ref = &v1alpha1.LocalObjectReference{Name: name}
-			n++
 		}
 		device.Status.Ports[i] = v1alpha1.DevicePort{
 			Name:                p.ID,

--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -279,49 +279,73 @@ func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Devic
 		Message: "Device is reachable",
 	})
 
-	ports, err := prov.ListPorts(ctx)
+	// Reboot-gated queries: only fetch hardware info and ports when the device
+	// has rebooted since the last observed reboot time, or on first connection.
+	lastReboot, err := prov.GetLastRebootTime(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to list device ports: %w", err)
+		return fmt.Errorf("failed to get last reboot time: %w", err)
 	}
 
+	if device.Status.LastRebootTime.IsZero() || lastReboot.After(device.Status.LastRebootTime.Time) {
+		info, err := prov.GetDeviceInfo(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get device info: %w", err)
+		}
+		device.Status.Manufacturer = info.Manufacturer
+		device.Status.Model = info.Model
+		device.Status.SerialNumber = info.SerialNumber
+		device.Status.FirmwareVersion = info.FirmwareVersion
+		device.Status.LastRebootTime = metav1.NewTime(lastReboot)
+
+		ports, err := prov.ListPorts(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list device ports: %w", err)
+		}
+		device.Status.Ports = make([]v1alpha1.DevicePort, len(ports))
+		for i, p := range ports {
+			device.Status.Ports[i] = v1alpha1.DevicePort{
+				Name:                p.ID,
+				Type:                p.Type,
+				SupportedSpeedsGbps: p.SupportedSpeedsGbps,
+				Transceiver:         p.Transceiver,
+			}
+			slices.Sort(device.Status.Ports[i].SupportedSpeedsGbps)
+		}
+
+		log := ctrl.LoggerFrom(ctx)
+		if device.Labels == nil {
+			device.Labels = map[string]string{}
+		}
+		if serial := strings.ToLower(device.Status.SerialNumber); serial != "" {
+			if device.Labels[v1alpha1.DeviceSerialLabel] == "" {
+				device.Labels[v1alpha1.DeviceSerialLabel] = serial
+			} else if device.Labels[v1alpha1.DeviceSerialLabel] != serial {
+				log.Info("Device serial label does not match observed device serial number", "labelSerial", device.Labels[v1alpha1.DeviceSerialLabel], "observedSerial", serial)
+			}
+		}
+	}
+
+	// Always rebuild InterfaceRef mappings from the local Interface list.
 	interfaces := new(v1alpha1.InterfaceList)
 	if err := r.List(ctx, interfaces, client.InNamespace(device.Namespace), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name}); err != nil {
 		return fmt.Errorf("failed to list interface resources for device: %w", err)
 	}
 
-	m := make(map[string]string) // ID => Resource Name
+	m := make(map[string]string) // port ID => Interface resource name
 	for _, intf := range interfaces.Items {
 		m[intf.Spec.Name] = intf.Name
 	}
 
-	device.Status.Ports = make([]v1alpha1.DevicePort, len(ports))
-	for i, p := range ports {
-		var ref *v1alpha1.LocalObjectReference
-		if name, ok := m[p.ID]; ok {
-			ref = &v1alpha1.LocalObjectReference{Name: name}
+	for i := range device.Status.Ports {
+		portName := device.Status.Ports[i].Name
+		var newRef *v1alpha1.LocalObjectReference
+		if name, ok := m[portName]; ok {
+			newRef = &v1alpha1.LocalObjectReference{Name: name}
 		}
-		device.Status.Ports[i] = v1alpha1.DevicePort{
-			Name:                p.ID,
-			Type:                p.Type,
-			SupportedSpeedsGbps: p.SupportedSpeedsGbps,
-			Transceiver:         p.Transceiver,
-			InterfaceRef:        ref,
-		}
-		slices.Sort(device.Status.Ports[i].SupportedSpeedsGbps)
+		device.Status.Ports[i].InterfaceRef = newRef
 	}
 
 	device.Status.PortSummary = PortSummary(device.Status.Ports)
-
-	info, err := prov.GetDeviceInfo(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get device details: %w", err)
-	}
-
-	device.Status.Manufacturer = info.Manufacturer
-	device.Status.Model = info.Model
-	device.Status.SerialNumber = info.SerialNumber
-	device.Status.FirmwareVersion = info.FirmwareVersion
-	device.Status.LastRebootTime = metav1.NewTime(info.LastRebootTime)
 
 	conditions.Set(device, metav1.Condition{
 		Type:    v1alpha1.ReadyCondition,
@@ -329,18 +353,6 @@ func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Devic
 		Reason:  v1alpha1.ReadyReason,
 		Message: "Device is healthy",
 	})
-
-	log := ctrl.LoggerFrom(ctx)
-	if device.Labels == nil {
-		device.Labels = map[string]string{}
-	}
-	if serial := strings.ToLower(device.Status.SerialNumber); serial != "" {
-		if device.Labels[v1alpha1.DeviceSerialLabel] == "" {
-			device.Labels[v1alpha1.DeviceSerialLabel] = serial
-		} else if device.Labels[v1alpha1.DeviceSerialLabel] != serial {
-			log.Info("Device serial label does not match observed device serial number", "labelSerial", device.Labels[v1alpha1.DeviceSerialLabel], "observedSerial", serial)
-		}
-	}
 
 	return nil
 }

--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -24,6 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -241,11 +242,16 @@ func (r *DeviceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.secretToDevices),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
-		// Watches enqueues Devices for contained Interface resources.
+		// Watches enqueues Devices when an Interface is created or deleted,
+		// since Interface.Spec.Name is immutable and only create/delete events
+		// can change the device's port summary.
 		Watches(
 			&v1alpha1.Interface{},
 			handler.EnqueueRequestsFromMapFunc(r.interfaceToDevices),
-			builder.WithPredicates(predicate.Or(predicate.ResourceVersionChangedPredicate{}, predicate.LabelChangedPredicate{})),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+			}),
 		).
 		Complete(r)
 }
@@ -327,7 +333,7 @@ func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Devic
 
 	// Always rebuild InterfaceRef mappings from the local Interface list.
 	interfaces := new(v1alpha1.InterfaceList)
-	if err := r.List(ctx, interfaces, client.InNamespace(device.Namespace), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name}); err != nil {
+	if err := r.List(ctx, interfaces, client.InNamespace(device.Namespace), client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name}); err != nil {
 		return fmt.Errorf("failed to list interface resources for device: %w", err)
 	}
 
@@ -467,11 +473,6 @@ func (r *DeviceReconciler) interfaceToDevices(ctx context.Context, obj client.Ob
 	intf, ok := obj.(*v1alpha1.Interface)
 	if !ok {
 		panic(fmt.Sprintf("Expected a Interface but got a %T", obj))
-	}
-
-	if intf.GetLabels()[v1alpha1.DeviceLabel] != intf.Spec.DeviceRef.Name {
-		// If the device label is not set (yet), we skip the event.
-		return nil
 	}
 
 	log := ctrl.LoggerFrom(ctx, "Interface", klog.KObj(intf), "Device", klog.KRef(intf.Namespace, intf.Spec.DeviceRef.Name))

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -80,12 +81,14 @@ var _ = Describe("Device Controller", func() {
 				resource := &v1alpha1.Device{}
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
-				g.Expect(resource.Status.Conditions).To(HaveLen(2))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(resource.Status.Conditions[0].Reason).To(Equal(v1alpha1.ReadyReason))
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 			}).Should(Succeed())
 
 			By("Creating the custom resource for the Kind Interface")
@@ -111,11 +114,13 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
 
-				g.Expect(resource.Status.Conditions).To(HaveLen(2))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 
 				g.Expect(resource.Status.Manufacturer).To(Equal("Manufacturer"))
 				g.Expect(resource.Status.Model).To(Equal("Model"))
@@ -174,12 +179,14 @@ var _ = Describe("Device Controller", func() {
 				resource := &v1alpha1.Device{}
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
-				g.Expect(resource.Status.Conditions).To(HaveLen(2))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(resource.Status.Conditions[0].Reason).To(Equal(v1alpha1.ProvisioningReason))
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionUnknown))
 			}).Should(Succeed())
 		})
 
@@ -372,12 +379,14 @@ var _ = Describe("Device Controller", func() {
 				resource := &v1alpha1.Device{}
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
-				g.Expect(resource.Status.Conditions).To(HaveLen(2))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(resource.Status.Conditions[0].Reason).To(Equal(v1alpha1.ReadyReason))
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 			}).Should(Succeed())
 		})
 
@@ -414,10 +423,12 @@ var _ = Describe("Device Controller", func() {
 				resource := &v1alpha1.Device{}
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
-				g.Expect(resource.Status.Conditions).To(HaveLen(2))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionUnknown))
 			}).Should(Succeed())
 
 			By("Setting the device to Running phase")
@@ -430,10 +441,12 @@ var _ = Describe("Device Controller", func() {
 				resource := &v1alpha1.Device{}
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
-				g.Expect(resource.Status.Conditions).To(HaveLen(2))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 			}).Should(Succeed())
 
 			By("Adding the reset-phase annotation to the device")
@@ -454,6 +467,61 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
 				_, exists := resource.Annotations[v1alpha1.DeviceMaintenanceAnnotation]
 				g.Expect(exists).To(BeFalse(), "Maintenance annotation should be removed after processing")
+			}).Should(Succeed())
+		})
+
+		It("Should set Reachable=False and Ready=Unknown when the device is unreachable", func() {
+			By("Making the provider return a connect error")
+			testProvider.SetConnectError(errors.New("connection refused"))
+
+			DeferCleanup(func() {
+				testProvider.SetConnectError(nil)
+			})
+
+			By("Creating the custom resource for the Kind Device")
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+
+			By("Verifying Reachable=False and Ready=Unknown when connect fails")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
+				g.Expect(resource.Status.Conditions).To(HaveLen(3))
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(resource.Status.Conditions[0].Reason).To(Equal(v1alpha1.UnreachableReason))
+				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
+				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[2].Reason).To(Equal(v1alpha1.UnreachableReason))
+			}).Should(Succeed())
+
+			By("Clearing the connect error to simulate recovery")
+			testProvider.SetConnectError(nil)
+
+			By("Verifying Reachable=True and Ready=True after recovery")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.ReachableCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 			}).Should(Succeed())
 		})
 	})

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -524,5 +524,45 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 			}).Should(Succeed())
 		})
+
+		It("Should update LastRebootTime in status when the device reboots", func() {
+			By("Creating the custom resource for the Kind Device")
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+
+			By("Waiting for the initial reconcile to populate LastRebootTime")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.LastRebootTime.Time).To(BeTemporally("==", lastRebootTime))
+			}).Should(Succeed())
+
+			By("Advancing the reboot time in the provider to simulate a device reboot")
+			newRebootTime := lastRebootTime.Add(time.Hour)
+			testProvider.SetLastRebootTime(newRebootTime)
+			DeferCleanup(func() {
+				testProvider.SetLastRebootTime(lastRebootTime)
+			})
+
+			By("Verifying LastRebootTime in status is updated to the new value")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.LastRebootTime.Time).To(BeTemporally("==", newRebootTime))
+			}).Should(Succeed())
+		})
 	})
 })

--- a/internal/controller/core/dhcprelay_controller.go
+++ b/internal/controller/core/dhcprelay_controller.go
@@ -310,6 +310,13 @@ func (r *DHCPRelayReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.DHCPRelay{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.DHCPRelay)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DHCPRelay{}).
 		Named("dhcprelay").
@@ -550,7 +557,7 @@ func (r *DHCPRelayReconciler) validateUniqueResourcePerDevice(ctx context.Contex
 	var list v1alpha1.DHCPRelayList
 	if err := r.List(ctx, &list,
 		client.InNamespace(s.DHCPRelay.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: s.Device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: s.Device.Name},
 	); err != nil {
 		return err
 	}
@@ -625,7 +632,7 @@ func (r *DHCPRelayReconciler) deviceToDHCPRelays(ctx context.Context, obj client
 	list := new(v1alpha1.DHCPRelayList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list DHCPRelays")
 		return nil
@@ -657,7 +664,7 @@ func (r *DHCPRelayReconciler) interfaceToDHCPRelays(ctx context.Context, obj cli
 	list := new(v1alpha1.DHCPRelayList)
 	if err := r.List(ctx, list,
 		client.InNamespace(intf.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: intf.Spec.DeviceRef.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: intf.Spec.DeviceRef.Name},
 	); err != nil {
 		log.Error(err, "Failed to list DHCPRelays")
 		return nil
@@ -694,7 +701,7 @@ func (r *DHCPRelayReconciler) vrfToDHCPRelays(ctx context.Context, obj client.Ob
 	list := new(v1alpha1.DHCPRelayList)
 	if err := r.List(ctx, list,
 		client.InNamespace(vrf.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: vrf.Spec.DeviceRef.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: vrf.Spec.DeviceRef.Name},
 	); err != nil {
 		log.Error(err, "Failed to list DHCPRelays")
 		return nil

--- a/internal/controller/core/dhcprelay_controller.go
+++ b/internal/controller/core/dhcprelay_controller.go
@@ -328,16 +328,13 @@ func (r *DHCPRelayReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 
 	return bldr.
 		// Watches enqueues DHCPRelays for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToDHCPRelays),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false

--- a/internal/controller/core/dns_controller.go
+++ b/internal/controller/core/dns_controller.go
@@ -202,7 +202,7 @@ func (r *DNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *DNSReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DNSReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *DNSReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.DNS{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.DNS)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -319,7 +326,7 @@ func (r *DNSReconciler) deviceToDNSs(ctx context.Context, obj client.Object) []c
 	list := new(v1alpha1.DNSList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list DNSs")
 		return nil

--- a/internal/controller/core/dns_controller.go
+++ b/internal/controller/core/dns_controller.go
@@ -231,16 +231,13 @@ func (r *DNSReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues DNSs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToDNSs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -310,7 +307,7 @@ func (r *DNSReconciler) finalize(ctx context.Context, s *dnsScope) (reterr error
 }
 
 // deviceToDNSs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for DNSs when their referenced Device's Paused spec field changes.
+// for DNSs when their referenced Device's effective pause state changes.
 func (r *DNSReconciler) deviceToDNSs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/evpninstance_controller.go
+++ b/internal/controller/core/evpninstance_controller.go
@@ -227,6 +227,13 @@ func (r *EVPNInstanceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		return err
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.EVPNInstance{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.EVPNInstance)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.EVPNInstance{}).
 		Named("evpninstance").
@@ -458,7 +465,7 @@ func (r *EVPNInstanceReconciler) deviceToEVPNInstances(ctx context.Context, obj 
 	list := new(v1alpha1.EVPNInstanceList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list EVPNInstances")
 		return nil

--- a/internal/controller/core/evpninstance_controller.go
+++ b/internal/controller/core/evpninstance_controller.go
@@ -259,16 +259,13 @@ func (r *EVPNInstanceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 			}),
 		).
 		// Watches enqueues EVPNInstances for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToEVPNInstances),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -449,7 +446,7 @@ func (r *EVPNInstanceReconciler) finalizeVLAN(ctx context.Context, s *eviScope) 
 }
 
 // deviceToEVPNInstances is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for EVPNInstances when their referenced Device's Paused spec field changes.
+// for EVPNInstances when their referenced Device's effective pause state changes.
 func (r *EVPNInstanceReconciler) deviceToEVPNInstances(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/interface_controller.go
+++ b/internal/controller/core/interface_controller.go
@@ -371,16 +371,13 @@ func (r *InterfaceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			}),
 		).
 		// Watches enqueues Interfaces for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToInterfaces),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -1040,7 +1037,7 @@ func (r *InterfaceReconciler) interfacesForProviderConfig(ctx context.Context, o
 }
 
 // deviceToInterfaces is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for Interfaces when their referenced Device's Paused spec field changes.
+// for Interfaces when their referenced Device's effective pause state changes.
 func (r *InterfaceReconciler) deviceToInterfaces(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/interface_controller.go
+++ b/internal/controller/core/interface_controller.go
@@ -271,6 +271,13 @@ func (r *InterfaceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		return err
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Interface{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.Interface)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Interface{}).
 		Named("interface").
@@ -1049,7 +1056,7 @@ func (r *InterfaceReconciler) deviceToInterfaces(ctx context.Context, obj client
 	interfaces := new(v1alpha1.InterfaceList)
 	if err := r.List(ctx, interfaces,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list Interfaces")
 		return nil

--- a/internal/controller/core/isis_controller.go
+++ b/internal/controller/core/isis_controller.go
@@ -240,16 +240,13 @@ func (r *ISISReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues ISISs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToISISs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -356,7 +353,7 @@ func (r *ISISReconciler) finalize(ctx context.Context, s *isisScope) (reterr err
 }
 
 // deviceToISISs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for ISISs when their referenced Device's Paused spec field changes.
+// for ISISs when their referenced Device's effective pause state changes.
 func (r *ISISReconciler) deviceToISISs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/isis_controller.go
+++ b/internal/controller/core/isis_controller.go
@@ -207,7 +207,7 @@ func (r *ISISReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ISISReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ISISReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -220,6 +220,13 @@ func (r *ISISReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.ISIS{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.ISIS)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -365,7 +372,7 @@ func (r *ISISReconciler) deviceToISISs(ctx context.Context, obj client.Object) [
 	list := new(v1alpha1.ISISList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list ISISs")
 		return nil

--- a/internal/controller/core/lldp_controller.go
+++ b/internal/controller/core/lldp_controller.go
@@ -388,7 +388,7 @@ func (r *LLDPReconciler) validateUniqueLLDPPerDevice(ctx context.Context, s *lld
 	var list v1alpha1.LLDPList
 	if err := r.List(ctx, &list,
 		client.InNamespace(s.LLDP.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: s.Device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: s.Device.Name},
 	); err != nil {
 		return err
 	}
@@ -420,6 +420,13 @@ func (r *LLDPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager)
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.LLDP{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.LLDP)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	c := ctrl.NewControllerManagedBy(mgr).
@@ -512,7 +519,7 @@ func (r *LLDPReconciler) deviceToLLDPs(ctx context.Context, obj client.Object) [
 	lldps := new(v1alpha1.LLDPList)
 	if err := r.List(ctx, lldps,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list LLDPs")
 		return nil

--- a/internal/controller/core/lldp_controller.go
+++ b/internal/controller/core/lldp_controller.go
@@ -438,16 +438,13 @@ func (r *LLDPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager)
 	}
 
 	// Watches enqueues LLDPs for updates in referenced Device resources.
-	// Triggers on update events when the Paused spec field changes.
+	// Triggers on create, delete, and update events when the device's effective pause state changes.
 	c = c.Watches(
 		&v1alpha1.Device{},
 		handler.EnqueueRequestsFromMapFunc(r.deviceToLLDPs),
 		builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				oldDevice := e.ObjectOld.(*v1alpha1.Device)
-				newDevice := e.ObjectNew.(*v1alpha1.Device)
-				// Only trigger when Paused spec field changes.
-				return oldDevice.Spec.Paused != newDevice.Spec.Paused
+				return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 			},
 			GenericFunc: func(e event.GenericEvent) bool {
 				return false
@@ -503,7 +500,7 @@ func (r *LLDPReconciler) finalize(ctx context.Context, s *lldpScope) (reterr err
 }
 
 // deviceToLLDPs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for LLDPs when their referenced Device's Paused spec field changes.
+// for LLDPs when their referenced Device's effective pause state changes.
 func (r *LLDPReconciler) deviceToLLDPs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/managementaccess_controller.go
+++ b/internal/controller/core/managementaccess_controller.go
@@ -202,7 +202,7 @@ func (r *ManagementAccessReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ManagementAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ManagementAccessReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *ManagementAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.ManagementAccess{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.ManagementAccess)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -319,7 +326,7 @@ func (r *ManagementAccessReconciler) deviceToManagementAccesses(ctx context.Cont
 	list := new(v1alpha1.ManagementAccessList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list ManagementAccesses")
 		return nil

--- a/internal/controller/core/managementaccess_controller.go
+++ b/internal/controller/core/managementaccess_controller.go
@@ -231,16 +231,13 @@ func (r *ManagementAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues ManagementAccesses for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToManagementAccesses),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -310,7 +307,7 @@ func (r *ManagementAccessReconciler) finalize(ctx context.Context, s *management
 }
 
 // deviceToManagementAccesses is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for ManagementAccesses when their referenced Device's Paused spec field changes.
+// for ManagementAccesses when their referenced Device's effective pause state changes.
 func (r *ManagementAccessReconciler) deviceToManagementAccesses(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/ntp_controller.go
+++ b/internal/controller/core/ntp_controller.go
@@ -231,16 +231,13 @@ func (r *NTPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues NTPs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToNTPs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -310,7 +307,7 @@ func (r *NTPReconciler) finalize(ctx context.Context, s *ntpScope) (reterr error
 }
 
 // deviceToNTPs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for NTPs when their referenced Device's Paused spec field changes.
+// for NTPs when their referenced Device's effective pause state changes.
 func (r *NTPReconciler) deviceToNTPs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/ntp_controller.go
+++ b/internal/controller/core/ntp_controller.go
@@ -202,7 +202,7 @@ func (r *NTPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *NTPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *NTPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *NTPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.NTP{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.NTP)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -319,7 +326,7 @@ func (r *NTPReconciler) deviceToNTPs(ctx context.Context, obj client.Object) []c
 	list := new(v1alpha1.NTPList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list NTPs")
 		return nil

--- a/internal/controller/core/nve_controller.go
+++ b/internal/controller/core/nve_controller.go
@@ -300,7 +300,7 @@ func (r *NetworkVirtualizationEdgeReconciler) validateUniqueNVEPerDevice(ctx con
 	var list v1alpha1.NetworkVirtualizationEdgeList
 	if err := r.List(ctx, &list,
 		client.InNamespace(s.NVE.Namespace),
-		client.MatchingFields{".spec.deviceRef.name": s.NVE.Spec.DeviceRef.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: s.NVE.Spec.DeviceRef.Name},
 	); err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func (r *NetworkVirtualizationEdgeReconciler) SetupWithManager(ctx context.Conte
 	}
 
 	// Index NVEs by their DeviceRef.name for uniqueness checks.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.NetworkVirtualizationEdge{}, ".spec.deviceRef.name", func(obj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.NetworkVirtualizationEdge{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
 		vpc := obj.(*v1alpha1.NetworkVirtualizationEdge)
 		return []string{vpc.Spec.DeviceRef.Name}
 	}); err != nil {
@@ -523,7 +523,7 @@ func (r *NetworkVirtualizationEdgeReconciler) deviceToNVEs(ctx context.Context, 
 	list := new(v1alpha1.NetworkVirtualizationEdgeList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list NVEs")
 		return nil

--- a/internal/controller/core/nve_controller.go
+++ b/internal/controller/core/nve_controller.go
@@ -449,16 +449,13 @@ func (r *NetworkVirtualizationEdgeReconciler) SetupWithManager(ctx context.Conte
 			}),
 		).
 		// Watches enqueues NVEs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToNVEs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -514,7 +511,7 @@ func (r *NetworkVirtualizationEdgeReconciler) interfaceToNVE(ctx context.Context
 }
 
 // deviceToNVEs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for NVEs when their referenced Device's Paused spec field changes.
+// for NVEs when their referenced Device's effective pause state changes.
 func (r *NetworkVirtualizationEdgeReconciler) deviceToNVEs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/ospf_controller.go
+++ b/internal/controller/core/ospf_controller.go
@@ -210,7 +210,7 @@ func (r *OSPFReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OSPFReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OSPFReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -223,6 +223,13 @@ func (r *OSPFReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.OSPF{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.OSPF)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -442,7 +449,7 @@ func (r *OSPFReconciler) deviceToOSPFs(ctx context.Context, obj client.Object) [
 	list := new(v1alpha1.OSPFList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list OSPFs")
 		return nil

--- a/internal/controller/core/ospf_controller.go
+++ b/internal/controller/core/ospf_controller.go
@@ -243,16 +243,13 @@ func (r *OSPFReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues OSPFs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToOSPFs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -433,7 +430,7 @@ func (r *OSPFReconciler) finalize(ctx context.Context, s *ospfScope) (reterr err
 }
 
 // deviceToOSPFs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for OSPFs when their referenced Device's Paused spec field changes.
+// for OSPFs when their referenced Device's effective pause state changes.
 func (r *OSPFReconciler) deviceToOSPFs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/pim_controller.go
+++ b/internal/controller/core/pim_controller.go
@@ -240,16 +240,13 @@ func (r *PIMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues PIMs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToPIMs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -358,7 +355,7 @@ func (r *PIMReconciler) finalize(ctx context.Context, s *pimScope) (reterr error
 }
 
 // deviceToPIMs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for PIMs when their referenced Device's Paused spec field changes.
+// for PIMs when their referenced Device's effective pause state changes.
 func (r *PIMReconciler) deviceToPIMs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/pim_controller.go
+++ b/internal/controller/core/pim_controller.go
@@ -207,7 +207,7 @@ func (r *PIMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PIMReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PIMReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -220,6 +220,13 @@ func (r *PIMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.PIM{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.PIM)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -367,7 +374,7 @@ func (r *PIMReconciler) deviceToPIMs(ctx context.Context, obj client.Object) []c
 	list := new(v1alpha1.PIMList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list PIMs")
 		return nil

--- a/internal/controller/core/prefixset_controller.go
+++ b/internal/controller/core/prefixset_controller.go
@@ -231,16 +231,13 @@ func (r *PrefixSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues PrefixSets for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToPrefixSets),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -319,7 +316,7 @@ func (r *PrefixSetReconciler) finalize(ctx context.Context, s *prefixSetScope) (
 }
 
 // deviceToPrefixSets is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for PrefixSets when their referenced Device's Paused spec field changes.
+// for PrefixSets when their referenced Device's effective pause state changes.
 func (r *PrefixSetReconciler) deviceToPrefixSets(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/prefixset_controller.go
+++ b/internal/controller/core/prefixset_controller.go
@@ -202,7 +202,7 @@ func (r *PrefixSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PrefixSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PrefixSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *PrefixSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.PrefixSet{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.PrefixSet)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -328,7 +335,7 @@ func (r *PrefixSetReconciler) deviceToPrefixSets(ctx context.Context, obj client
 	list := new(v1alpha1.PrefixSetList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list PrefixSets")
 		return nil

--- a/internal/controller/core/routingpolicy_controller.go
+++ b/internal/controller/core/routingpolicy_controller.go
@@ -228,6 +228,13 @@ func (r *RoutingPolicyReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		return err
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.RoutingPolicy{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.RoutingPolicy)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.RoutingPolicy{}).
 		Named("routingpolicy").
@@ -456,7 +463,7 @@ func (r *RoutingPolicyReconciler) deviceToRoutingPolicies(ctx context.Context, o
 	list := new(v1alpha1.RoutingPolicyList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list RoutingPolicies")
 		return nil

--- a/internal/controller/core/routingpolicy_controller.go
+++ b/internal/controller/core/routingpolicy_controller.go
@@ -260,16 +260,13 @@ func (r *RoutingPolicyReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			}),
 		).
 		// Watches enqueues RoutingPolicies for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToRoutingPolicies),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -447,7 +444,7 @@ func (r *RoutingPolicyReconciler) prefixSetToRoutingPolicy(ctx context.Context, 
 }
 
 // deviceToRoutingPolicies is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for RoutingPolicies when their referenced Device's Paused spec field changes.
+// for RoutingPolicies when their referenced Device's effective pause state changes.
 func (r *RoutingPolicyReconciler) deviceToRoutingPolicies(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/snmp_controller.go
+++ b/internal/controller/core/snmp_controller.go
@@ -202,7 +202,7 @@ func (r *SNMPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *SNMPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *SNMPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *SNMPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.SNMP{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.SNMP)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -321,7 +328,7 @@ func (r *SNMPReconciler) deviceToSNMPs(ctx context.Context, obj client.Object) [
 	list := new(v1alpha1.SNMPList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list SNMPs")
 		return nil

--- a/internal/controller/core/snmp_controller.go
+++ b/internal/controller/core/snmp_controller.go
@@ -231,16 +231,13 @@ func (r *SNMPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues SNMPs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToSNMPs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -312,7 +309,7 @@ func (r *SNMPReconciler) finalize(ctx context.Context, s *snmpScope) (reterr err
 }
 
 // deviceToSNMPs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for SNMPs when their referenced Device's Paused spec field changes.
+// for SNMPs when their referenced Device's effective pause state changes.
 func (r *SNMPReconciler) deviceToSNMPs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&UserReconciler{
@@ -149,7 +149,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&DNSReconciler{
@@ -158,7 +158,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&NTPReconciler{
@@ -167,7 +167,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&AccessControlListReconciler{
@@ -176,7 +176,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&CertificateReconciler{
@@ -185,7 +185,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&SNMPReconciler{
@@ -194,7 +194,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&SyslogReconciler{
@@ -203,7 +203,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&ManagementAccessReconciler{
@@ -212,7 +212,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&ISISReconciler{
@@ -222,7 +222,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&VRFReconciler{
@@ -232,7 +232,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&PIMReconciler{
@@ -242,7 +242,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&BGPReconciler{
@@ -252,7 +252,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&BGPPeerReconciler{
@@ -262,7 +262,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&OSPFReconciler{
@@ -272,7 +272,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&VLANReconciler{
@@ -282,7 +282,7 @@ var _ = BeforeSuite(func() {
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&EVPNInstanceReconciler{
@@ -310,7 +310,7 @@ var _ = BeforeSuite(func() {
 		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&RoutingPolicyReconciler{

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -116,11 +116,11 @@ var _ = BeforeSuite(func() {
 	prov := func() provider.Provider { return testProvider }
 
 	err = (&DeviceReconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
-		Provider:        prov,
-		RequeueInterval: time.Second,
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		Recorder:          recorder,
+		Provider:          prov,
+		HeartbeatInterval: time.Second,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -417,6 +417,8 @@ var (
 type Provider struct {
 	sync.Mutex
 
+	ConnectError error // if non-nil, Connect returns this error
+
 	Ports           sets.Set[string]
 	User            sets.Set[string]
 	PreLoginBanner  *string
@@ -460,7 +462,19 @@ func NewProvider() *Provider {
 	}
 }
 
-func (p *Provider) Connect(context.Context, *deviceutil.Connection) error    { return nil }
+// SetConnectError sets the error that Connect will return on subsequent calls.
+// Pass nil to clear the error and allow connections to succeed.
+func (p *Provider) SetConnectError(err error) {
+	p.Lock()
+	defer p.Unlock()
+	p.ConnectError = err
+}
+
+func (p *Provider) Connect(_ context.Context, _ *deviceutil.Connection) error {
+	p.Lock()
+	defer p.Unlock()
+	return p.ConnectError
+}
 func (p *Provider) Disconnect(context.Context, *deviceutil.Connection) error { return nil }
 
 func (p *Provider) ListPorts(context.Context) (ports []provider.DevicePort, err error) {

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -417,7 +417,8 @@ var (
 type Provider struct {
 	sync.Mutex
 
-	ConnectError error // if non-nil, Connect returns this error
+	ConnectError   error // if non-nil, Connect returns this error
+	LastRebootTime time.Time
 
 	Ports           sets.Set[string]
 	User            sets.Set[string]
@@ -447,6 +448,7 @@ type Provider struct {
 
 func NewProvider() *Provider {
 	return &Provider{
+		LastRebootTime:  lastRebootTime,
 		Ports:           sets.New[string](),
 		User:            sets.New[string](),
 		ACLs:            sets.New[string](),
@@ -470,6 +472,13 @@ func (p *Provider) SetConnectError(err error) {
 	p.ConnectError = err
 }
 
+// SetLastRebootTime sets the time returned by GetLastRebootTime on subsequent calls.
+func (p *Provider) SetLastRebootTime(t time.Time) {
+	p.Lock()
+	defer p.Unlock()
+	p.LastRebootTime = t
+}
+
 func (p *Provider) Connect(_ context.Context, _ *deviceutil.Connection) error {
 	p.Lock()
 	defer p.Unlock()
@@ -489,13 +498,18 @@ func (p *Provider) ListPorts(context.Context) (ports []provider.DevicePort, err 
 	return
 }
 
+func (p *Provider) GetLastRebootTime(_ context.Context) (time.Time, error) {
+	p.Lock()
+	defer p.Unlock()
+	return p.LastRebootTime, nil
+}
+
 func (p *Provider) GetDeviceInfo(context.Context) (*provider.DeviceInfo, error) {
 	return &provider.DeviceInfo{
 		Manufacturer:    "Manufacturer",
 		Model:           "Model",
 		SerialNumber:    "123456789",
 		FirmwareVersion: "1.0.0",
-		LastRebootTime:  lastRebootTime,
 	}, nil
 }
 

--- a/internal/controller/core/syslog_controller.go
+++ b/internal/controller/core/syslog_controller.go
@@ -231,16 +231,13 @@ func (r *SyslogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues Syslogs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToSyslogs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -316,7 +313,7 @@ func (r *SyslogReconciler) finalize(ctx context.Context, s *syslogScope) (reterr
 }
 
 // deviceToSyslogs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for Syslogs when their referenced Device's Paused spec field changes.
+// for Syslogs when their referenced Device's effective pause state changes.
 func (r *SyslogReconciler) deviceToSyslogs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/syslog_controller.go
+++ b/internal/controller/core/syslog_controller.go
@@ -202,7 +202,7 @@ func (r *SyslogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *SyslogReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *SyslogReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -211,6 +211,13 @@ func (r *SyslogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Syslog{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.Syslog)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -325,7 +332,7 @@ func (r *SyslogReconciler) deviceToSyslogs(ctx context.Context, obj client.Objec
 	list := new(v1alpha1.SyslogList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list Syslogs")
 		return nil

--- a/internal/controller/core/user_controller.go
+++ b/internal/controller/core/user_controller.go
@@ -205,7 +205,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *UserReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -214,6 +214,13 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.User{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.User)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -397,7 +404,7 @@ func (r *UserReconciler) deviceToUsers(ctx context.Context, obj client.Object) [
 	list := new(v1alpha1.UserList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list Users")
 		return nil

--- a/internal/controller/core/user_controller.go
+++ b/internal/controller/core/user_controller.go
@@ -240,16 +240,13 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		// Watches enqueues Users for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToUsers),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -388,7 +385,7 @@ func (r *UserReconciler) secretToUser(ctx context.Context, obj client.Object) []
 }
 
 // deviceToUsers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for Users when their referenced Device's Paused spec field changes.
+// for Users when their referenced Device's effective pause state changes.
 func (r *UserReconciler) deviceToUsers(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/vlan_controller.go
+++ b/internal/controller/core/vlan_controller.go
@@ -207,7 +207,7 @@ func (r *VLANReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *VLANReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VLANReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -220,6 +220,13 @@ func (r *VLANReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.VLAN{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.VLAN)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -354,7 +361,7 @@ func (r *VLANReconciler) deviceToVLANs(ctx context.Context, obj client.Object) [
 	list := new(v1alpha1.VLANList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list VLANs")
 		return nil

--- a/internal/controller/core/vlan_controller.go
+++ b/internal/controller/core/vlan_controller.go
@@ -240,16 +240,13 @@ func (r *VLANReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues VLANs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToVLANs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -345,7 +342,7 @@ func (r *VLANReconciler) finalize(ctx context.Context, s *vlanScope) (reterr err
 }
 
 // deviceToVLANs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for VLANs when their referenced Device's Paused spec field changes.
+// for VLANs when their referenced Device's effective pause state changes.
 func (r *VLANReconciler) deviceToVLANs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/vrf_controller.go
+++ b/internal/controller/core/vrf_controller.go
@@ -292,16 +292,13 @@ func (r *VRFReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return bldr.
 		// Watches enqueues VRFs for updates in referenced Device resources.
-		// Triggers on create, delete, and update events when the Paused spec field changes.
+		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
 			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToVRFs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldDevice := e.ObjectOld.(*v1alpha1.Device)
-					newDevice := e.ObjectNew.(*v1alpha1.Device)
-					// Only trigger when Paused spec field changes.
-					return oldDevice.Spec.Paused != newDevice.Spec.Paused
+					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -328,7 +325,7 @@ func (r *VRFReconciler) finalize(ctx context.Context, s *vrfScope) (reterr error
 }
 
 // deviceToVRFs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for VRFs when their referenced Device's Paused spec field changes.
+// for VRFs when their referenced Device's effective pause state changes.
 func (r *VRFReconciler) deviceToVRFs(ctx context.Context, obj client.Object) []ctrl.Request {
 	device, ok := obj.(*v1alpha1.Device)
 	if !ok {

--- a/internal/controller/core/vrf_controller.go
+++ b/internal/controller/core/vrf_controller.go
@@ -259,7 +259,7 @@ func (r *VRFReconciler) reconcile(ctx context.Context, s *vrfScope) (_ ctrl.Resu
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *VRFReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VRFReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if r.RequeueInterval == 0 {
 		return errors.New("requeue interval must not be 0")
 	}
@@ -272,6 +272,13 @@ func (r *VRFReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.VRF{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.VRF)
+		return []string{o.Spec.DeviceRef.Name}
+	}); err != nil {
+		return err
 	}
 
 	bldr := ctrl.NewControllerManagedBy(mgr).
@@ -337,7 +344,7 @@ func (r *VRFReconciler) deviceToVRFs(ctx context.Context, obj client.Object) []c
 	list := new(v1alpha1.VRFList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list VRFs")
 		return nil

--- a/internal/paused/paused.go
+++ b/internal/paused/paused.go
@@ -69,8 +69,11 @@ func EnsureCondition(ctx context.Context, c client.Client, device *v1alpha1.Devi
 	return isPaused, true, nil
 }
 
-// computeCondition builds the Paused condition based on [v1alpha1.Device.Spec.Paused]
-// and the presence of the [v1alpha1.PausedAnnotation] on the object.
+// computeCondition builds the Paused condition. A resource is paused when
+// any of the following apply (in priority order):
+//  1. device.spec.paused is true
+//  2. device's Reachable condition is not true (child resources only)
+//  3. the object carries [v1alpha1.PausedAnnotation]
 func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 	condition := metav1.Condition{
 		Type:               v1alpha1.PausedCondition,
@@ -79,11 +82,25 @@ func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 		ObservedGeneration: obj.GetGeneration(),
 	}
 
-	if device != nil && device.Spec.Paused {
-		condition.Status = metav1.ConditionTrue
-		condition.Reason = v1alpha1.PausedReason
-		condition.Message = "Device spec.paused is set to true"
-		return condition
+	if device != nil {
+		if device.Spec.Paused {
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = v1alpha1.PausedReason
+			condition.Message = "Device spec.paused is set to true"
+			return condition
+		}
+		// Phase and reachability checks only apply to child resources
+		// (device != obj). The device itself must not pause due to its
+		// own reachability — it needs to keep reconciling to set the
+		// Reachable condition.
+		if device != obj {
+			if cond := conditions.Get(device, v1alpha1.ReachableCondition); cond != nil && cond.Status != metav1.ConditionTrue {
+				condition.Status = metav1.ConditionTrue
+				condition.Reason = v1alpha1.PausedReason
+				condition.Message = "Device is not reachable: " + cond.Message
+				return condition
+			}
+		}
 	}
 
 	if _, ok := obj.GetAnnotations()[v1alpha1.PausedAnnotation]; ok {
@@ -93,4 +110,23 @@ func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 	}
 
 	return condition
+}
+
+// DevicePausedChanged reports whether the device's effective pause state changed
+// between the old and new object versions. It returns true when spec.paused
+// flipped or when the Reachable condition status changed, since both affect
+// whether child resources are paused.
+//
+// The effective pause state is determined by [computeCondition].
+func DevicePausedChanged(oldObj, newObj client.Object) bool {
+	oldDevice := oldObj.(*v1alpha1.Device)
+	newDevice := newObj.(*v1alpha1.Device)
+	if oldDevice.Spec.Paused != newDevice.Spec.Paused {
+		return true
+	}
+	oldReachable := conditions.Get(oldDevice, v1alpha1.ReachableCondition)
+	newReachable := conditions.Get(newDevice, v1alpha1.ReachableCondition)
+	oldUnreachable := oldReachable != nil && oldReachable.Status != metav1.ConditionTrue
+	newUnreachable := newReachable != nil && newReachable.Status != metav1.ConditionTrue
+	return oldUnreachable != newUnreachable
 }

--- a/internal/paused/paused.go
+++ b/internal/paused/paused.go
@@ -72,8 +72,9 @@ func EnsureCondition(ctx context.Context, c client.Client, device *v1alpha1.Devi
 // computeCondition builds the Paused condition. A resource is paused when
 // any of the following apply (in priority order):
 //  1. device.spec.paused is true
-//  2. device's Reachable condition is not true (child resources only)
-//  3. the object carries [v1alpha1.PausedAnnotation]
+//  2. device.status.phase is not Running (child resources only)
+//  3. device's Reachable condition is not true (child resources only)
+//  4. the object carries [v1alpha1.PausedAnnotation]
 func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 	condition := metav1.Condition{
 		Type:               v1alpha1.PausedCondition,
@@ -91,9 +92,15 @@ func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 		}
 		// Phase and reachability checks only apply to child resources
 		// (device != obj). The device itself must not pause due to its
-		// own reachability — it needs to keep reconciling to set the
-		// Reachable condition.
+		// own phase or reachability — it needs to keep reconciling to
+		// reach Running and to set the Reachable condition.
 		if device != obj {
+			if device.Status.Phase != "" && device.Status.Phase != v1alpha1.DevicePhaseRunning {
+				condition.Status = metav1.ConditionTrue
+				condition.Reason = v1alpha1.PausedReason
+				condition.Message = "Device is not in phase Running"
+				return condition
+			}
 			if cond := conditions.Get(device, v1alpha1.ReachableCondition); cond != nil && cond.Status != metav1.ConditionTrue {
 				condition.Status = metav1.ConditionTrue
 				condition.Reason = v1alpha1.PausedReason
@@ -113,15 +120,17 @@ func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 }
 
 // DevicePausedChanged reports whether the device's effective pause state changed
-// between the old and new object versions. It returns true when spec.paused
-// flipped or when the Reachable condition status changed, since both affect
-// whether child resources are paused.
-//
-// The effective pause state is determined by [computeCondition].
+// between the old and new object versions. The effective pause state is
+// determined by [computeCondition].
 func DevicePausedChanged(oldObj, newObj client.Object) bool {
 	oldDevice := oldObj.(*v1alpha1.Device)
 	newDevice := newObj.(*v1alpha1.Device)
 	if oldDevice.Spec.Paused != newDevice.Spec.Paused {
+		return true
+	}
+	oldPhasePaused := oldDevice.Status.Phase != "" && oldDevice.Status.Phase != v1alpha1.DevicePhaseRunning
+	newPhasePaused := newDevice.Status.Phase != "" && newDevice.Status.Phase != v1alpha1.DevicePhaseRunning
+	if oldPhasePaused != newPhasePaused {
 		return true
 	}
 	oldReachable := conditions.Get(oldDevice, v1alpha1.ReachableCondition)

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -196,8 +196,7 @@ func (p *Provider) GetDeviceInfo(ctx context.Context) (*provider.DeviceInfo, err
 	m := new(Model)
 	s := new(SerialNumber)
 	fw := new(FirmwareVersion)
-	bt := new(BootTime)
-	if err := p.client.GetState(ctx, m, s, fw, bt); err != nil {
+	if err := p.client.GetState(ctx, m, s, fw); err != nil {
 		return nil, err
 	}
 
@@ -206,8 +205,15 @@ func (p *Provider) GetDeviceInfo(ctx context.Context) (*provider.DeviceInfo, err
 		Model:           string(*m),
 		SerialNumber:    string(*s),
 		FirmwareVersion: string(*fw),
-		LastRebootTime:  bt.Time,
 	}, nil
+}
+
+func (p *Provider) GetLastRebootTime(ctx context.Context) (time.Time, error) {
+	bt := new(BootTime)
+	if err := p.client.GetState(ctx, bt); err != nil {
+		return time.Time{}, err
+	}
+	return bt.Time, nil
 }
 
 func (p *Provider) EnsureACL(ctx context.Context, req *provider.EnsureACLRequest) error {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -35,6 +35,8 @@ type DeviceProvider interface {
 	// GetDeviceInfo retrieves basic information about the device,
 	// such as manufacturer, model, serial number, and firmware version.
 	GetDeviceInfo(context.Context) (*DeviceInfo, error)
+	// GetLastRebootTime retrieves the timestamp of the last device reboot.
+	GetLastRebootTime(context.Context) (time.Time, error)
 	// Reboot initiates a reboot of the device.
 	Reboot(context.Context, *deviceutil.Connection) error
 	// FactoryReset performs a factory reset of the device.
@@ -71,8 +73,6 @@ type DeviceInfo struct {
 	SerialNumber string
 	// FirmwareVersion is the firmware version running on the device, e.g. "10.4(3)".
 	FirmwareVersion string
-	// LastRebootTime is the timestamp of the last reboot of the device.
-	LastRebootTime time.Time
 }
 
 // InterfaceProvider is the interface for the realization of the Interface objects over different providers.

--- a/internal/provisioning/http.go
+++ b/internal/provisioning/http.go
@@ -432,7 +432,7 @@ func (s *HTTPServer) GetDeviceCertificate(w http.ResponseWriter, r *http.Request
 	c := clientutil.NewClient(s.Client, device.Namespace)
 
 	certList := v1alpha1.CertificateList{}
-	if err = c.List(ctx, &certList, client.InNamespace(device.Namespace), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name}); err != nil {
+	if err = c.List(ctx, &certList, client.InNamespace(device.Namespace), client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name}); err != nil {
 		s.Logger.Error(err, "Failed to list certificates", "device", device.Name)
 		http.Error(w, "Failed to list certificates", http.StatusInternalServerError)
 		return

--- a/internal/provisioning/http_test.go
+++ b/internal/provisioning/http_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
@@ -644,6 +645,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Labels:    map[string]string{v1alpha1.DeviceLabel: "test-device"},
 					},
 					Spec: v1alpha1.CertificateSpec{
+						DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
 						SecretRef: v1alpha1.SecretReference{Name: "test-device-cert-secret-1"},
 					},
 				},
@@ -654,6 +656,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Labels:    map[string]string{v1alpha1.DeviceLabel: "test-device"},
 					},
 					Spec: v1alpha1.CertificateSpec{
+						DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
 						SecretRef: v1alpha1.SecretReference{Name: "test-device-cert-secret-2"},
 					},
 				},
@@ -685,6 +688,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Labels:    map[string]string{v1alpha1.DeviceLabel: "test-device"},
 					},
 					Spec: v1alpha1.CertificateSpec{
+						DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
 						SecretRef: v1alpha1.SecretReference{Name: "nonexistent-secret"},
 					},
 				},
@@ -716,6 +720,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Labels:    map[string]string{v1alpha1.DeviceLabel: "test-device"},
 					},
 					Spec: v1alpha1.CertificateSpec{
+						DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
 						SecretRef: v1alpha1.SecretReference{Name: "test-device-cert-secret"},
 					},
 				},
@@ -759,6 +764,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Labels:    map[string]string{v1alpha1.DeviceLabel: "test-device"},
 					},
 					Spec: v1alpha1.CertificateSpec{
+						DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
 						SecretRef: v1alpha1.SecretReference{Name: "test-device-cert-secret"},
 					},
 				},
@@ -808,6 +814,7 @@ func TestGetDeviceCertificate(t *testing.T) {
 						Labels:    map[string]string{v1alpha1.DeviceLabel: "test-device"},
 					},
 					Spec: v1alpha1.CertificateSpec{
+						DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
 						SecretRef: v1alpha1.SecretReference{Name: "test-device-cert-secret"},
 					},
 				},
@@ -846,7 +853,11 @@ func TestGetDeviceCertificate(t *testing.T) {
 				req.Header.Set("Authorization", tt.authorization)
 			}
 
-			clientBuilder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			clientBuilder := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithIndex(&v1alpha1.Certificate{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+					return []string{obj.(*v1alpha1.Certificate).Spec.DeviceRef.Name}
+				})
 			if tt.device != nil {
 				clientBuilder.WithObjects(tt.device).WithStatusSubresource(tt.device)
 			}


### PR DESCRIPTION
#### Summary

 - Introduce a dedicated Reachable condition on the Device that tracks connectivity independently from Ready. When the controller cannot connect, Reachable=False and Ready=Unknown (per K8s API conventions: state is unobservable, not definitively unhealthy). A HeartbeatInterval flag governs periodic requeuing.
 - Extend computeCondition in internal/paused to pause child resources when the device is unreachable (Reachable != True) or not in the Running phase, in addition to the existing spec.paused check.
 - Update all Device watch predicates across the resource controllers to use a new DevicePausedChanged helper, so child resources are paused promptly on reachability or phase changes rather than waiting for the next periodic requeue.
