### PR TITLE
Add bgpRef to BGPPeer and replace implicit BGP lookup

### DIFF
--- a/api/core/v1alpha1/bgp_peer_types.go
+++ b/api/core/v1alpha1/bgp_peer_types.go
@@ -24,6 +24,11 @@ type BGPPeerSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
+	// BgpRef is a reference to the BGP instance this peer belongs to.
+	// The BGP object must exist in the same namespace.
+	// +required
+	BgpRef LocalObjectReference `json:"bgpRef"`
+
 	// AdminState indicates whether this BGP peer is administratively up or down.
 	// When Down, the BGP session with this peer is administratively shut down.
 	// +optional

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -539,6 +539,7 @@ func (in *BGPPeerSpec) DeepCopyInto(out *BGPPeerSpec) {
 		*out = new(TypedLocalObjectReference)
 		**out = **in
 	}
+	out.BgpRef = in.BgpRef
 	out.ASNumber = in.ASNumber
 	if in.LocalAddress != nil {
 		in, out := &in.LocalAddress, &out.LocalAddress

--- a/charts/network-operator/templates/crd/bgppeers.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bgppeers.networking.metal.ironcore.dev.yaml
@@ -195,6 +195,22 @@ spec:
                   ASNumber is the autonomous system number (ASN) of the BGP peer.
                   Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
                 x-kubernetes-int-or-string: true
+              bgpRef:
+                description: |-
+                  BgpRef is a reference to the BGP instance this peer belongs to.
+                  The BGP object must exist in the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
               description:
                 description: |-
                   Description is an optional human-readable description for this BGP peer.
@@ -281,6 +297,7 @@ spec:
             required:
             - address
             - asNumber
+            - bgpRef
             - deviceRef
             type: object
           status:

--- a/config/crd/bases/networking.metal.ironcore.dev_bgppeers.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_bgppeers.yaml
@@ -192,6 +192,22 @@ spec:
                   ASNumber is the autonomous system number (ASN) of the BGP peer.
                   Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
                 x-kubernetes-int-or-string: true
+              bgpRef:
+                description: |-
+                  BgpRef is a reference to the BGP instance this peer belongs to.
+                  The BGP object must exist in the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
               description:
                 description: |-
                   Description is an optional human-readable description for this BGP peer.
@@ -278,6 +294,7 @@ spec:
             required:
             - address
             - asNumber
+            - bgpRef
             - deviceRef
             type: object
           status:

--- a/config/samples/v1alpha1_bgppeer.yaml
+++ b/config/samples/v1alpha1_bgppeer.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf1
+  bgpRef:
+    name: bgp
   address: 10.0.0.1
   asNumber: 65000
   localAddress:
@@ -28,6 +30,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf1
+  bgpRef:
+    name: bgp
   address: 10.0.0.2
   asNumber: 65000
   localAddress:

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -481,6 +481,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `deviceRef` _[LocalObjectReference](#localobjectreference)_ | DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.<br />Immutable. |  | Required: \{\} <br /> |
 | `providerConfigRef` _[TypedLocalObjectReference](#typedlocalobjectreference)_ | ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.<br />This reference is used to link the BGP to its provider-specific configuration. |  | Optional: \{\} <br /> |
+| `bgpRef` _[LocalObjectReference](#localobjectreference)_ | BgpRef is a reference to the BGP instance this peer belongs to.<br />The BGP object must exist in the same namespace. |  | Required: \{\} <br /> |
 | `adminState` _[AdminState](#adminstate)_ | AdminState indicates whether this BGP peer is administratively up or down.<br />When Down, the BGP session with this peer is administratively shut down. | Up | Enum: [Up Down] <br />Optional: \{\} <br /> |
 | `address` _string_ | Address is the IPv4 address of the BGP peer. |  | Format: ipv4 <br />Required: \{\} <br /> |
 | `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) of the BGP peer.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Required: \{\} <br /> |

--- a/docs/tutorials/evpn-vxlan-fabric.md
+++ b/docs/tutorials/evpn-vxlan-fabric.md
@@ -433,6 +433,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf1
+  bgpRef:
+    name: leaf1-bgp
   address: 10.0.0.1
   asNumber: 65000
   localAddress:

--- a/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/leaf1-bgp-peers.yaml
+++ b/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/leaf1-bgp-peers.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf1
+  bgpRef:
+    name: leaf1-bgp
   address: 10.0.0.1
   asNumber: 65000
   localAddress:
@@ -22,6 +24,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf1
+  bgpRef:
+    name: leaf1-bgp
   address: 10.0.0.2
   asNumber: 65000
   localAddress:

--- a/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/leaf2-bgp-peers.yaml
+++ b/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/leaf2-bgp-peers.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf2
+  bgpRef:
+    name: leaf2-bgp
   address: 10.0.0.1
   asNumber: 65000
   localAddress:
@@ -22,6 +24,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf2
+  bgpRef:
+    name: leaf2-bgp
   address: 10.0.0.2
   asNumber: 65000
   localAddress:

--- a/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/leaf3-bgp-peers.yaml
+++ b/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/leaf3-bgp-peers.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf3
+  bgpRef:
+    name: leaf3-bgp
   address: 10.0.0.1
   asNumber: 65000
   localAddress:
@@ -22,6 +24,8 @@ metadata:
 spec:
   deviceRef:
     name: leaf3
+  bgpRef:
+    name: leaf3-bgp
   address: 10.0.0.2
   asNumber: 65000
   localAddress:

--- a/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/spine1-bgp-peers.yaml
+++ b/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/spine1-bgp-peers.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   deviceRef:
     name: spine1
+  bgpRef:
+    name: spine1-bgp
   address: 10.0.0.10
   asNumber: 65000
   localAddress:
@@ -23,6 +25,8 @@ metadata:
 spec:
   deviceRef:
     name: spine1
+  bgpRef:
+    name: spine1-bgp
   address: 10.0.0.11
   asNumber: 65000
   localAddress:
@@ -41,6 +45,8 @@ metadata:
 spec:
   deviceRef:
     name: spine1
+  bgpRef:
+    name: spine1-bgp
   address: 10.0.0.12
   asNumber: 65000
   localAddress:

--- a/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/spine2-bgp-peers.yaml
+++ b/examples/cisco-n9k-evpn-vxlan/kubernetes/10-bgp-peers/spine2-bgp-peers.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   deviceRef:
     name: spine2
+  bgpRef:
+    name: spine2-bgp
   address: 10.0.0.10
   asNumber: 65000
   localAddress:
@@ -23,6 +25,8 @@ metadata:
 spec:
   deviceRef:
     name: spine2
+  bgpRef:
+    name: spine2-bgp
   address: 10.0.0.11
   asNumber: 65000
   localAddress:
@@ -41,6 +45,8 @@ metadata:
 spec:
   deviceRef:
     name: spine2
+  bgpRef:
+    name: spine2-bgp
   address: 10.0.0.12
   asNumber: 65000
   localAddress:

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -271,7 +271,7 @@ func (r *BGPPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					oldBGP := e.ObjectOld.(*v1alpha1.BGP)
 					newBGP := e.ObjectNew.(*v1alpha1.BGP)
 					// Only trigger when the BGP transitions from not-ready to ready.
-					return !conditions.IsReady(oldBGP) && conditions.IsReady(newBGP)
+					return conditions.IsReady(oldBGP) != conditions.IsReady(newBGP)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -308,35 +308,19 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 		conditions.RecomputeReady(s.BGPPeer)
 	}()
 
-	// Check that at least one BGP resource exists for the device.
-	// A BGPPeer cannot function without a BGP process running on the same device.
-	bgpList := new(v1alpha1.BGPList)
-	if err := r.List(ctx, bgpList,
-		client.InNamespace(s.BGPPeer.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: s.Device.Name},
-	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list BGP resources for device %q: %w", s.Device.Name, err)
+	bgp, err := r.reconcileBGP(ctx, s.BGPPeer, s.Device)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	if len(bgpList.Items) == 0 {
-		conditions.Set(s.BGPPeer, metav1.Condition{
-			Type:    v1alpha1.ConfiguredCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  v1alpha1.BGPNotFoundReason,
-			Message: fmt.Sprintf("no BGP resource found for device %q", s.Device.Name),
-		})
-		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("no BGP resource found for device %q", s.Device.Name))
-	}
-
-	// Ensure at least one BGP resource on the device is ready before
-	// establishing peers. BGP has no operational condition, so its ready
-	// condition reflects only successful configuration.
-	if !slices.ContainsFunc(bgpList.Items, func(bgp v1alpha1.BGP) bool { return conditions.IsReady(&bgp) }) {
+	// BGP has no operational condition, so its ready condition reflects only successful configuration.
+	// Wait for the BGP watch to re-trigger rather than requeuing periodically.
+	if !conditions.IsReady(bgp) {
 		conditions.Set(s.BGPPeer, metav1.Condition{
 			Type:    v1alpha1.ConfiguredCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  v1alpha1.WaitingForDependenciesReason,
-			Message: fmt.Sprintf("BGP resource for device %q is not yet ready", s.Device.Name),
+			Message: fmt.Sprintf("BGP %s is not yet ready", s.BGPPeer.Spec.BgpRef.Name),
 		})
 		return ctrl.Result{}, nil
 	}
@@ -379,10 +363,11 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 	}()
 
 	// Ensure the BGPPeer is realized on the provider.
-	err := s.Provider.EnsureBGPPeer(ctx, &provider.EnsureBGPPeerRequest{
+	err = s.Provider.EnsureBGPPeer(ctx, &provider.EnsureBGPPeerRequest{
 		BGPPeer:         s.BGPPeer,
 		ProviderConfig:  s.ProviderConfig,
 		SourceInterface: sourceInterface,
+		BGP:             bgp,
 	})
 
 	cond := conditions.FromError(err)
@@ -442,6 +427,11 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (_ c
 }
 
 func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (reterr error) {
+	bgp, err := r.reconcileBGP(ctx, s.BGPPeer, s.Device)
+	if err != nil {
+		return err
+	}
+
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
 		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
@@ -454,6 +444,7 @@ func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (rete
 	return s.Provider.DeleteBGPPeer(ctx, &provider.DeleteBGPPeerRequest{
 		BGPPeer:        s.BGPPeer,
 		ProviderConfig: s.ProviderConfig,
+		BGP:            bgp,
 	})
 }
 
@@ -501,26 +492,59 @@ func (r *BGPPeerReconciler) bgpToBGPPeers(ctx context.Context, obj client.Object
 	log := ctrl.LoggerFrom(ctx, "BGP", klog.KObj(bgp))
 
 	list := new(v1alpha1.BGPPeerList)
-	if err := r.List(ctx, list,
-		client.InNamespace(bgp.Namespace),
-		client.MatchingLabels{v1alpha1.DeviceLabel: bgp.Spec.DeviceRef.Name},
-	); err != nil {
+	if err := r.List(ctx, list, client.InNamespace(bgp.Namespace)); err != nil {
 		log.Error(err, "Failed to list BGPPeers")
 		return nil
 	}
 
-	requests := make([]ctrl.Request, 0, len(list.Items))
+	var requests []ctrl.Request
 	for _, i := range list.Items {
-		log.Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&i))
-		requests = append(requests, ctrl.Request{
-			NamespacedName: client.ObjectKey{
-				Name:      i.Name,
-				Namespace: i.Namespace,
-			},
-		})
+		if i.Spec.BgpRef.Name == bgp.Name {
+			log.Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&i))
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      i.Name,
+					Namespace: i.Namespace,
+				},
+			})
+		}
 	}
 
 	return requests
+}
+
+// reconcileBGP resolves the referenced BGP instance.
+// Sets ConfiguredCondition and returns a terminal error when the BGP is not found
+// or belongs to a different device.
+func (r *BGPPeerReconciler) reconcileBGP(ctx context.Context, peer *v1alpha1.BGPPeer, device *v1alpha1.Device) (*v1alpha1.BGP, error) {
+	bgp := new(v1alpha1.BGP)
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      peer.Spec.BgpRef.Name,
+		Namespace: peer.Namespace,
+	}, bgp); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(peer, metav1.Condition{
+				Type:    v1alpha1.ConfiguredCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.BGPNotFoundReason,
+				Message: fmt.Sprintf("BGP %s not found", peer.Spec.BgpRef.Name),
+			})
+			return nil, reconcile.TerminalError(fmt.Errorf("bgp %s not found", peer.Spec.BgpRef.Name))
+		}
+		return nil, fmt.Errorf("failed to get BGP %s: %w", peer.Spec.BgpRef.Name, err)
+	}
+
+	if bgp.Spec.DeviceRef.Name != device.Name {
+		conditions.Set(peer, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("BGP %s belongs to device %s, not %s", peer.Spec.BgpRef.Name, bgp.Spec.DeviceRef.Name, device.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("bgp %s belongs to different device", peer.Spec.BgpRef.Name))
+	}
+
+	return bgp, nil
 }
 
 // bgpPeersForProviderConfig is a [handler.MapFunc] to be used to enqueue requests for reconciliation

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -98,6 +98,7 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 				Spec: v1alpha1.BGPPeerSpec{
 					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 				},
@@ -172,6 +173,7 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 				Spec: v1alpha1.BGPPeerSpec{
 					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 					LocalAddress: &v1alpha1.BGPPeerLocalAddress{
@@ -211,6 +213,7 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 				Spec: v1alpha1.BGPPeerSpec{
 					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 					LocalAddress: &v1alpha1.BGPPeerLocalAddress{
@@ -261,6 +264,7 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 				Spec: v1alpha1.BGPPeerSpec{
 					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 					LocalAddress: &v1alpha1.BGPPeerLocalAddress{
@@ -287,32 +291,18 @@ var _ = Describe("BGPPeer Controller", func() {
 			}).Should(Succeed())
 		})
 
-		It("Should set Configured=False with BGPNotFoundReason when no BGP resource exists on device", func() {
-			By("Creating a separate Device without a BGP resource")
-			device := &v1alpha1.Device{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bgppeer-nobgp-",
-					Namespace:    metav1.NamespaceDefault,
-				},
-				Spec: v1alpha1.DeviceSpec{
-					Endpoint: v1alpha1.Endpoint{
-						Address: "192.168.10.3:9339",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, device)).To(Succeed())
-			key := client.ObjectKey{Name: device.Name, Namespace: metav1.NamespaceDefault}
-
-			By("Creating a BGPPeer on the device that has no BGP")
+		It("Should set Configured=False with BGPNotFoundReason when bgpRef points to a non-existent BGP", func() {
+			By("Creating a BGPPeer with a non-existent bgpRef")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      device.Name,
+					Name:      name,
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
-					Address:   "10.0.0.2",
-					ASNumber:  intstr.FromInt(65001),
+					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: "does-not-exist"},
+					Address:   host,
+					ASNumber:  intstr.FromInt(65000),
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
@@ -335,12 +325,8 @@ var _ = Describe("BGPPeer Controller", func() {
 
 			By("Verifying the BGP peer is NOT configured in the provider")
 			Consistently(func(g Gomega) {
-				g.Expect(testProvider.BGPPeers.Has("10.0.0.2")).To(BeFalse(), "Provider should not have BGP peer configured")
+				g.Expect(testProvider.BGPPeers.Has(host)).To(BeFalse(), "Provider should not have BGP peer configured")
 			}).Should(Succeed())
-
-			By("Cleaning up test-specific resources")
-			Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
 		})
 
 		It("Should set Configured=False with WaitingForDependenciesReason when BGP exists but is not configured", func() {
@@ -359,14 +345,11 @@ var _ = Describe("BGPPeer Controller", func() {
 			Expect(k8sClient.Create(ctx, unconfiguredDevice)).To(Succeed())
 			unconfiguredKey := client.ObjectKey{Name: unconfiguredDevice.Name, Namespace: metav1.NamespaceDefault}
 
-			By("Creating a paused BGP resource with DeviceLabel pre-set (will not be configured)")
+			By("Creating a paused BGP resource (will not be configured)")
 			bgp := &v1alpha1.BGP{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-bgppeer-uncfg-bgp-",
 					Namespace:    metav1.NamespaceDefault,
-					Labels: map[string]string{
-						v1alpha1.DeviceLabel: unconfiguredDevice.Name,
-					},
 					Annotations: map[string]string{
 						v1alpha1.PausedAnnotation: "",
 					},
@@ -379,7 +362,7 @@ var _ = Describe("BGPPeer Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
 
-			By("Creating a BGPPeer on the device with the unconfigured BGP")
+			By("Creating a BGPPeer referencing the unconfigured BGP")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      unconfiguredDevice.Name,
@@ -387,6 +370,7 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 				Spec: v1alpha1.BGPPeerSpec{
 					DeviceRef: v1alpha1.LocalObjectReference{Name: unconfiguredDevice.Name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgp.Name},
 					Address:   "10.0.0.3",
 					ASNumber:  intstr.FromInt(65002),
 				},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -398,11 +398,15 @@ type EnsureBGPPeerRequest struct {
 	BGPPeer         *v1alpha1.BGPPeer
 	ProviderConfig  *ProviderConfig
 	SourceInterface string
+	// BGP is the resolved BGP instance referenced by BGPPeer.Spec.BgpRef.
+	BGP *v1alpha1.BGP
 }
 
 type DeleteBGPPeerRequest struct {
 	BGPPeer        *v1alpha1.BGPPeer
 	ProviderConfig *ProviderConfig
+	// BGP is the resolved BGP instance referenced by BGPPeer.Spec.BgpRef.
+	BGP *v1alpha1.BGP
 }
 
 type BGPPeerStatusRequest struct {


### PR DESCRIPTION
BGPPeer.Spec now carries a required BgpRef field pointing to the parent BGP instance. The controller resolves this reference via a new reconcileBGP helper that sets ConfiguredCondition and returns a terminal error when the BGP is not found or belongs to a different device; when the BGP exists but is not yet ready it returns nil so the reconciler returns without retrying.

The resolved BGP is passed through EnsureBGPPeerRequest and DeleteBGPPeerRequest so providers can use it. Currently the NX-OS provider has no use for that, so there is no related change in the NX-OS provider code.

This partially reverts commit 5ce63e2f, which deliberately avoided a direct reference to allow operators to create BGPPeer resources without knowing the Kubernetes resource name of the BGP process. With bgpRef that trade-off is reversed in favour of an explicit, verifiable ownership link. The reason is to support a reference to a VRF which will be part of an upcoming change.