### PR TITLE
Fix inverted provisioning timeout check in device controller

### DIFF
--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -159,7 +159,7 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 			log.Info("Device has not made a provisioning request yet")
 			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
-		if activeProv.StartTime.Add(time.Hour).After(time.Now()) {
+		if activeProv.StartTime.Add(time.Hour).Before(time.Now()) {
 			obj.Status.Phase = v1alpha1.DevicePhaseFailed
 			r.Recorder.Eventf(obj, nil, "Warning", "ProvisioningFailed", "Reconcile", "Device provisioning has timed out")
 			return ctrl.Result{}, nil

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -16,74 +16,6 @@ import (
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 )
 
-func drainRecordedEvents() {
-	if testRecorder == nil {
-		return
-	}
-
-	for {
-		select {
-		case <-testRecorder.Events:
-		default:
-			return
-		}
-	}
-}
-
-func waitForRecordedEvent(expected string) {
-	Eventually(func(g Gomega) string {
-		select {
-		case event := <-testRecorder.Events:
-			return event
-		default:
-			return ""
-		}
-	}).Should(ContainSubstring(expected))
-}
-
-func setActiveProvisioningEntry(key client.ObjectKey, startTime time.Time) {
-	Eventually(func(g Gomega) {
-		resource := &v1alpha1.Device{}
-		g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
-
-		patch := resource.DeepCopy()
-		patch.Status.Phase = v1alpha1.DevicePhaseProvisioning
-		patch.Status.Provisioning = []v1alpha1.ProvisioningInfo{{
-			Token:     "test-token",
-			StartTime: metav1.NewTime(startTime),
-		}}
-
-		g.Expect(k8sClient.Status().Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
-	}).Should(Succeed())
-}
-
-func newProvisioningDevice(name string) *v1alpha1.Device {
-	return &v1alpha1.Device{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: metav1.NamespaceDefault,
-		},
-		Spec: v1alpha1.DeviceSpec{
-			Endpoint: v1alpha1.Endpoint{
-				Address: "192.168.10.2:9339",
-				SecretRef: &v1alpha1.SecretReference{
-					Name: name,
-				},
-			},
-			Provisioning: &v1alpha1.Provisioning{
-				Image: v1alpha1.Image{
-					URL:          "http://example.com/nxos.bin",
-					Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
-					ChecksumType: v1alpha1.ChecksumTypeMD5,
-				},
-				BootScript: v1alpha1.TemplateSource{
-					Inline: new("boot nxos.bin"),
-				},
-			},
-		},
-	}
-}
-
 var _ = Describe("Device Controller", func() {
 	Context("When reconciling a resource", func() {
 		var (
@@ -211,7 +143,30 @@ var _ = Describe("Device Controller", func() {
 
 		It("Should transition from Pending to Provisioning when provisioning is configured", func() {
 			By("Creating the custom resource for the Kind Device")
-			device := newProvisioningDevice(name)
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+					Provisioning: &v1alpha1.Provisioning{
+						Image: v1alpha1.Image{
+							URL:          "http://example.com/nxos.bin",
+							Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
+							ChecksumType: v1alpha1.ChecksumTypeMD5,
+						},
+						BootScript: v1alpha1.TemplateSource{
+							Inline: new("boot nxos.bin"),
+						},
+					},
+				},
+			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 
 			By("Verifying the device transitions to Provisioning phase")
@@ -230,7 +185,30 @@ var _ = Describe("Device Controller", func() {
 
 		It("Should keep the device provisioning before timeout", func() {
 			By("Creating the custom resource for the Kind Device")
-			device := newProvisioningDevice(name)
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+					Provisioning: &v1alpha1.Provisioning{
+						Image: v1alpha1.Image{
+							URL:          "http://example.com/nxos.bin",
+							Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
+							ChecksumType: v1alpha1.ChecksumTypeMD5,
+						},
+						BootScript: v1alpha1.TemplateSource{
+							Inline: new("boot nxos.bin"),
+						},
+					},
+				},
+			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 
 			By("Waiting for the device to enter provisioning")
@@ -240,8 +218,19 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
 			}).Should(Succeed())
 
-			drainRecordedEvents()
-			setActiveProvisioningEntry(key, time.Now().Add(-59*time.Minute))
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+
+				patch := resource.DeepCopy()
+				patch.Status.Phase = v1alpha1.DevicePhaseProvisioning
+				patch.Status.Provisioning = []v1alpha1.ProvisioningInfo{{
+					Token:     "test-token",
+					StartTime: metav1.NewTime(time.Now().Add(-59 * time.Minute)),
+				}}
+
+				g.Expect(k8sClient.Status().Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
+			}).Should(Succeed())
 
 			By("Verifying the device stays in provisioning phase")
 			Consistently(func(g Gomega) v1alpha1.DevicePhase {
@@ -249,21 +238,34 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				return resource.Status.Phase
 			}, time.Second, 100*time.Millisecond).Should(Equal(v1alpha1.DevicePhaseProvisioning))
-
-			By("Verifying no timeout event is emitted")
-			Consistently(func() string {
-				select {
-				case event := <-testRecorder.Events:
-					return event
-				default:
-					return ""
-				}
-			}, time.Second, 100*time.Millisecond).Should(Equal(""))
 		})
 
 		It("Should fail provisioning after the timeout threshold", func() {
 			By("Creating the custom resource for the Kind Device")
-			device := newProvisioningDevice(name)
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+					Provisioning: &v1alpha1.Provisioning{
+						Image: v1alpha1.Image{
+							URL:          "http://example.com/nxos.bin",
+							Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
+							ChecksumType: v1alpha1.ChecksumTypeMD5,
+						},
+						BootScript: v1alpha1.TemplateSource{
+							Inline: new("boot nxos.bin"),
+						},
+					},
+				},
+			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 
 			By("Waiting for the device to enter provisioning")
@@ -273,8 +275,19 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
 			}).Should(Succeed())
 
-			drainRecordedEvents()
-			setActiveProvisioningEntry(key, time.Now().Add(-61*time.Minute))
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+
+				patch := resource.DeepCopy()
+				patch.Status.Phase = v1alpha1.DevicePhaseProvisioning
+				patch.Status.Provisioning = []v1alpha1.ProvisioningInfo{{
+					Token:     "test-token",
+					StartTime: metav1.NewTime(time.Now().Add(-61 * time.Minute)),
+				}}
+
+				g.Expect(k8sClient.Status().Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
+			}).Should(Succeed())
 
 			By("Verifying the device transitions to Failed phase")
 			Eventually(func(g Gomega) {
@@ -282,9 +295,6 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseFailed))
 			}).Should(Succeed())
-
-			By("Verifying the timeout event is emitted")
-			waitForRecordedEvent("ProvisioningFailed")
 		})
 
 		It("Should keep an existing mismatched serial label", func() {

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -16,6 +16,74 @@ import (
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 )
 
+func drainRecordedEvents() {
+	if testRecorder == nil {
+		return
+	}
+
+	for {
+		select {
+		case <-testRecorder.Events:
+		default:
+			return
+		}
+	}
+}
+
+func waitForRecordedEvent(expected string) {
+	Eventually(func(g Gomega) string {
+		select {
+		case event := <-testRecorder.Events:
+			return event
+		default:
+			return ""
+		}
+	}).Should(ContainSubstring(expected))
+}
+
+func setActiveProvisioningEntry(key client.ObjectKey, startTime time.Time) {
+	Eventually(func(g Gomega) {
+		resource := &v1alpha1.Device{}
+		g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+
+		patch := resource.DeepCopy()
+		patch.Status.Phase = v1alpha1.DevicePhaseProvisioning
+		patch.Status.Provisioning = []v1alpha1.ProvisioningInfo{{
+			Token:     "test-token",
+			StartTime: metav1.NewTime(startTime),
+		}}
+
+		g.Expect(k8sClient.Status().Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
+	}).Should(Succeed())
+}
+
+func newProvisioningDevice(name string) *v1alpha1.Device {
+	return &v1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.DeviceSpec{
+			Endpoint: v1alpha1.Endpoint{
+				Address: "192.168.10.2:9339",
+				SecretRef: &v1alpha1.SecretReference{
+					Name: name,
+				},
+			},
+			Provisioning: &v1alpha1.Provisioning{
+				Image: v1alpha1.Image{
+					URL:          "http://example.com/nxos.bin",
+					Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
+					ChecksumType: v1alpha1.ChecksumTypeMD5,
+				},
+				BootScript: v1alpha1.TemplateSource{
+					Inline: new("boot nxos.bin"),
+				},
+			},
+		},
+	}
+}
+
 var _ = Describe("Device Controller", func() {
 	Context("When reconciling a resource", func() {
 		var (
@@ -143,30 +211,7 @@ var _ = Describe("Device Controller", func() {
 
 		It("Should transition from Pending to Provisioning when provisioning is configured", func() {
 			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
-				},
-				Spec: v1alpha1.DeviceSpec{
-					Endpoint: v1alpha1.Endpoint{
-						Address: "192.168.10.2:9339",
-						SecretRef: &v1alpha1.SecretReference{
-							Name: name,
-						},
-					},
-					Provisioning: &v1alpha1.Provisioning{
-						Image: v1alpha1.Image{
-							URL:          "http://example.com/nxos.bin",
-							Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
-							ChecksumType: v1alpha1.ChecksumTypeMD5,
-						},
-						BootScript: v1alpha1.TemplateSource{
-							Inline: new("boot nxos.bin"),
-						},
-					},
-				},
-			}
+			device := newProvisioningDevice(name)
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 
 			By("Verifying the device transitions to Provisioning phase")
@@ -181,6 +226,65 @@ var _ = Describe("Device Controller", func() {
 				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.PausedCondition))
 				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
 			}).Should(Succeed())
+		})
+
+		It("Should keep the device provisioning before timeout", func() {
+			By("Creating the custom resource for the Kind Device")
+			device := newProvisioningDevice(name)
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+
+			By("Waiting for the device to enter provisioning")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
+			}).Should(Succeed())
+
+			drainRecordedEvents()
+			setActiveProvisioningEntry(key, time.Now().Add(-59*time.Minute))
+
+			By("Verifying the device stays in provisioning phase")
+			Consistently(func(g Gomega) v1alpha1.DevicePhase {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				return resource.Status.Phase
+			}, time.Second, 100*time.Millisecond).Should(Equal(v1alpha1.DevicePhaseProvisioning))
+
+			By("Verifying no timeout event is emitted")
+			Consistently(func() string {
+				select {
+				case event := <-testRecorder.Events:
+					return event
+				default:
+					return ""
+				}
+			}, time.Second, 100*time.Millisecond).Should(Equal(""))
+		})
+
+		It("Should fail provisioning after the timeout threshold", func() {
+			By("Creating the custom resource for the Kind Device")
+			device := newProvisioningDevice(name)
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+
+			By("Waiting for the device to enter provisioning")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
+			}).Should(Succeed())
+
+			drainRecordedEvents()
+			setActiveProvisioningEntry(key, time.Now().Add(-61*time.Minute))
+
+			By("Verifying the device transitions to Failed phase")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseFailed))
+			}).Should(Succeed())
+
+			By("Verifying the timeout event is emitted")
+			waitForRecordedEvent("ProvisioningFailed")
 		})
 
 		It("Should keep an existing mismatched serial label", func() {

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -44,6 +44,7 @@ var (
 	testEnv      *envtest.Environment
 	k8sClient    client.Client
 	k8sManager   ctrl.Manager
+	testRecorder *events.FakeRecorder
 	testProvider = NewProvider()
 	testLocker   *resourcelock.ResourceLocker
 
@@ -92,12 +93,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	recorder := events.NewFakeRecorder(0)
-	go func() {
-		for event := range recorder.Events {
-			GinkgoLogr.Info("Event", "event", event)
-		}
-	}()
+	testRecorder = events.NewFakeRecorder(1000)
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -118,7 +114,7 @@ var _ = BeforeSuite(func() {
 	err = (&DeviceReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		RequeueInterval: time.Second,
 	}).SetupWithManager(k8sManager)
@@ -127,7 +123,7 @@ var _ = BeforeSuite(func() {
 	err = (&InterfaceReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -137,7 +133,7 @@ var _ = BeforeSuite(func() {
 	err = (&BannerReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -146,7 +142,7 @@ var _ = BeforeSuite(func() {
 	err = (&UserReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -155,7 +151,7 @@ var _ = BeforeSuite(func() {
 	err = (&DNSReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -164,7 +160,7 @@ var _ = BeforeSuite(func() {
 	err = (&NTPReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -173,7 +169,7 @@ var _ = BeforeSuite(func() {
 	err = (&AccessControlListReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -182,7 +178,7 @@ var _ = BeforeSuite(func() {
 	err = (&CertificateReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -191,7 +187,7 @@ var _ = BeforeSuite(func() {
 	err = (&SNMPReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -200,7 +196,7 @@ var _ = BeforeSuite(func() {
 	err = (&SyslogReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -209,7 +205,7 @@ var _ = BeforeSuite(func() {
 	err = (&ManagementAccessReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -218,7 +214,7 @@ var _ = BeforeSuite(func() {
 	err = (&ISISReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -228,7 +224,7 @@ var _ = BeforeSuite(func() {
 	err = (&VRFReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -238,7 +234,7 @@ var _ = BeforeSuite(func() {
 	err = (&PIMReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -248,7 +244,7 @@ var _ = BeforeSuite(func() {
 	err = (&BGPReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -258,7 +254,7 @@ var _ = BeforeSuite(func() {
 	err = (&BGPPeerReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -268,7 +264,7 @@ var _ = BeforeSuite(func() {
 	err = (&OSPFReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -278,7 +274,7 @@ var _ = BeforeSuite(func() {
 	err = (&VLANReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -288,7 +284,7 @@ var _ = BeforeSuite(func() {
 	err = (&EVPNInstanceReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
@@ -297,7 +293,7 @@ var _ = BeforeSuite(func() {
 	err = (&NetworkVirtualizationEdgeReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -307,7 +303,7 @@ var _ = BeforeSuite(func() {
 	err = (&PrefixSetReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -316,7 +312,7 @@ var _ = BeforeSuite(func() {
 	err = (&RoutingPolicyReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
+		Recorder: testRecorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
@@ -325,7 +321,7 @@ var _ = BeforeSuite(func() {
 	err = (&LLDPReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -335,7 +331,7 @@ var _ = BeforeSuite(func() {
 	err = (&DHCPRelayReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
+		Recorder:        testRecorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -44,7 +44,6 @@ var (
 	testEnv      *envtest.Environment
 	k8sClient    client.Client
 	k8sManager   ctrl.Manager
-	testRecorder *events.FakeRecorder
 	testProvider = NewProvider()
 	testLocker   *resourcelock.ResourceLocker
 
@@ -93,7 +92,12 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	testRecorder = events.NewFakeRecorder(1000)
+	recorder := events.NewFakeRecorder(0)
+	go func() {
+		for event := range recorder.Events {
+			GinkgoLogr.Info("Event", "event", event)
+		}
+	}()
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -114,7 +118,7 @@ var _ = BeforeSuite(func() {
 	err = (&DeviceReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		RequeueInterval: time.Second,
 	}).SetupWithManager(k8sManager)
@@ -123,7 +127,7 @@ var _ = BeforeSuite(func() {
 	err = (&InterfaceReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -133,7 +137,7 @@ var _ = BeforeSuite(func() {
 	err = (&BannerReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -142,7 +146,7 @@ var _ = BeforeSuite(func() {
 	err = (&UserReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -151,7 +155,7 @@ var _ = BeforeSuite(func() {
 	err = (&DNSReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -160,7 +164,7 @@ var _ = BeforeSuite(func() {
 	err = (&NTPReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -169,7 +173,7 @@ var _ = BeforeSuite(func() {
 	err = (&AccessControlListReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -178,7 +182,7 @@ var _ = BeforeSuite(func() {
 	err = (&CertificateReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -187,7 +191,7 @@ var _ = BeforeSuite(func() {
 	err = (&SNMPReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -196,7 +200,7 @@ var _ = BeforeSuite(func() {
 	err = (&SyslogReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -205,7 +209,7 @@ var _ = BeforeSuite(func() {
 	err = (&ManagementAccessReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -214,7 +218,7 @@ var _ = BeforeSuite(func() {
 	err = (&ISISReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -224,7 +228,7 @@ var _ = BeforeSuite(func() {
 	err = (&VRFReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -234,7 +238,7 @@ var _ = BeforeSuite(func() {
 	err = (&PIMReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -244,7 +248,7 @@ var _ = BeforeSuite(func() {
 	err = (&BGPReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -254,7 +258,7 @@ var _ = BeforeSuite(func() {
 	err = (&BGPPeerReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -264,7 +268,7 @@ var _ = BeforeSuite(func() {
 	err = (&OSPFReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -274,7 +278,7 @@ var _ = BeforeSuite(func() {
 	err = (&VLANReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -284,7 +288,7 @@ var _ = BeforeSuite(func() {
 	err = (&EVPNInstanceReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
@@ -293,7 +297,7 @@ var _ = BeforeSuite(func() {
 	err = (&NetworkVirtualizationEdgeReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -303,7 +307,7 @@ var _ = BeforeSuite(func() {
 	err = (&PrefixSetReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(k8sManager)
@@ -312,7 +316,7 @@ var _ = BeforeSuite(func() {
 	err = (&RoutingPolicyReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: testRecorder,
+		Recorder: recorder,
 		Provider: prov,
 		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
@@ -321,7 +325,7 @@ var _ = BeforeSuite(func() {
 	err = (&LLDPReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,
@@ -331,7 +335,7 @@ var _ = BeforeSuite(func() {
 	err = (&DHCPRelayReconciler{
 		Client:          k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
-		Recorder:        testRecorder,
+		Recorder:        recorder,
 		Provider:        prov,
 		Locker:          testLocker,
 		RequeueInterval: time.Second,


### PR DESCRIPTION
## Summary

This PR fixes an inverted timeout condition in the device controller provisioning flow.

Previously, the controller marked a device as failed when:

`activeProv.StartTime.Add(time.Hour).After(time.Now())`

That condition is true while the provisioning deadline is still in the future, which means the controller could fail provisioning before the timeout was actually reached.

This PR changes the logic so that provisioning only fails after the deadline has passed.

## Changes

- fix the timeout check in the provisioning reconcile path
- add boundary tests for:
  - provisioning still in progress before the 1 hour timeout
  - provisioning failing after the timeout threshold

## Why this is needed

Without this fix, a device can transition to `Failed` too early and emit a misleading `ProvisioningFailed` event even though the provisioning window has not expired yet.

## Validation

Validated locally with:
- `gofmt`
- `go test -run '^$' ./internal/controller/core`
- `go test ./internal/provisioning`