### PR TITLE
Include zz_generated files in Tilt docker build context

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -12,7 +12,7 @@ allow_k8s_contexts(['minikube', 'kind-network'])
 load('ext://cert_manager', 'deploy_cert_manager')
 deploy_cert_manager(version='v1.18.2')
 
-docker_build('ghcr.io/ironcore-dev/network-operator', '.', ignore=['**/*/zz_generated.deepcopy.go', 'config/crd/bases/*'], only=[
+docker_build('ghcr.io/ironcore-dev/network-operator', '.', ignore=['config/crd/bases/*'], only=[
     'api/', 'cmd/', 'hack/', 'internal/', 'go.mod', 'go.sum', 'Makefile',
 ])
 


### PR DESCRIPTION
Since 6107f1c6, the Dockerfile switched from a read-write bind mount running 'make install' (which generated the zz_generated.deepcopy.go files as part of the build) to a read-only bind mount running 'go build' directly. Generated files must therefore be present in the build context before the build starts.

The docker_build ignore list previously excluded all zz_generated.deepcopy.go files, causing the image build to fail with missing generated code. Remove them from docker_build's ignore list so Tilt includes them in the build context after controller-gen produces them via the local_resource step.

The local_resource ignore list retains the exclusion to prevent changes to generated files from re-triggering 'make generate' in a feedback loop.