### PR TITLE
Refactor controller reconcile signatures and add event-driven watches

### DIFF
--- a/api/cisco/nx/v1alpha1/vpcdomain_types.go
+++ b/api/cisco/nx/v1alpha1/vpcdomain_types.go
@@ -194,10 +194,12 @@ type VPCDomainStatus struct {
 
 	// Role indicates the current operational role of this vPC domain peer.
 	// +optional
+	// +kubebuilder:default=Unknown
 	Role VPCDomainRole `json:"role,omitempty"`
 
 	// KeepAliveStatus indicates the status of the peer via the keepalive link.
 	// +optional
+	// +kubebuilder:default=Unknown
 	KeepAliveStatus Status `json:"keepaliveStatus,omitempty"`
 
 	// KeepAliveStatusMsg provides additional information about the keepalive status, a list of strings reported by the device.
@@ -208,6 +210,7 @@ type VPCDomainStatus struct {
 	// the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status
 	// will remain unchanged (with the value of the last check).
 	// +optional
+	// +kubebuilder:default=Unknown
 	PeerStatus Status `json:"peerStatus,omitempty"`
 
 	// PeerStatusMsg provides additional information about the peer status, a list of strings reported by the device.
@@ -224,7 +227,20 @@ type VPCDomainStatus struct {
 
 	// PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`.
 	// +optional
+	// +kubebuilder:default=Unknown
 	PeerLinkIfOperStatus Status `json:"peerLinkIfOperStatus,omitempty"`
+}
+
+// Reset resets fields of the VPCDomainStatus to their default value.
+// This is used in the case where the controller failed to determine the status of the vPC domain.
+func (s *VPCDomainStatus) Reset() {
+	s.Role = VPCDomainRoleUnknown
+	s.KeepAliveStatus = StatusUnknown
+	s.KeepAliveStatusMsg = nil
+	s.PeerStatus = StatusUnknown
+	s.PeerStatusMsg = nil
+	s.PeerUptime = metav1.Duration{}
+	s.PeerLinkIfOperStatus = StatusUnknown
 }
 
 // The VPCDomainRole type represents the operational role of a vPC domain peer as returned by the device.

--- a/charts/network-operator/templates/crd/vpcdomains.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/vpcdomains.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -406,6 +406,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               keepaliveStatus:
+                default: Unknown
                 description: KeepAliveStatus indicates the status of the peer via
                   the keepalive link.
                 type: string
@@ -420,9 +421,11 @@ spec:
                   domain peer-link.
                 type: string
               peerLinkIfOperStatus:
+                default: Unknown
                 description: PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`.
                 type: string
               peerStatus:
+                default: Unknown
                 description: |-
                   PeerStatus indicates the status of the vPC domain peer-link in the latest consistency check with the peer. This means that if
                   the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status
@@ -439,6 +442,7 @@ spec:
                   been up and reachable via keepalive.
                 type: string
               role:
+                default: Unknown
                 description: Role indicates the current operational role of this vPC
                   domain peer.
                 type: string

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -420,7 +420,6 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-		RequeueInterval:  requeueInterval,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ISIS")
 		os.Exit(1)
@@ -433,7 +432,6 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-		RequeueInterval:  requeueInterval,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PIM")
 		os.Exit(1)
@@ -511,7 +509,6 @@ func main() {
 		WatchFilterValue: watchFilterValue,
 		Provider:         prov,
 		Locker:           locker,
-		RequeueInterval:  requeueInterval,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VRF")
 		os.Exit(1)

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_vpcdomains.yaml
@@ -403,6 +403,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               keepaliveStatus:
+                default: Unknown
                 description: KeepAliveStatus indicates the status of the peer via
                   the keepalive link.
                 type: string
@@ -417,9 +418,11 @@ spec:
                   domain peer-link.
                 type: string
               peerLinkIfOperStatus:
+                default: Unknown
                 description: PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`.
                 type: string
               peerStatus:
+                default: Unknown
                 description: |-
                   PeerStatus indicates the status of the vPC domain peer-link in the latest consistency check with the peer. This means that if
                   the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status
@@ -436,6 +439,7 @@ spec:
                   been up and reachable via keepalive.
                 type: string
               role:
+                default: Unknown
                 description: Role indicates the current operational role of this vPC
                   domain peer.
                 type: string

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -3853,14 +3853,14 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#condition-v1-meta) array_ | Conditions represent the latest available observations about the vPCDomain state.<br />Standard conditions include:<br />- Ready: overall readiness of the vPC domain<br />- Configured: whether the vPCDomain configuration was successfully applied to the device<br />- Operational: whether the vPC domain is operationally up. This condition is true when<br />  the status fields `PeerLinkIfOperStatus`, `KeepAliveStatus`, and `PeerStatus` are all set<br />  to `UP`.<br />For this Cisco model there is not one single unique operational property that reflects the<br />operational status of the vPC domain. The combination of peer status, keepalive status, and<br />the interface used as peer-link determine the overall health and operational condition of<br />the vPC domain. |  | Optional: \{\} <br /> |
-| `role` _[VPCDomainRole](#vpcdomainrole)_ | Role indicates the current operational role of this vPC domain peer. |  | Optional: \{\} <br /> |
-| `keepaliveStatus` _[Status](#status)_ | KeepAliveStatus indicates the status of the peer via the keepalive link. |  | Optional: \{\} <br /> |
+| `role` _[VPCDomainRole](#vpcdomainrole)_ | Role indicates the current operational role of this vPC domain peer. | Unknown | Optional: \{\} <br /> |
+| `keepaliveStatus` _[Status](#status)_ | KeepAliveStatus indicates the status of the peer via the keepalive link. | Unknown | Optional: \{\} <br /> |
 | `keepaliveStatusMsg` _string array_ | KeepAliveStatusMsg provides additional information about the keepalive status, a list of strings reported by the device. |  | Optional: \{\} <br /> |
-| `peerStatus` _[Status](#status)_ | PeerStatus indicates the status of the vPC domain peer-link in the latest consistency check with the peer. This means that if<br />the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status<br />will remain unchanged (with the value of the last check). |  | Optional: \{\} <br /> |
+| `peerStatus` _[Status](#status)_ | PeerStatus indicates the status of the vPC domain peer-link in the latest consistency check with the peer. This means that if<br />the adjacency is lost, e.g., due to a shutdown link, the device will not be able to perform such check and the reported status<br />will remain unchanged (with the value of the last check). | Unknown | Optional: \{\} <br /> |
 | `peerStatusMsg` _string array_ | PeerStatusMsg provides additional information about the peer status, a list of strings reported by the device. |  | Optional: \{\} <br /> |
 | `peerUptime` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#duration-v1-meta)_ | PeerUptime indicates how long the vPC domain peer has been up and reachable via keepalive. |  | Optional: \{\} <br /> |
 | `peerLinkIf` _string_ | PeerLinkIf is the name of the interface used as the vPC domain peer-link. |  | Optional: \{\} <br /> |
-| `peerLinkIfOperStatus` _[Status](#status)_ | PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`. |  | Optional: \{\} <br /> |
+| `peerLinkIfOperStatus` _[Status](#status)_ | PeerLinkIfOperStatus is the Operational status of `PeerLinkIf`. | Unknown | Optional: \{\} <br /> |
 
 
 

--- a/internal/controller/cisco/nx/vpcdomain_controller.go
+++ b/internal/controller/cisco/nx/vpcdomain_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -33,8 +32,8 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/provider"
 	"github.com/ironcore-dev/network-operator/internal/resourcelock"
 
-	nxv1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
-	corev1 "github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 	corecontroller "github.com/ironcore-dev/network-operator/internal/controller/core"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 )
@@ -62,18 +61,6 @@ type VPCDomainReconciler struct {
 	RequeueInterval time.Duration
 }
 
-// // scope holds the different objects that are read and used during the reconcile.
-type vpcdomainScope struct {
-	Device     *corev1.Device
-	VPCDomain  *nxv1.VPCDomain
-	Connection *deviceutil.Connection
-	Provider   Provider
-	// VRF is the VRF referenced in the KeepAlive configuration
-	VRF *corev1.VRF
-	// PeerLink is the port-channel interface referenced as the peer link
-	PeerLink *corev1.Interface
-}
-
 // +kubebuilder:rbac:groups=nx.cisco.networking.metal.ironcore.dev,resources=vpcdomains,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nx.cisco.networking.metal.ironcore.dev,resources=vpcdomains/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=nx.cisco.networking.metal.ironcore.dev,resources=vpcdomains/finalizers,verbs=update
@@ -85,15 +72,18 @@ type vpcdomainScope struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/reconcile
 func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	log := logf.FromContext(ctx)
+	log := ctrl.LoggerFrom(ctx)
 	log.V(3).Info("Reconciling resource")
 
-	obj := new(nxv1.VPCDomain)
+	obj := new(nxv1alpha1.VPCDomain)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.V(3).Info("VPCDomain resource not found. Ignoring since object must be deleted.")
+			// If the custom resource is not found then it usually means that it was deleted or not created
+			// In this way, we will stop the reconciliation
+			log.V(3).Info("Resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
+		// Error reading the object - requeue the request.
 		log.Error(err, "Failed to get resource")
 		return ctrl.Result{}, err
 	}
@@ -101,10 +91,10 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	prov, ok := r.Provider().(Provider)
 	if !ok {
 		meta.SetStatusCondition(&obj.Status.Conditions, metav1.Condition{
-			Type:    corev1.ReadyCondition,
+			Type:    v1alpha1.ReadyCondition,
 			Status:  metav1.ConditionFalse,
-			Reason:  corev1.NotImplementedReason,
-			Message: "Provider does not implement provider.VPCDomainProvider",
+			Reason:  v1alpha1.NotImplementedReason,
+			Message: "Invalid provider configured for VPCDomain reconciler",
 		})
 		return ctrl.Result{}, r.Status().Update(ctx, obj)
 	}
@@ -146,12 +136,12 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if !obj.DeletionTimestamp.IsZero() {
-		if controllerutil.ContainsFinalizer(obj, corev1.FinalizerName) {
+		if controllerutil.ContainsFinalizer(obj, v1alpha1.FinalizerName) {
 			if err := r.finalize(ctx, s); err != nil {
 				log.Error(err, "Failed to finalize resource")
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(obj, corev1.FinalizerName)
+			controllerutil.RemoveFinalizer(obj, v1alpha1.FinalizerName)
 			if err := r.Update(ctx, obj); err != nil {
 				log.Error(err, "Failed to remove finalizer from resource")
 				return ctrl.Result{}, err
@@ -161,8 +151,8 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
-	if !controllerutil.ContainsFinalizer(obj, corev1.FinalizerName) {
-		controllerutil.AddFinalizer(obj, corev1.FinalizerName)
+	if !controllerutil.ContainsFinalizer(obj, v1alpha1.FinalizerName) {
+		controllerutil.AddFinalizer(obj, v1alpha1.FinalizerName)
 		if err := r.Update(ctx, obj); err != nil {
 			log.Error(err, "Failed to add finalizer to resource")
 			return ctrl.Result{}, err
@@ -172,7 +162,7 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	orig := obj.DeepCopy()
-	if conditions.InitializeConditions(obj, corev1.ReadyCondition) {
+	if conditions.InitializeConditions(obj, v1alpha1.ReadyCondition) {
 		log.V(1).Info("Initializing status conditions")
 		return ctrl.Result{}, r.Status().Update(ctx, obj)
 	}
@@ -194,8 +184,7 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}()
 
-	err = r.reconcile(ctx, s)
-	if err != nil {
+	if err = r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
@@ -203,209 +192,13 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{RequeueAfter: corecontroller.Jitter(r.RequeueInterval)}, nil
 }
 
-// reconcile contains the main reconciliation logic for the VPCDomain resource.
-func (r *VPCDomainReconciler) reconcile(ctx context.Context, s *vpcdomainScope) (reterr error) {
-	if s.VPCDomain.Labels == nil {
-		s.VPCDomain.Labels = make(map[string]string)
-	}
-	s.VPCDomain.Labels[corev1.DeviceLabel] = s.Device.Name
-
-	// Ensure owner reference to device
-	if !controllerutil.HasControllerReference(s.VPCDomain) {
-		if err := controllerutil.SetOwnerReference(s.Device, s.VPCDomain, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return err
-		}
-	}
-
-	// Connect to remote device
-	var connErr error
-	if connErr = s.Provider.Connect(ctx, s.Connection); connErr != nil {
-		r.resetStatus(ctx, &s.VPCDomain.Status)
-		return kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to connect to provider: %w", connErr)})
-	}
-	defer func() {
-		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
-			reterr = kerrors.NewAggregate([]error{reterr, err})
-		}
-	}()
-
-	defer func() {
-		conditions.RecomputeReady(s.VPCDomain)
-	}()
-
-	// Reconcile referenced resources (validate and update vpcdomainScope)
-	if err := r.reconcilePeerLink(ctx, s); err != nil {
-		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to reconcile referenced resource: %w", err)})
-	}
-	if err := r.reconcileKeepAliveVRF(ctx, s); err != nil {
-		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to reconcile referenced resource: %w", err)})
-	}
-	if reterr != nil {
-		return reconcile.TerminalError(reterr)
-	}
-
-	//  Realize the vPC via the provider and update configuration status
-	err := s.Provider.EnsureVPCDomain(ctx, s.VPCDomain, s.VRF, s.PeerLink)
-	cond := conditions.FromError(err)
-	conditions.Set(s.VPCDomain, cond)
-	if err != nil {
-		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to reconcile resource: %w", err)})
-	}
-
-	// Retrieve and update status from the device, nil out on error
-	status, err := s.Provider.GetStatusVPCDomain(ctx)
-	if err != nil {
-		r.resetStatus(ctx, &s.VPCDomain.Status)
-		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to get resource status: %w", err)})
-	}
-
-	if reterr != nil {
-		return reterr
-	}
-
-	s.VPCDomain.Status.Role = status.Role
-
-	slices.Sort(status.KeepAliveStatusMsg)
-	s.VPCDomain.Status.KeepAliveStatusMsg = status.KeepAliveStatusMsg
-	s.VPCDomain.Status.KeepAliveStatus = nxv1.StatusDown
-	if status.KeepAliveStatus {
-		s.VPCDomain.Status.KeepAliveStatus = nxv1.StatusUp
-	}
-	slices.Sort(s.VPCDomain.Status.KeepAliveStatusMsg)
-	s.VPCDomain.Status.PeerStatusMsg = status.PeerStatusMsg
-	s.VPCDomain.Status.PeerStatus = nxv1.StatusDown
-	if status.PeerStatus {
-		s.VPCDomain.Status.PeerStatus = nxv1.StatusUp
-	}
-	s.VPCDomain.Status.PeerUptime = metav1.Duration{Duration: status.PeerUptime}
-
-	// Fetch the status of the port-channel forming the vPC's peer link
-	peerlinkOperSt := false
-	if s.PeerLink != nil {
-		s.VPCDomain.Status.PeerLinkIf = s.PeerLink.Spec.Name
-		if c := meta.FindStatusCondition(s.PeerLink.Status.Conditions, corev1.OperationalCondition); c != nil {
-			s.VPCDomain.Status.PeerLinkIfOperStatus = nxv1.StatusDown
-			if c.Status == metav1.ConditionTrue {
-				s.VPCDomain.Status.PeerLinkIfOperStatus = nxv1.StatusUp
-				peerlinkOperSt = true
-			}
-		}
-	}
-
-	cond = metav1.Condition{
-		Type:    corev1.OperationalCondition,
-		Status:  metav1.ConditionTrue,
-		Reason:  corev1.OperationalReason,
-		Message: "vPC domain is operational",
-	}
-	// See comment in this type's status definition for details on the operational condition.
-	if !status.PeerStatus || !status.KeepAliveStatus || !peerlinkOperSt {
-		cond = metav1.Condition{
-			Type:    corev1.OperationalCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  corev1.DegradedReason,
-			Message: "vPC domain is not fully operational. Either the peer-link interface is down, keepalive is not working, or the peer adjacency is not correctly formed.",
-		}
-	}
-	conditions.Set(s.VPCDomain, cond)
-
-	return reterr
-}
-
-// reconcilePeerLink checks that peer's interface reference exists and is of type Aggregate.
-// Updates the scope accordingly.
-// Ignores the interface status: Port-channels require the domain to be configured first.
-func (r *VPCDomainReconciler) reconcilePeerLink(ctx context.Context, s *vpcdomainScope) error {
-	intf := new(corev1.Interface)
-	intf.Name = s.VPCDomain.Spec.Peer.InterfaceRef.Name
-	intf.Namespace = s.VPCDomain.Namespace
-
-	if err := r.Get(ctx, client.ObjectKey{Name: intf.Name, Namespace: intf.Namespace}, intf); err != nil {
-		if apierrors.IsNotFound(err) {
-			conditions.Set(s.VPCDomain, metav1.Condition{
-				Type:    corev1.ConfiguredCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  corev1.WaitingForDependenciesReason,
-				Message: fmt.Sprintf("interface resource '%s' not found in namespace '%s'", intf.Name, intf.Namespace),
-			})
-			return fmt.Errorf("member interface %s not found", intf.Name)
-		}
-		return fmt.Errorf("failed to get member interface %q: %w", intf.Name, err)
-	}
-
-	if intf.Spec.Type != corev1.InterfaceTypeAggregate && intf.Spec.Type != corev1.InterfaceTypePhysical {
-		conditions.Set(s.VPCDomain, metav1.Condition{
-			Type:    corev1.ConfiguredCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  corev1.InvalidInterfaceTypeReason,
-			Message: fmt.Sprintf("interface referenced by '%s' must be of type %q or type %q", intf.Name, corev1.InterfaceTypeAggregate, corev1.InterfaceTypePhysical),
-		})
-		return fmt.Errorf("interface referenced by '%s' must be of type %q or type %q", intf.Name, corev1.InterfaceTypeAggregate, corev1.InterfaceTypePhysical)
-	}
-
-	if s.VPCDomain.Spec.DeviceRef.Name != intf.Spec.DeviceRef.Name {
-		conditions.Set(s.VPCDomain, metav1.Condition{
-			Type:    corev1.ConfiguredCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  corev1.CrossDeviceReferenceReason,
-			Message: fmt.Sprintf("interface '%s' deviceRef '%s' does not match vPC deviceRef '%s'", intf.Name, intf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name),
-		})
-		return fmt.Errorf("interface '%s' deviceRef '%s' does not match vPC deviceRef '%s'", intf.Name, intf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name)
-	}
-	s.PeerLink = intf
-	return nil
-}
-
-// reconcileKeepAliveVRF ensures that the referenced VRF resource exists
-// Updates the scope accordingly.
-func (r *VPCDomainReconciler) reconcileKeepAliveVRF(ctx context.Context, s *vpcdomainScope) error {
-	if s.VPCDomain.Spec.Peer.KeepAlive.VrfRef == nil {
-		return nil
-	}
-	vrf := new(corev1.VRF)
-	vrf.Name = s.VPCDomain.Spec.Peer.KeepAlive.VrfRef.Name
-	vrf.Namespace = s.VPCDomain.Namespace
-
-	if err := r.Get(ctx, client.ObjectKey{Name: vrf.Name, Namespace: vrf.Namespace}, vrf); err != nil {
-		if apierrors.IsNotFound(err) {
-			conditions.Set(s.VPCDomain, metav1.Condition{
-				Type:    corev1.ConfiguredCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  corev1.WaitingForDependenciesReason,
-				Message: fmt.Sprintf("VRF resource '%s' not found in namespace '%s'", vrf.Name, vrf.Namespace),
-			})
-			return fmt.Errorf("VRF %q not found", vrf.Name)
-		}
-		return fmt.Errorf("failed to get VRF %q: %w", vrf.Name, err)
-	}
-
-	if s.VPCDomain.Spec.DeviceRef.Name != vrf.Spec.DeviceRef.Name {
-		conditions.Set(s.VPCDomain, metav1.Condition{
-			Type:    corev1.ConfiguredCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  corev1.CrossDeviceReferenceReason,
-			Message: fmt.Sprintf("VRF '%s' deviceRef '%s' does not match VPCDomain deviceRef '%s'", vrf.Name, vrf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name),
-		})
-		return fmt.Errorf("VRF '%s' deviceRef '%s' does not match VPCDomain deviceRef '%s'", vrf.Name, vrf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name)
-	}
-
-	s.VRF = vrf
-	return nil
-}
-
-// resetStatus resets the status fields of the VPCDomain resource.
-func (r *VPCDomainReconciler) resetStatus(_ context.Context, s *nxv1.VPCDomainStatus) {
-	s.PeerStatus = nxv1.StatusUnknown
-	s.PeerStatusMsg = []string{}
-	s.Role = nxv1.VPCDomainRoleUnknown
-	s.PeerUptime = metav1.Duration{}
-}
+const vpcDomainPeerLinkRefKey = ".spec.peer.interfaceRef.name"
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VPCDomainReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
-		labelSelector.MatchLabels = map[string]string{corev1.WatchLabel: r.WatchFilterValue}
+		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
 	}
 
 	filter, err := predicate.LabelSelectorPredicate(labelSelector)
@@ -414,43 +207,37 @@ func (r *VPCDomainReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// Index vPCs by their peer interface reference
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1.VPCDomain{}, ".spec.peer.interfaceRef.name", func(obj client.Object) []string {
-		vpc := obj.(*nxv1.VPCDomain)
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1alpha1.VPCDomain{}, vpcDomainPeerLinkRefKey, func(obj client.Object) []string {
+		vpc := obj.(*nxv1alpha1.VPCDomain)
 		return []string{vpc.Spec.Peer.InterfaceRef.Name}
 	}); err != nil {
 		return err
 	}
 
 	// Index vPCs by their device reference
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1.VPCDomain{}, corev1.DeviceRefIndexKey, func(obj client.Object) []string {
-		vpc := obj.(*nxv1.VPCDomain)
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &nxv1alpha1.VPCDomain{}, v1alpha1.DeviceRefIndexKey, func(obj client.Object) []string {
+		vpc := obj.(*nxv1alpha1.VPCDomain)
 		return []string{vpc.Spec.DeviceRef.Name}
 	}); err != nil {
 		return err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nxv1.VPCDomain{}).
+		For(&nxv1alpha1.VPCDomain{}).
 		Named("vpcdomain").
 		WithEventFilter(filter).
 		// Trigger reconciliation for changes in the operational status of the referenced interface: The device can shut down the port-channel by itself
 		// in certain failure scenarios, e.g., incompatible configuration.
 		Watches(
-			&corev1.Interface{},
+			&v1alpha1.Interface{},
 			handler.EnqueueRequestsFromMapFunc(r.mapInterfaceToVPCDomain),
 			builder.WithPredicates(predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool {
-					iface := e.Object.(*corev1.Interface)
-					return iface.Spec.Type == corev1.InterfaceTypeAggregate || iface.Spec.Type == corev1.InterfaceTypePhysical
-				},
-				DeleteFunc: func(e event.DeleteEvent) bool {
-					iface := e.Object.(*corev1.Interface)
-					return iface.Spec.Type == corev1.InterfaceTypeAggregate || iface.Spec.Type == corev1.InterfaceTypePhysical
-				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					o := e.ObjectOld.(*corev1.Interface)
-					n := e.ObjectNew.(*corev1.Interface)
-					return (n.Spec.Type == corev1.InterfaceTypeAggregate || n.Spec.Type == corev1.InterfaceTypePhysical) && conditionChanged(o.Status.Conditions, n.Status.Conditions, corev1.OperationalCondition)
+					oldInterface := e.ObjectOld.(*v1alpha1.Interface)
+					newInterface := e.ObjectNew.(*v1alpha1.Interface)
+					oldOperational := conditions.Get(oldInterface, v1alpha1.OperationalCondition)
+					newOperational := conditions.Get(newInterface, v1alpha1.OperationalCondition)
+					return ((oldOperational == nil) != (newOperational == nil)) || (newOperational != nil && oldOperational.Status != newOperational.Status)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -460,7 +247,7 @@ func (r *VPCDomainReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		// Watches enqueues VPCDomains for updates in referenced Device resources.
 		// Triggers on create, delete, and update events when the device's effective pause state changes.
 		Watches(
-			&corev1.Device{},
+			&v1alpha1.Device{},
 			handler.EnqueueRequestsFromMapFunc(r.deviceToVPCDomains),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
@@ -474,30 +261,226 @@ func (r *VPCDomainReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		Complete(r)
 }
 
+// // scope holds the different objects that are read and used during the reconcile.
+type vpcdomainScope struct {
+	Device     *v1alpha1.Device
+	VPCDomain  *nxv1alpha1.VPCDomain
+	Connection *deviceutil.Connection
+	Provider   Provider
+}
+
+// reconcile contains the main reconciliation logic for the VPCDomain resource.
+func (r *VPCDomainReconciler) reconcile(ctx context.Context, s *vpcdomainScope) (reterr error) {
+	if s.VPCDomain.Labels == nil {
+		s.VPCDomain.Labels = make(map[string]string)
+	}
+	s.VPCDomain.Labels[v1alpha1.DeviceLabel] = s.Device.Name
+
+	// Ensure owner reference to device
+	if !controllerutil.HasControllerReference(s.VPCDomain) {
+		if err := controllerutil.SetOwnerReference(s.Device, s.VPCDomain, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+			return err
+		}
+	}
+
+	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
+		return fmt.Errorf("failed to connect to provider: %w", err)
+	}
+	defer func() {
+		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+	}()
+
+	defer func() {
+		conditions.RecomputeReady(s.VPCDomain)
+	}()
+
+	peerLink, err := r.reconcilePeerLink(ctx, s)
+	if err != nil {
+		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to reconcile referenced resource: %w", err)})
+	}
+
+	var vrf *v1alpha1.VRF
+	if s.VPCDomain.Spec.Peer.KeepAlive.VrfRef == nil {
+		vrf, err = r.reconcileKeepAliveVRF(ctx, s)
+		if err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to reconcile referenced resource: %w", err)})
+		}
+	}
+
+	if reterr != nil {
+		return reterr
+	}
+
+	//  Realize the vPC via the provider and update configuration status
+	err = s.Provider.EnsureVPCDomain(ctx, s.VPCDomain, vrf, peerLink)
+	cond := conditions.FromError(err)
+	conditions.Set(s.VPCDomain, cond)
+	if err != nil {
+		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to reconcile resource: %w", err)})
+	}
+
+	// Retrieve and update status from the device, nil out on error
+	status, err := s.Provider.GetStatusVPCDomain(ctx)
+	if err != nil {
+		s.VPCDomain.Status.Reset()
+		reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("failed to get resource status: %w", err)})
+	}
+
+	if reterr != nil {
+		return reterr
+	}
+
+	s.VPCDomain.Status.Role = status.Role
+
+	slices.Sort(status.KeepAliveStatusMsg)
+	s.VPCDomain.Status.KeepAliveStatusMsg = status.KeepAliveStatusMsg
+	s.VPCDomain.Status.KeepAliveStatus = nxv1alpha1.StatusDown
+	if status.KeepAliveStatus {
+		s.VPCDomain.Status.KeepAliveStatus = nxv1alpha1.StatusUp
+	}
+	slices.Sort(s.VPCDomain.Status.KeepAliveStatusMsg)
+	s.VPCDomain.Status.PeerStatusMsg = status.PeerStatusMsg
+	s.VPCDomain.Status.PeerStatus = nxv1alpha1.StatusDown
+	if status.PeerStatus {
+		s.VPCDomain.Status.PeerStatus = nxv1alpha1.StatusUp
+	}
+	s.VPCDomain.Status.PeerUptime = metav1.Duration{Duration: status.PeerUptime}
+
+	// Fetch the status of the port-channel forming the vPC's peer link
+	peerlinkOperSt := false
+	s.VPCDomain.Status.PeerLinkIf = peerLink.Spec.Name
+	if cond := conditions.Get(peerLink, v1alpha1.OperationalCondition); cond != nil {
+		s.VPCDomain.Status.PeerLinkIfOperStatus = nxv1alpha1.StatusDown
+		if cond.Status == metav1.ConditionTrue {
+			s.VPCDomain.Status.PeerLinkIfOperStatus = nxv1alpha1.StatusUp
+			peerlinkOperSt = true
+		}
+	}
+
+	cond = metav1.Condition{
+		Type:    v1alpha1.OperationalCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.OperationalReason,
+		Message: "vPC domain is operational",
+	}
+	// See comment in this type's status definition for details on the operational condition.
+	if !status.PeerStatus || !status.KeepAliveStatus || !peerlinkOperSt {
+		cond = metav1.Condition{
+			Type:    v1alpha1.OperationalCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.DegradedReason,
+			Message: "vPC domain is not fully operational. Either the peer-link interface is down, keepalive is not working, or the peer adjacency is not correctly formed.",
+		}
+	}
+	conditions.Set(s.VPCDomain, cond)
+
+	return nil
+}
+
+// reconcilePeerLink checks that peer's interface reference exists and is of type Aggregate.
+// Ignores the interface status: Port-channels require the domain to be configured first.
+func (r *VPCDomainReconciler) reconcilePeerLink(ctx context.Context, s *vpcdomainScope) (*v1alpha1.Interface, error) {
+	intf := new(v1alpha1.Interface)
+	intf.Name = s.VPCDomain.Spec.Peer.InterfaceRef.Name
+	intf.Namespace = s.VPCDomain.Namespace
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(intf), intf); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(s.VPCDomain, metav1.Condition{
+				Type:    v1alpha1.ConfiguredCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.WaitingForDependenciesReason,
+				Message: fmt.Sprintf("interface resource '%s' not found in namespace '%s'", intf.Name, intf.Namespace),
+			})
+			return nil, reconcile.TerminalError(fmt.Errorf("member interface %s not found", intf.Name))
+		}
+		return nil, fmt.Errorf("failed to get member interface %q: %w", intf.Name, err)
+	}
+
+	if intf.Spec.Type != v1alpha1.InterfaceTypeAggregate && intf.Spec.Type != v1alpha1.InterfaceTypePhysical {
+		conditions.Set(s.VPCDomain, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.InvalidInterfaceTypeReason,
+			Message: fmt.Sprintf("interface referenced by '%s' must be of type %q or type %q", intf.Name, v1alpha1.InterfaceTypeAggregate, v1alpha1.InterfaceTypePhysical),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("interface referenced by '%s' must be of type %q or type %q", intf.Name, v1alpha1.InterfaceTypeAggregate, v1alpha1.InterfaceTypePhysical))
+	}
+
+	if s.VPCDomain.Spec.DeviceRef.Name != intf.Spec.DeviceRef.Name {
+		conditions.Set(s.VPCDomain, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("interface '%s' deviceRef '%s' does not match vPC deviceRef '%s'", intf.Name, intf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("interface '%s' deviceRef '%s' does not match vPC deviceRef '%s'", intf.Name, intf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name))
+	}
+
+	return intf, nil
+}
+
+// reconcileKeepAliveVRF ensures that the referenced VRF resource exists
+func (r *VPCDomainReconciler) reconcileKeepAliveVRF(ctx context.Context, s *vpcdomainScope) (*v1alpha1.VRF, error) {
+	vrf := new(v1alpha1.VRF)
+	vrf.Name = s.VPCDomain.Spec.Peer.KeepAlive.VrfRef.Name
+	vrf.Namespace = s.VPCDomain.Namespace
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(vrf), vrf); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(s.VPCDomain, metav1.Condition{
+				Type:    v1alpha1.ConfiguredCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.WaitingForDependenciesReason,
+				Message: fmt.Sprintf("VRF resource '%s' not found in namespace '%s'", vrf.Name, vrf.Namespace),
+			})
+			return nil, reconcile.TerminalError(fmt.Errorf("VRF %q not found", vrf.Name))
+		}
+		return nil, fmt.Errorf("failed to get VRF %q: %w", vrf.Name, err)
+	}
+
+	if s.VPCDomain.Spec.DeviceRef.Name != vrf.Spec.DeviceRef.Name {
+		conditions.Set(s.VPCDomain, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("VRF '%s' deviceRef '%s' does not match VPCDomain deviceRef '%s'", vrf.Name, vrf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("VRF '%s' deviceRef '%s' does not match VPCDomain deviceRef '%s'", vrf.Name, vrf.Spec.DeviceRef.Name, s.VPCDomain.Spec.DeviceRef.Name))
+	}
+
+	return vrf, nil
+}
+
 func (r *VPCDomainReconciler) mapInterfaceToVPCDomain(ctx context.Context, obj client.Object) []ctrl.Request {
-	iface, ok := obj.(*corev1.Interface)
+	iface, ok := obj.(*v1alpha1.Interface)
 	if !ok {
 		panic(fmt.Sprintf("Expected a Interface but got a %T", obj))
 	}
 
-	vpc := new(nxv1.VPCDomain)
-	var vpcs nxv1.VPCDomainList
-	if err := r.List(ctx, &vpcs,
-		client.InNamespace(vpc.Namespace),
-		client.MatchingFields{
-			".spec.peer.interfaceRef.name": iface.Name,
-			corev1.DeviceRefIndexKey:       iface.Spec.DeviceRef.Name,
-		},
+	log := ctrl.LoggerFrom(ctx, "Interface", klog.KObj(iface))
+
+	list := new(nxv1alpha1.VPCDomainList)
+	if err := r.List(ctx, list,
+		client.InNamespace(iface.Namespace),
+		client.MatchingFields{vpcDomainPeerLinkRefKey: iface.Name},
 	); err != nil {
+		log.Error(err, "Failed to list VPCDomains")
 		return nil
 	}
 
-	requests := make([]reconcile.Request, 0, len(vpcs.Items))
-	for i := range vpcs.Items {
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for _, i := range list.Items {
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKeyFromObject(&vpcs.Items[i]),
+			NamespacedName: client.ObjectKey{
+				Name:      i.Name,
+				Namespace: i.Namespace,
+			},
 		})
 	}
+
 	return requests
 }
 
@@ -516,17 +499,17 @@ func (r *VPCDomainReconciler) finalize(ctx context.Context, s *vpcdomainScope) (
 // deviceToVPCDomains is a [handler.MapFunc] to be used to enqueue requests for reconciliation
 // for VPCDomains when their referenced Device's effective pause state changes.
 func (r *VPCDomainReconciler) deviceToVPCDomains(ctx context.Context, obj client.Object) []ctrl.Request {
-	device, ok := obj.(*corev1.Device)
+	device, ok := obj.(*v1alpha1.Device)
 	if !ok {
 		panic(fmt.Sprintf("Expected a Device but got a %T", obj))
 	}
 
 	log := ctrl.LoggerFrom(ctx, "Device", klog.KObj(device))
 
-	list := new(nxv1.VPCDomainList)
+	list := new(nxv1alpha1.VPCDomainList)
 	if err := r.List(ctx, list,
 		client.InNamespace(device.Namespace),
-		client.MatchingFields{corev1.DeviceRefIndexKey: device.Name},
+		client.MatchingFields{v1alpha1.DeviceRefIndexKey: device.Name},
 	); err != nil {
 		log.Error(err, "Failed to list VPCDomains")
 		return nil
@@ -544,16 +527,4 @@ func (r *VPCDomainReconciler) deviceToVPCDomains(ctx context.Context, obj client
 	}
 
 	return requests
-}
-
-func conditionChanged(oldConds, newConds []metav1.Condition, t string) bool {
-	o := meta.FindStatusCondition(oldConds, t)
-	n := meta.FindStatusCondition(newConds, t)
-	if o == nil && n == nil {
-		return false
-	}
-	if o == nil || n == nil {
-		return true
-	}
-	return o.Status != n.Status
 }

--- a/internal/controller/core/bgp_controller.go
+++ b/internal/controller/core/bgp_controller.go
@@ -197,13 +197,12 @@ func (r *BGPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -272,7 +271,7 @@ type bgpScope struct {
 	Provider       provider.BGPProvider
 }
 
-func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (_ ctrl.Result, reterr error) {
+func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (reterr error) {
 	if s.BGP.Labels == nil {
 		s.BGP.Labels = make(map[string]string)
 	}
@@ -282,12 +281,12 @@ func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (_ ctrl.Resu
 	// Ensure the BGP is owned by the Device.
 	if !controllerutil.HasControllerReference(s.BGP) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.BGP, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -306,7 +305,7 @@ func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (_ ctrl.Resu
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.BGP, cond)
 
-	return ctrl.Result{}, err
+	return err
 }
 
 func (r *BGPReconciler) finalize(ctx context.Context, s *bgpScope) (reterr error) {

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -201,13 +201,12 @@ func (r *BGPPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -294,7 +293,7 @@ type bgpPeerScope struct {
 	Provider       provider.BGPPeerProvider
 }
 
-func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ ctrl.Result, reterr error) {
+func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (reterr error) {
 	if s.BGPPeer.Labels == nil {
 		s.BGPPeer.Labels = make(map[string]string)
 	}
@@ -304,7 +303,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 	// Ensure the BGPPeer is owned by the Device.
 	if !controllerutil.HasControllerReference(s.BGPPeer) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.BGPPeer, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -314,7 +313,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 
 	bgp, err := r.reconcileBGP(ctx, s.BGPPeer, s.Device)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	// BGP has no operational condition, so its ready condition reflects only successful configuration.
@@ -326,7 +325,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 			Reason:  v1alpha1.WaitingForDependenciesReason,
 			Message: fmt.Sprintf("BGP %s is not yet ready", s.BGPPeer.Spec.BgpRef.Name),
 		})
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	var sourceInterface string
@@ -340,9 +339,9 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 					Reason:  v1alpha1.InterfaceNotFoundReason,
 					Message: fmt.Sprintf("source interface %q not found", addr.InterfaceRef.Name),
 				})
-				return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("source interface %q not found", addr.InterfaceRef.Name))
+				return reconcile.TerminalError(fmt.Errorf("source interface %q not found", addr.InterfaceRef.Name))
 			}
-			return ctrl.Result{}, fmt.Errorf("failed to get source interface %q: %w", addr.InterfaceRef.Name, err)
+			return fmt.Errorf("failed to get source interface %q: %w", addr.InterfaceRef.Name, err)
 		}
 
 		if intf.Spec.DeviceRef.Name != s.Device.Name {
@@ -352,13 +351,13 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 				Reason:  v1alpha1.CrossDeviceReferenceReason,
 				Message: fmt.Sprintf("source interface %q does not belong to device %q", intf.Name, s.Device.Name),
 			})
-			return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("source interface %q does not belong to device %q", intf.Name, s.Device.Name))
+			return reconcile.TerminalError(fmt.Errorf("source interface %q does not belong to device %q", intf.Name, s.Device.Name))
 		}
 		sourceInterface = intf.Spec.Name
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -378,7 +377,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 	conditions.Set(s.BGPPeer, cond)
 
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	status, err := s.Provider.GetPeerStatus(ctx, &provider.BGPPeerStatusRequest{
@@ -386,7 +385,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 		ProviderConfig: s.ProviderConfig,
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get bgp peer status: %w", err)
+		return fmt.Errorf("failed to get bgp peer status: %w", err)
 	}
 
 	cond = metav1.Condition{
@@ -427,7 +426,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 	}
 	s.BGPPeer.Status.AdvertisedPrefixesSummary = strings.Join(summaries, ", ")
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, err
+	return nil
 }
 
 func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (reterr error) {

--- a/internal/controller/core/dhcprelay_controller.go
+++ b/internal/controller/core/dhcprelay_controller.go
@@ -199,13 +199,12 @@ func (r *DHCPRelayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 
 // scope holds the different objects that are read and used during the reconcile.
@@ -215,11 +214,9 @@ type dhcprelayScope struct {
 	Connection     *deviceutil.Connection
 	ProviderConfig *provider.ProviderConfig
 	Provider       provider.DHCPRelayProvider
-	interfaces     []*v1alpha1.Interface
-	vrf            *v1alpha1.VRF
 }
 
-func (r *DHCPRelayReconciler) reconcile(ctx context.Context, s *dhcprelayScope) (_ ctrl.Result, reterr error) {
+func (r *DHCPRelayReconciler) reconcile(ctx context.Context, s *dhcprelayScope) (reterr error) {
 	if s.DHCPRelay.Labels == nil {
 		s.DHCPRelay.Labels = make(map[string]string)
 	}
@@ -228,33 +225,31 @@ func (r *DHCPRelayReconciler) reconcile(ctx context.Context, s *dhcprelayScope) 
 	// Ensure the DHCPRelay is owned by the Device.
 	if !controllerutil.HasControllerReference(s.DHCPRelay) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.DHCPRelay, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
 	if err := r.validateUniqueResourcePerDevice(ctx, s); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	if err := r.validateProviderConfigRef(ctx, s); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	interfaces, err := r.reconcileInterfaceRefs(ctx, s)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	s.interfaces = interfaces
 
 	vrf, err := r.reconcileVRFRef(ctx, s)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	s.vrf = vrf
 
 	// Connect to remote device using the provider.
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -266,8 +261,8 @@ func (r *DHCPRelayReconciler) reconcile(ctx context.Context, s *dhcprelayScope) 
 	err = s.Provider.EnsureDHCPRelay(ctx, &provider.DHCPRelayRequest{
 		DHCPRelay:      s.DHCPRelay,
 		ProviderConfig: s.ProviderConfig,
-		Interfaces:     s.interfaces,
-		VRF:            s.vrf,
+		Interfaces:     interfaces,
+		VRF:            vrf,
 	})
 
 	cond := conditions.FromError(err)
@@ -276,22 +271,22 @@ func (r *DHCPRelayReconciler) reconcile(ctx context.Context, s *dhcprelayScope) 
 	conditions.Set(s.DHCPRelay, cond)
 
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	// Retrieve and update the status from the device; this include the list of interfaces that are actually configured on the device.
 	status, err := s.Provider.GetDHCPRelayStatus(ctx, &provider.DHCPRelayRequest{
 		DHCPRelay:      s.DHCPRelay,
 		ProviderConfig: s.ProviderConfig,
-		Interfaces:     s.interfaces,
+		Interfaces:     interfaces,
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get DHCP relay status: %w", err)
+		return fmt.Errorf("failed to get DHCP relay status: %w", err)
 	}
 
 	s.DHCPRelay.Status.ConfiguredInterfaces = status.ConfiguredInterfaces
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/core/interface_controller.go
+++ b/internal/controller/core/interface_controller.go
@@ -202,16 +202,15 @@ func (r *InterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 
-var (
+const (
 	interfaceTypeKey          = ".spec.type"
 	interfaceUnnumberedRefKey = ".spec.ipv4.unnumbered.interfaceRef.name"
 	interfaceVlanRefKey       = ".spec.vlanRef.name"
@@ -403,7 +402,7 @@ type scope struct {
 	Provider       provider.InterfaceProvider
 }
 
-func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.Result, reterr error) {
+func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (reterr error) {
 	if s.Interface.Labels == nil {
 		s.Interface.Labels = make(map[string]string)
 	}
@@ -413,7 +412,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 	// Ensure the Interface is owned by the Device.
 	if !controllerutil.HasControllerReference(s.Interface) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.Interface, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -426,7 +425,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 		var err error
 		members, err = r.reconcileMemberInterfaces(ctx, s)
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -436,7 +435,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 		key := client.ObjectKey{Name: s.Interface.Status.MemberOf.Name, Namespace: s.Interface.Namespace}
 		if err := r.Get(ctx, key, aggregateParent); err != nil {
 			if !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("failed to get aggregate parent %q: %w", s.Interface.Status.MemberOf.Name, err)
+				return fmt.Errorf("failed to get aggregate parent %q: %w", s.Interface.Status.MemberOf.Name, err)
 			}
 			aggregateParent = nil
 		}
@@ -452,7 +451,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 		var err error
 		vlan, err = r.reconcileVLAN(ctx, s)
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -461,7 +460,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 		var err error
 		vrf, err = r.reconcileVRF(ctx, s)
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -470,12 +469,12 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 		var err error
 		ip, err = r.reconcileIPv4(ctx, s)
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -499,7 +498,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 	conditions.Set(s.Interface, cond)
 
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	status, err := s.Provider.GetInterfaceStatus(ctx, &provider.InterfaceRequest{
@@ -507,7 +506,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 		ProviderConfig: s.ProviderConfig,
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get interface status: %w", err)
+		return fmt.Errorf("failed to get interface status: %w", err)
 	}
 
 	cond = metav1.Condition{
@@ -526,7 +525,7 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (_ ctrl.R
 	}
 	conditions.Set(s.Interface, cond)
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return nil
 }
 
 func (r *InterfaceReconciler) reconcileIPv4(ctx context.Context, s *scope) (provider.IPv4, error) {
@@ -870,7 +869,6 @@ func (r *InterfaceReconciler) interfaceToUnnumbered(ctx context.Context, obj cli
 	for _, i := range interfaces.Items {
 		if i.Spec.IPv4 != nil && i.Spec.IPv4.Unnumbered != nil && i.Spec.IPv4.Unnumbered.InterfaceRef.Name == intf.Name {
 			log.V(2).Info("Enqueuing Interface for reconciliation", "Interface", klog.KObj(&i))
-
 			requests = append(requests, ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      i.Name,

--- a/internal/controller/core/isis_controller.go
+++ b/internal/controller/core/isis_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -53,10 +54,6 @@ type ISISReconciler struct {
 
 	// Locker is used to synchronize operations on resources targeting the same device.
 	Locker *resourcelock.ResourceLocker
-
-	// RequeueInterval is the duration after which the controller should requeue the reconciliation,
-	// regardless of changes.
-	RequeueInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=isis,verbs=get;list;watch;create;update;patch;delete
@@ -197,21 +194,16 @@ func (r *ISISReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ISISReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	if r.RequeueInterval == 0 {
-		return errors.New("requeue interval must not be 0")
-	}
-
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -260,6 +252,24 @@ func (r *ISISReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager)
 				},
 			}),
 		).
+		// Watches enqueues ISISs for updates in referenced Interface resources.
+		// Only triggers on create, delete and update events when the Configured condition changes.
+		Watches(
+			&v1alpha1.Interface{},
+			handler.EnqueueRequestsFromMapFunc(r.interfaceToISIS),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldInterface := e.ObjectOld.(*v1alpha1.Interface)
+					newInterface := e.ObjectNew.(*v1alpha1.Interface)
+					oldConfigured := conditions.Get(oldInterface, v1alpha1.ConfiguredCondition)
+					newConfigured := conditions.Get(newInterface, v1alpha1.ConfiguredCondition)
+					return ((oldConfigured == nil) != (newConfigured == nil)) || (newConfigured != nil && oldConfigured.Status != newConfigured.Status)
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -272,7 +282,7 @@ type isisScope struct {
 	Provider       provider.ISISProvider
 }
 
-func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Result, reterr error) {
+func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (reterr error) {
 	if s.ISIS.Labels == nil {
 		s.ISIS.Labels = make(map[string]string)
 	}
@@ -282,7 +292,7 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 	// Ensure the ISIS is owned by the Device.
 	if !controllerutil.HasControllerReference(s.ISIS) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.ISIS, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -301,9 +311,9 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 					Reason:  v1alpha1.InterfaceNotFoundReason,
 					Message: fmt.Sprintf("Interface %s not found", iface.Name),
 				})
-				return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("interface %s not found", iface.Name))
+				return reconcile.TerminalError(fmt.Errorf("interface %s not found", iface.Name))
 			}
-			return ctrl.Result{}, err
+			return err
 		}
 
 		if !conditions.IsConfigured(intf) {
@@ -313,14 +323,14 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 				Reason:  v1alpha1.WaitingForDependenciesReason,
 				Message: "Waiting for referenced interfaces to become configured",
 			})
-			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+			return nil
 		}
 
 		interfaces = append(interfaces, intf)
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -340,7 +350,7 @@ func (r *ISISReconciler) reconcile(ctx context.Context, s *isisScope) (_ ctrl.Re
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.ISIS, cond)
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return err
 }
 
 func (r *ISISReconciler) finalize(ctx context.Context, s *isisScope) (reterr error) {
@@ -357,6 +367,42 @@ func (r *ISISReconciler) finalize(ctx context.Context, s *isisScope) (reterr err
 		ISIS:           s.ISIS,
 		ProviderConfig: s.ProviderConfig,
 	})
+}
+
+// interfaceToOSPF is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for ISISs when one of their referenced Interface's changes.
+func (r *ISISReconciler) interfaceToISIS(ctx context.Context, obj client.Object) []ctrl.Request {
+	iface, ok := obj.(*v1alpha1.Interface)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Interface but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "Interface", klog.KObj(iface))
+
+	list := new(v1alpha1.ISISList)
+	if err := r.List(ctx, list,
+		client.InNamespace(iface.Namespace),
+	); err != nil {
+		log.Error(err, "Failed to list ISISs")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for _, i := range list.Items {
+		if slices.ContainsFunc(i.Spec.InterfaceRefs, func(ref v1alpha1.LocalObjectReference) bool {
+			return ref.Name == iface.Name
+		}) {
+			log.V(2).Info("Enqueuing ISIS for reconciliation", "ISIS", klog.KObj(&i))
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      i.Name,
+					Namespace: i.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
 }
 
 // deviceToISISs is a [handler.MapFunc] to be used to enqueue requests for reconciliation

--- a/internal/controller/core/lldp_controller.go
+++ b/internal/controller/core/lldp_controller.go
@@ -188,26 +188,23 @@ func (r *LLDPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
-	return res, nil
+
+	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 
 type lldpScope struct {
-	Device     *v1alpha1.Device
-	LLDP       *v1alpha1.LLDP
-	Connection *deviceutil.Connection
-	Provider   provider.LLDPProvider
-	// ProviderConfig is the resource referenced by LLDP.Spec.ProviderConfigRef, if any.
+	Device         *v1alpha1.Device
+	LLDP           *v1alpha1.LLDP
+	Connection     *deviceutil.Connection
+	Provider       provider.LLDPProvider
 	ProviderConfig *provider.ProviderConfig
-	// Interfaces are the Interface resources referenced by LLDP.Spec.InterfaceRefs.
-	Interfaces []*v1alpha1.Interface
 }
 
-func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (_ ctrl.Result, reterr error) {
+func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (reterr error) {
 	if s.LLDP.Labels == nil {
 		s.LLDP.Labels = make(map[string]string)
 	}
@@ -216,7 +213,7 @@ func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (_ ctrl.Re
 	// Ensure LLDP resource is owned by the Device.
 	if !controllerutil.HasControllerReference(s.LLDP) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.LLDP, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -225,21 +222,20 @@ func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (_ ctrl.Re
 	}()
 
 	if err := r.validateUniqueLLDPPerDevice(ctx, s); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	if err := r.validateProviderConfigRef(ctx, s); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	interfaces, err := r.reconcileInterfaceRefs(ctx, s)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	s.Interfaces = interfaces
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -251,14 +247,14 @@ func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (_ ctrl.Re
 	err = s.Provider.EnsureLLDP(ctx, &provider.LLDPRequest{
 		LLDP:           s.LLDP,
 		ProviderConfig: s.ProviderConfig,
-		Interfaces:     s.Interfaces,
+		Interfaces:     interfaces,
 	})
 
 	cond := conditions.FromError(err)
 	conditions.Set(s.LLDP, cond)
 
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	status, err := s.Provider.GetLLDPStatus(ctx, &provider.LLDPRequest{
@@ -266,7 +262,7 @@ func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (_ ctrl.Re
 		ProviderConfig: s.ProviderConfig,
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get LLDP status: %w", err)
+		return fmt.Errorf("failed to get LLDP status: %w", err)
 	}
 
 	cond = metav1.Condition{
@@ -282,7 +278,7 @@ func (r *LLDPReconciler) reconcile(ctx context.Context, s *lldpScope) (_ ctrl.Re
 	}
 	conditions.Set(s.LLDP, cond)
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return nil
 }
 
 // validateProviderConfigRef checks if the referenced provider configuration exists and is compatible with the target platform.

--- a/internal/controller/core/nve_controller.go
+++ b/internal/controller/core/nve_controller.go
@@ -199,7 +199,6 @@ func (r *NetworkVirtualizationEdgeReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, err
 	}
 
-	// force a periodic requeue to enforce state is in sync
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 

--- a/internal/controller/core/ospf_controller.go
+++ b/internal/controller/core/ospf_controller.go
@@ -200,13 +200,12 @@ func (r *OSPFReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -263,6 +262,24 @@ func (r *OSPFReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager)
 				},
 			}),
 		).
+		// Watches enqueues OSPFs for updates in referenced Interface resources.
+		// Only triggers on create, delete and update events when the Configured condition changes.
+		Watches(
+			&v1alpha1.Interface{},
+			handler.EnqueueRequestsFromMapFunc(r.interfaceToOSPF),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldInterface := e.ObjectOld.(*v1alpha1.Interface)
+					newInterface := e.ObjectNew.(*v1alpha1.Interface)
+					oldConfigured := conditions.Get(oldInterface, v1alpha1.ConfiguredCondition)
+					newConfigured := conditions.Get(newInterface, v1alpha1.ConfiguredCondition)
+					return ((oldConfigured == nil) != (newConfigured == nil)) || (newConfigured != nil && oldConfigured.Status != newConfigured.Status)
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -275,7 +292,7 @@ type ospfScope struct {
 	Provider       provider.OSPFProvider
 }
 
-func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Result, reterr error) {
+func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (reterr error) {
 	if s.OSPF.Labels == nil {
 		s.OSPF.Labels = make(map[string]string)
 	}
@@ -285,7 +302,7 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 	// Ensure the OSPF is owned by the Device.
 	if !controllerutil.HasControllerReference(s.OSPF) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.OSPF, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -304,9 +321,9 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 					Reason:  v1alpha1.InterfaceNotFoundReason,
 					Message: fmt.Sprintf("interface %q not found", ref.Name),
 				})
-				return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("interface %q not found", ref.Name))
+				return reconcile.TerminalError(fmt.Errorf("interface %q not found", ref.Name))
 			}
-			return ctrl.Result{}, err
+			return err
 		}
 
 		if !conditions.IsConfigured(intf) {
@@ -316,7 +333,7 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 				Reason:  v1alpha1.WaitingForDependenciesReason,
 				Message: "Waiting for referenced interfaces to be configured",
 			})
-			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+			return nil
 		}
 
 		interfaces = append(interfaces, provider.OSPFInterface{
@@ -327,7 +344,7 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -346,7 +363,7 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 	conditions.Set(s.OSPF, cond)
 
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	status, err := s.Provider.GetOSPFStatus(ctx, &provider.OSPFStatusRequest{
@@ -355,7 +372,7 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 		ProviderConfig: s.ProviderConfig,
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get ospf status: %w", err)
+		return fmt.Errorf("failed to get ospf status: %w", err)
 	}
 
 	cond = metav1.Condition{
@@ -417,7 +434,7 @@ func (r *OSPFReconciler) reconcile(ctx context.Context, s *ospfScope) (_ ctrl.Re
 	s.OSPF.Status.AdjacencySummary = strings.Join(summaries, ", ")
 	s.OSPF.Status.ObservedGeneration = s.OSPF.Generation
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return nil
 }
 
 func (r *OSPFReconciler) finalize(ctx context.Context, s *ospfScope) (reterr error) {
@@ -464,6 +481,42 @@ func (r *OSPFReconciler) deviceToOSPFs(ctx context.Context, obj client.Object) [
 				Namespace: i.Namespace,
 			},
 		})
+	}
+
+	return requests
+}
+
+// interfaceToOSPF is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for OSPFs when one of their referenced Interface's changes.
+func (r *OSPFReconciler) interfaceToOSPF(ctx context.Context, obj client.Object) []ctrl.Request {
+	iface, ok := obj.(*v1alpha1.Interface)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Interface but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "Interface", klog.KObj(iface))
+
+	list := new(v1alpha1.OSPFList)
+	if err := r.List(ctx, list,
+		client.InNamespace(iface.Namespace),
+	); err != nil {
+		log.Error(err, "Failed to list OSPFs")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for _, i := range list.Items {
+		if slices.ContainsFunc(i.Spec.InterfaceRefs, func(ref v1alpha1.OSPFInterface) bool {
+			return ref.Name == iface.Name
+		}) {
+			log.V(2).Info("Enqueuing OSPF for reconciliation", "OSPF", klog.KObj(&i))
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      i.Name,
+					Namespace: i.Namespace,
+				},
+			})
+		}
 	}
 
 	return requests

--- a/internal/controller/core/pim_controller.go
+++ b/internal/controller/core/pim_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -53,10 +54,6 @@ type PIMReconciler struct {
 
 	// Locker is used to synchronize operations on resources targeting the same device.
 	Locker *resourcelock.ResourceLocker
-
-	// RequeueInterval is the duration after which the controller should requeue the reconciliation,
-	// regardless of changes.
-	RequeueInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=pim,verbs=get;list;watch;create;update;patch;delete
@@ -197,21 +194,16 @@ func (r *PIMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PIMReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	if r.RequeueInterval == 0 {
-		return errors.New("requeue interval must not be 0")
-	}
-
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}
@@ -260,6 +252,24 @@ func (r *PIMReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 				},
 			}),
 		).
+		// Watches enqueues PIMs for updates in referenced Interface resources.
+		// Only triggers on create, delete and update events when the Configured condition changes.
+		Watches(
+			&v1alpha1.Interface{},
+			handler.EnqueueRequestsFromMapFunc(r.interfaceToPIM),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldInterface := e.ObjectOld.(*v1alpha1.Interface)
+					newInterface := e.ObjectNew.(*v1alpha1.Interface)
+					oldConfigured := conditions.Get(oldInterface, v1alpha1.ConfiguredCondition)
+					newConfigured := conditions.Get(newInterface, v1alpha1.ConfiguredCondition)
+					return ((oldConfigured == nil) != (newConfigured == nil)) || (newConfigured != nil && oldConfigured.Status != newConfigured.Status)
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
 		Complete(r)
 }
 
@@ -272,7 +282,7 @@ type pimScope struct {
 	Provider       provider.PIMProvider
 }
 
-func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Result, reterr error) {
+func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (reterr error) {
 	if s.PIM.Labels == nil {
 		s.PIM.Labels = make(map[string]string)
 	}
@@ -282,7 +292,7 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Resu
 	// Ensure the PIM is owned by the Device.
 	if !controllerutil.HasControllerReference(s.PIM) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.PIM, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 	defer func() {
@@ -300,9 +310,9 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Resu
 					Reason:  v1alpha1.InterfaceNotFoundReason,
 					Message: fmt.Sprintf("interface %q not found", intf.Name),
 				})
-				return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("interface %q not found", intf.Name))
+				return reconcile.TerminalError(fmt.Errorf("interface %q not found", intf.Name))
 			}
-			return ctrl.Result{}, err
+			return err
 		}
 
 		if !conditions.IsConfigured(res) {
@@ -312,7 +322,7 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Resu
 				Reason:  v1alpha1.WaitingForDependenciesReason,
 				Message: "Waiting for referenced interfaces to become configured",
 			})
-			return ctrl.Result{RequeueAfter: r.RequeueInterval}, nil
+			return nil
 		}
 
 		interfaces = append(interfaces, provider.PIMInterface{
@@ -322,7 +332,7 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Resu
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -342,7 +352,7 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (_ ctrl.Resu
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.PIM, cond)
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return err
 }
 
 func (r *PIMReconciler) finalize(ctx context.Context, s *pimScope) (reterr error) {
@@ -389,6 +399,42 @@ func (r *PIMReconciler) deviceToPIMs(ctx context.Context, obj client.Object) []c
 				Namespace: i.Namespace,
 			},
 		})
+	}
+
+	return requests
+}
+
+// interfaceToOSPF is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for PIMs when one of their referenced Interface's changes.
+func (r *PIMReconciler) interfaceToPIM(ctx context.Context, obj client.Object) []ctrl.Request {
+	iface, ok := obj.(*v1alpha1.Interface)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Interface but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "Interface", klog.KObj(iface))
+
+	list := new(v1alpha1.PIMList)
+	if err := r.List(ctx, list,
+		client.InNamespace(iface.Namespace),
+	); err != nil {
+		log.Error(err, "Failed to list PIMs")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for _, i := range list.Items {
+		if slices.ContainsFunc(i.Spec.InterfaceRefs, func(ref v1alpha1.PIMInterface) bool {
+			return ref.Name == iface.Name
+		}) {
+			log.V(2).Info("Enqueuing PIM for reconciliation", "PIM", klog.KObj(&i))
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      i.Name,
+					Namespace: i.Namespace,
+				},
+			})
+		}
 	}
 
 	return requests

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -216,32 +216,29 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&ISISReconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
-		Provider:        prov,
-		Locker:          testLocker,
-		RequeueInterval: time.Second,
+		Client:   k8sManager.GetClient(),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: recorder,
+		Provider: prov,
+		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&VRFReconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
-		Provider:        prov,
-		Locker:          testLocker,
-		RequeueInterval: time.Second,
+		Client:   k8sManager.GetClient(),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: recorder,
+		Provider: prov,
+		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&PIMReconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		Recorder:        recorder,
-		Provider:        prov,
-		Locker:          testLocker,
-		RequeueInterval: time.Second,
+		Client:   k8sManager.GetClient(),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: recorder,
+		Provider: prov,
+		Locker:   testLocker,
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/core/vlan_controller.go
+++ b/internal/controller/core/vlan_controller.go
@@ -197,13 +197,12 @@ func (r *VLANReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -272,7 +271,7 @@ type vlanScope struct {
 	Provider       provider.VLANProvider
 }
 
-func (r *VLANReconciler) reconcile(ctx context.Context, s *vlanScope) (_ ctrl.Result, reterr error) {
+func (r *VLANReconciler) reconcile(ctx context.Context, s *vlanScope) (reterr error) {
 	if s.VLAN.Labels == nil {
 		s.VLAN.Labels = make(map[string]string)
 	}
@@ -282,7 +281,7 @@ func (r *VLANReconciler) reconcile(ctx context.Context, s *vlanScope) (_ ctrl.Re
 	// Ensure the VLAN is owned by the Device.
 	if !controllerutil.HasControllerReference(s.VLAN) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.VLAN, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -291,7 +290,7 @@ func (r *VLANReconciler) reconcile(ctx context.Context, s *vlanScope) (_ ctrl.Re
 	}()
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -313,7 +312,7 @@ func (r *VLANReconciler) reconcile(ctx context.Context, s *vlanScope) (_ ctrl.Re
 		ProviderConfig: s.ProviderConfig,
 	})
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get vlan status: %w", err)
+		return fmt.Errorf("failed to get vlan status: %w", err)
 	}
 
 	cond = metav1.Condition{
@@ -329,7 +328,7 @@ func (r *VLANReconciler) reconcile(ctx context.Context, s *vlanScope) (_ ctrl.Re
 	}
 	conditions.Set(s.VLAN, cond)
 
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return nil
 }
 
 func (r *VLANReconciler) finalize(ctx context.Context, s *vlanScope) (reterr error) {

--- a/internal/controller/core/vrf_controller.go
+++ b/internal/controller/core/vrf_controller.go
@@ -53,10 +53,6 @@ type VRFReconciler struct {
 
 	// Locker is used to synchronize operations on resources targeting the same device.
 	Locker *resourcelock.ResourceLocker
-
-	// RequeueInterval is the duration after which the controller should requeue the reconciliation,
-	// regardless of changes.
-	RequeueInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=vrfs,verbs=get;list;watch;create;update;patch;delete
@@ -199,13 +195,12 @@ func (r *VRFReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 		}
 	}()
 
-	res, err := r.reconcile(ctx, s)
-	if err != nil {
+	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
 		return ctrl.Result{}, err
 	}
 
-	return res, nil
+	return ctrl.Result{}, nil
 }
 
 // scope holds the different objects that are read and used during the reconcile.
@@ -217,7 +212,7 @@ type vrfScope struct {
 	Provider       provider.VRFProvider
 }
 
-func (r *VRFReconciler) reconcile(ctx context.Context, s *vrfScope) (_ ctrl.Result, reterr error) {
+func (r *VRFReconciler) reconcile(ctx context.Context, s *vrfScope) (reterr error) {
 	if s.VRF.Labels == nil {
 		s.VRF.Labels = make(map[string]string)
 	}
@@ -226,13 +221,13 @@ func (r *VRFReconciler) reconcile(ctx context.Context, s *vrfScope) (_ ctrl.Resu
 	// Ensure the VRF is owned by the Device.
 	if !controllerutil.HasControllerReference(s.VRF) {
 		if err := controllerutil.SetOwnerReference(s.Device, s.VRF, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
 	// Connect to remote device using the provider.
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to connect to provider: %w", err)
+		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
 	defer func() {
 		if err := s.Provider.Disconnect(ctx, s.Connection); err != nil {
@@ -251,19 +246,11 @@ func (r *VRFReconciler) reconcile(ctx context.Context, s *vrfScope) (_ ctrl.Resu
 	cond.Type = v1alpha1.ReadyCondition
 	conditions.Set(s.VRF, cond)
 
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil
+	return err
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VRFReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	if r.RequeueInterval == 0 {
-		return errors.New("requeue interval must not be 0")
-	}
-
 	labelSelector := metav1.LabelSelector{}
 	if r.WatchFilterValue != "" {
 		labelSelector.MatchLabels = map[string]string{v1alpha1.WatchLabel: r.WatchFilterValue}


### PR DESCRIPTION
Consistently apply the following patterns across all controllers:

- Change reconcile() return type from (ctrl.Result, error) to (error). Move the RequeueAfter result to the Reconcile() caller so reconcile() is only responsible for business logic, not requeue scheduling.

- Remove the RequeueInterval field from ISIS, PIM, and VRF reconcilers (and the corresponding validation in SetupWithManager and wiring in cmd/main.go). These controllers now use proper watch triggers to reconcile based on referenced resource changes. Unlike controllers that track operational state (e.g. interface oper-status), these resources have no device-side operational state requiring periodic syncs.

- Remove cached references from scope structs (e.g. Interfaces, VRF, PeerLink in lldpScope, dhcprelayScope, vpcdomainScope). Previously these fields were fetched and set in sub-reconciler functions, then read back in reconcile() through the scope. This is a poor pattern because: 1) the values never leave the reconcile() function scope and 2) they are absent from the scope when passed to finalize(), where a reader might assume they are populated. Use local variables within reconcile() instead.

- Add Interface Watches to ISIS, OSPF, and PIM controllers that trigger reconciliation when a referenced Interface's Configured condition changes, replacing the previous poll-based requeue.

- Align vpcdomain_controller with the rest of the codebase: rename import aliases (nxv1 to nxv1alpha1, corev1 to unaliased v1alpha1), replace meta.FindStatusCondition with conditions.Get in watch predicates, extract field indexer key strings into package-level constants, and remove the now unused conditionChanged helper.

- Add kubebuilder default markers and a Reset() method to VPCDomainStatus instead of having a method on the reconciler.