### PR TITLE
Add vrfRef to BGP and propagate VRF through BGPPeer controller

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -90,6 +90,7 @@ k8s_resource(new_name='pim', objects=['pim:pim'], resource_deps=['lo0', 'lo1', '
 
 k8s_yaml('./config/samples/v1alpha1_bgp.yaml')
 k8s_resource(new_name='bgp', objects=['bgp:bgp'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+k8s_resource(new_name='bgp-vrf-cc-admin', objects=['bgp-vrf-cc-admin:bgp'], resource_deps=['vrf-admin'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 
 k8s_yaml('./config/samples/v1alpha1_bgppeer.yaml')
 k8s_resource(new_name='peer-spine1', objects=['leaf1-spine1:bgppeer'], resource_deps=['bgp', 'lo0'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)

--- a/api/core/v1alpha1/bgp_types.go
+++ b/api/core/v1alpha1/bgp_types.go
@@ -12,12 +12,19 @@ import (
 )
 
 // BGPSpec defines the desired state of BGP
+// +kubebuilder:validation:XValidation:rule="(!has(self.vrfRef) && !has(oldSelf.vrfRef)) || (has(self.vrfRef) && has(oldSelf.vrfRef) && self.vrfRef == oldSelf.vrfRef)",message="VrfRef is immutable"
 type BGPSpec struct {
 	// DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
 	// Immutable.
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="DeviceRef is immutable"
 	DeviceRef LocalObjectReference `json:"deviceRef"`
+
+	// VrfRef is an optional reference to the VRF this BGP instance is scoped to.
+	// When omitted, the BGP instance is configured in the default VRF.
+	// Immutable.
+	// +optional
+	VrfRef *LocalObjectReference `json:"vrfRef,omitempty"`
 
 	// ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.
 	// This reference is used to link the BGP to its provider-specific configuration.
@@ -31,7 +38,9 @@ type BGPSpec struct {
 
 	// ASNumber is the autonomous system number (ASN) for the BGP router.
 	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Immutable.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ASNumber is immutable"
 	ASNumber intstr.IntOrString `json:"asNumber"`
 
 	// RouterID is the BGP router identifier, used in BGP messages to identify the originating router.

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -613,6 +613,11 @@ func (in *BGPRouteTargetPolicy) DeepCopy() *BGPRouteTargetPolicy {
 func (in *BGPSpec) DeepCopyInto(out *BGPSpec) {
 	*out = *in
 	out.DeviceRef = in.DeviceRef
+	if in.VrfRef != nil {
+		in, out := &in.VrfRef, &out.VrfRef
+		*out = new(LocalObjectReference)
+		**out = **in
+	}
 	if in.ProviderConfigRef != nil {
 		in, out := &in.ProviderConfigRef, &out.ProviderConfigRef
 		*out = new(TypedLocalObjectReference)

--- a/charts/network-operator/templates/crd/bgp.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bgp.networking.metal.ironcore.dev.yaml
@@ -253,7 +253,11 @@ spec:
                 description: |-
                   ASNumber is the autonomous system number (ASN) for the BGP router.
                   Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                  Immutable.
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: ASNumber is immutable
+                  rule: self == oldSelf
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
@@ -313,11 +317,32 @@ spec:
                   Follows dotted quad notation (IPv4 format).
                 format: ipv4
                 type: string
+              vrfRef:
+                description: |-
+                  VrfRef is an optional reference to the VRF this BGP instance is scoped to.
+                  When omitted, the BGP instance is configured in the default VRF.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
             required:
             - asNumber
             - deviceRef
             - routerId
             type: object
+            x-kubernetes-validations:
+            - message: VrfRef is immutable
+              rule: (!has(self.vrfRef) && !has(oldSelf.vrfRef)) || (has(self.vrfRef)
+                && has(oldSelf.vrfRef) && self.vrfRef == oldSelf.vrfRef)
           status:
             description: |-
               Status of the resource. This is set and updated automatically.

--- a/config/crd/bases/networking.metal.ironcore.dev_bgp.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_bgp.yaml
@@ -250,7 +250,11 @@ spec:
                 description: |-
                   ASNumber is the autonomous system number (ASN) for the BGP router.
                   Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                  Immutable.
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: ASNumber is immutable
+                  rule: self == oldSelf
               deviceRef:
                 description: |-
                   DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.
@@ -310,11 +314,32 @@ spec:
                   Follows dotted quad notation (IPv4 format).
                 format: ipv4
                 type: string
+              vrfRef:
+                description: |-
+                  VrfRef is an optional reference to the VRF this BGP instance is scoped to.
+                  When omitted, the BGP instance is configured in the default VRF.
+                  Immutable.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
             required:
             - asNumber
             - deviceRef
             - routerId
             type: object
+            x-kubernetes-validations:
+            - message: VrfRef is immutable
+              rule: (!has(self.vrfRef) && !has(oldSelf.vrfRef)) || (has(self.vrfRef)
+                && has(oldSelf.vrfRef) && self.vrfRef == oldSelf.vrfRef)
           status:
             description: |-
               Status of the resource. This is set and updated automatically.

--- a/config/samples/v1alpha1_bgp.yaml
+++ b/config/samples/v1alpha1_bgp.yaml
@@ -34,3 +34,26 @@ spec:
         enabled: false
       routeTargetPolicy:
         retainAll: true
+---
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: BGP
+metadata:
+  labels:
+    app.kubernetes.io/name: network-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: bgp-vrf-cc-admin
+spec:
+  deviceRef:
+    name: leaf1
+  vrfRef:
+    name: vrf-cc-admin
+  # See ./cisco/nx/v1alpha1_bgpconfig.yaml
+  # providerConfigRef:
+  #   apiVersion: nx.cisco.networking.metal.ironcore.dev/v1alpha1
+  #   kind: BGPConfig
+  #   name: bgpconfig-sample
+  asNumber: 65000
+  routerId: 10.0.0.10
+  addressFamilies:
+    ipv4Unicast:
+      enabled: true

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -541,9 +541,10 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `deviceRef` _[LocalObjectReference](#localobjectreference)_ | DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.<br />Immutable. |  | Required: \{\} <br /> |
+| `vrfRef` _[LocalObjectReference](#localobjectreference)_ | VrfRef is an optional reference to the VRF this BGP instance is scoped to.<br />When omitted, the BGP instance is configured in the default VRF.<br />Immutable. |  | Optional: \{\} <br /> |
 | `providerConfigRef` _[TypedLocalObjectReference](#typedlocalobjectreference)_ | ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.<br />This reference is used to link the BGP to its provider-specific configuration. |  | Optional: \{\} <br /> |
 | `adminState` _[AdminState](#adminstate)_ | AdminState indicates whether this BGP router is administratively up or down. | Up | Enum: [Up Down] <br />Optional: \{\} <br /> |
-| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) for the BGP router.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Required: \{\} <br /> |
+| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) for the BGP router.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.<br />Immutable. |  | Required: \{\} <br /> |
 | `routerId` _string_ | RouterID is the BGP router identifier, used in BGP messages to identify the originating router.<br />Follows dotted quad notation (IPv4 format). |  | Format: ipv4 <br />Required: \{\} <br /> |
 | `addressFamilies` _[BGPAddressFamilies](#bgpaddressfamilies)_ | AddressFamilies configures supported BGP address families and their specific settings. |  | Optional: \{\} <br /> |
 

--- a/internal/controller/core/bgp_controller.go
+++ b/internal/controller/core/bgp_controller.go
@@ -36,6 +36,9 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/resourcelock"
 )
 
+// bgpVrfRefIndexKey is the field index key for BGP.Spec.VrfRef.Name.
+const bgpVrfRefIndexKey = ".spec.vrfRef.name"
+
 // BGPReconciler reconciles a BGP object
 type BGPReconciler struct {
 	client.Client
@@ -62,6 +65,7 @@ type BGPReconciler struct {
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgp,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgp/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgp/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=vrfs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -228,6 +232,16 @@ func (r *BGPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 		return err
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.BGP{}, bgpVrfRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.BGP)
+		if o.Spec.VrfRef == nil {
+			return nil
+		}
+		return []string{o.Spec.VrfRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.BGP{}).
 		Named("bgp").
@@ -253,6 +267,20 @@ func (r *BGPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return paused.DevicePausedChanged(e.ObjectOld, e.ObjectNew)
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
+		// Watches enqueues BGPs for updates in referenced VRF resources.
+		// Only triggers on create and delete events since VRF names are immutable.
+		Watches(
+			&v1alpha1.VRF{},
+			handler.EnqueueRequestsFromMapFunc(r.vrfToBGPs),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return false
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -285,6 +313,15 @@ func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (reterr erro
 		}
 	}
 
+	var vrf *v1alpha1.VRF
+	if s.BGP.Spec.VrfRef != nil {
+		var err error
+		vrf, err = r.reconcileVRF(ctx, s.BGP, s.Device)
+		if err != nil {
+			return err
+		}
+	}
+
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
 		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
@@ -298,6 +335,7 @@ func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (reterr erro
 	err := s.Provider.EnsureBGP(ctx, &provider.EnsureBGPRequest{
 		BGP:            s.BGP,
 		ProviderConfig: s.ProviderConfig,
+		VRF:            vrf,
 	})
 
 	cond := conditions.FromError(err)
@@ -309,6 +347,21 @@ func (r *BGPReconciler) reconcile(ctx context.Context, s *bgpScope) (reterr erro
 }
 
 func (r *BGPReconciler) finalize(ctx context.Context, s *bgpScope) (reterr error) {
+	var vrf *v1alpha1.VRF
+	if s.BGP.Spec.VrfRef != nil {
+		vrf = new(v1alpha1.VRF)
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      s.BGP.Spec.VrfRef.Name,
+			Namespace: s.BGP.Namespace,
+		}, vrf); err != nil {
+			// If the VRF is not found, we can assume it was deleted and with it the BGP reference, so we can proceed with deletion without error.
+			return client.IgnoreNotFound(err)
+		}
+		if vrf.Spec.DeviceRef.Name != s.Device.Name {
+			return reconcile.TerminalError(fmt.Errorf("vrf %s belongs to different device", s.BGP.Spec.VrfRef.Name))
+		}
+	}
+
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
 		return fmt.Errorf("failed to connect to provider: %w", err)
 	}
@@ -321,7 +374,40 @@ func (r *BGPReconciler) finalize(ctx context.Context, s *bgpScope) (reterr error
 	return s.Provider.DeleteBGP(ctx, &provider.DeleteBGPRequest{
 		BGP:            s.BGP,
 		ProviderConfig: s.ProviderConfig,
+		VRF:            vrf,
 	})
+}
+
+// reconcileVRF resolves the VRF referenced by the BGP's VrfRef field.
+// Returns nil when no VrfRef is set, meaning the default VRF should be used.
+// Sets ReadyCondition and returns a terminal error when the VRF is not found or belongs to a different device.
+func (r *BGPReconciler) reconcileVRF(ctx context.Context, bgp *v1alpha1.BGP, device *v1alpha1.Device) (*v1alpha1.VRF, error) {
+	vrf := new(v1alpha1.VRF)
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      bgp.Spec.VrfRef.Name,
+		Namespace: bgp.Namespace,
+	}, vrf); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(bgp, metav1.Condition{
+				Type:    v1alpha1.ReadyCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.VRFNotFoundReason,
+				Message: fmt.Sprintf("VRF %s not found", bgp.Spec.VrfRef.Name),
+			})
+			return nil, reconcile.TerminalError(fmt.Errorf("vrf %s not found", bgp.Spec.VrfRef.Name))
+		}
+		return nil, fmt.Errorf("failed to get VRF %s: %w", bgp.Spec.VrfRef.Name, err)
+	}
+	if vrf.Spec.DeviceRef.Name != device.Name {
+		conditions.Set(bgp, metav1.Condition{
+			Type:    v1alpha1.ReadyCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("VRF %s belongs to device %s, not %s", bgp.Spec.VrfRef.Name, vrf.Spec.DeviceRef.Name, device.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("vrf %s belongs to different device", bgp.Spec.VrfRef.Name))
+	}
+	return vrf, nil
 }
 
 // deviceToBGPs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
@@ -386,5 +472,37 @@ func (r *BGPReconciler) bgpForProviderConfig(ctx context.Context, obj client.Obj
 		}
 	}
 
+	return requests
+}
+
+// vrfToBGPs is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for BGPs when their referenced VRF is created or deleted.
+func (r *BGPReconciler) vrfToBGPs(ctx context.Context, obj client.Object) []ctrl.Request {
+	vrf, ok := obj.(*v1alpha1.VRF)
+	if !ok {
+		panic(fmt.Sprintf("Expected a VRF but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "VRF", klog.KObj(vrf))
+
+	list := new(v1alpha1.BGPList)
+	if err := r.List(ctx, list,
+		client.InNamespace(vrf.Namespace),
+		client.MatchingFields{bgpVrfRefIndexKey: vrf.Name},
+	); err != nil {
+		log.Error(err, "Failed to list BGPs")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(list.Items))
+	for _, b := range list.Items {
+		log.V(2).Info("Enqueuing BGP for reconciliation", "BGP", klog.KObj(&b))
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      b.Name,
+				Namespace: b.Namespace,
+			},
+		})
+	}
 	return requests
 }

--- a/internal/controller/core/bgp_controller_test.go
+++ b/internal/controller/core/bgp_controller_test.go
@@ -6,24 +6,23 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/conditions"
 )
 
 var _ = Describe("BGP Controller", func() {
 	Context("When reconciling a resource", func() {
-		var (
-			name string
-			key  client.ObjectKey
-		)
+		var device *v1alpha1.Device
 
 		BeforeEach(func() {
-			By("Creating the custom resource for the Kind Device")
-			device := &v1alpha1.Device{
+			By("Creating a Device resource for testing")
+			device = &v1alpha1.Device{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-bgp-",
 					Namespace:    metav1.NamespaceDefault,
@@ -35,73 +34,66 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
-			name = device.Name
-			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		})
 
+		AfterEach(func() {
+			By("Deleting the Device resource")
+			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+		})
+
+		It("Should successfully reconcile the resource", func() {
 			By("Creating the custom resource for the Kind BGP")
-			resource := &v1alpha1.BGP{
+			bgp := &v1alpha1.BGP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgp-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
 					ASNumber:  intstr.FromInt(65000),
 					RouterID:  "10.0.0.10",
 				},
 			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-		})
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+				Eventually(func(g Gomega) {
+					b := &v1alpha1.BGP{}
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
+				}).Should(Succeed())
+				By("Ensuring the resource is deleted from the provider")
+				Eventually(func(g Gomega) {
+					g.Expect(testProvider.BGP).To(BeNil(), "Provider should not have BGP instance configured")
+				}).Should(Succeed())
+			})
 
-		AfterEach(func() {
-			var resource client.Object = &v1alpha1.BGP{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance BGP")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
-			Eventually(func(g Gomega) {
-				g.Expect(testProvider.BGP).To(BeNil(), "Provider should not have BGP instance configured")
-			}).Should(Succeed())
-		})
-
-		It("Should successfully reconcile the resource", func() {
 			By("Adding a finalizer to the resource")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGP{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
 				g.Expect(controllerutil.ContainsFinalizer(resource, v1alpha1.FinalizerName)).To(BeTrue())
 			}).Should(Succeed())
 
 			By("Adding the device label to the resource")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGP{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
-				g.Expect(resource.Labels).To(HaveKeyWithValue(v1alpha1.DeviceLabel, name))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
+				g.Expect(resource.Labels).To(HaveKeyWithValue(v1alpha1.DeviceLabel, device.Name))
 			}).Should(Succeed())
 
 			By("Adding the device as a owner reference")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGP{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
 				g.Expect(resource.OwnerReferences).To(HaveLen(1))
 				g.Expect(resource.OwnerReferences[0].Kind).To(Equal("Device"))
-				g.Expect(resource.OwnerReferences[0].Name).To(Equal(name))
+				g.Expect(resource.OwnerReferences[0].Name).To(Equal(device.Name))
 			}).Should(Succeed())
 
 			By("Updating the resource status")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGP{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(2))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
@@ -112,6 +104,135 @@ var _ = Describe("BGP Controller", func() {
 			By("Ensuring the resource is created in the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.BGP).ToNot(BeNil(), "Provider should have BGP instance configured")
+			}).Should(Succeed())
+		})
+
+		It("Should set ReadyCondition=False when vrfRef points to a non-existent VRF", func() {
+			By("Creating a BGP with a vrfRef pointing to a non-existent VRF")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.11",
+					VrfRef:    &v1alpha1.LocalObjectReference{Name: "does-not-exist"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+				Eventually(func(g Gomega) {
+					b := &v1alpha1.BGP{}
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("Expecting ReadyCondition to be False with VRFNotFoundReason reason")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
+				cond := conditions.Get(resource, v1alpha1.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(v1alpha1.VRFNotFoundReason))
+			}).Should(Succeed())
+		})
+
+		It("Should pass VRF to the provider when vrfRef is set", func() {
+			By("Creating a VRF")
+			vrf := &v1alpha1.VRF{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vrf-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.VRFSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					Name:      "CC-MGMT",
+				},
+			}
+			Expect(k8sClient.Create(ctx, vrf)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, vrf)).To(Succeed())
+			})
+
+			By("Creating a BGP with the vrfRef set")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.12",
+					VrfRef:    &v1alpha1.LocalObjectReference{Name: vrf.Name},
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+				Eventually(func(g Gomega) {
+					b := &v1alpha1.BGP{}
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("Ensuring the provider receives the VRF")
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.BGPVRF).ToNot(BeNil())
+				g.Expect(testProvider.BGPVRF.Spec.Name).To(Equal("CC-MGMT"))
+			}).Should(Succeed())
+
+			By("Ensuring ReadyCondition is True")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
+				cond := conditions.Get(resource, v1alpha1.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Should reject VrfRef changes via the API server", func() {
+			By("Creating the custom resource for the Kind BGP")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.10",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+				Eventually(func(g Gomega) {
+					b := &v1alpha1.BGP{}
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("Waiting for the BGP to be reconciled so we know it exists")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
+				g.Expect(controllerutil.ContainsFinalizer(resource, v1alpha1.FinalizerName)).To(BeTrue())
+			}).Should(Succeed())
+
+			By("Attempting to set VrfRef (must be rejected — immutable)")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), resource)).To(Succeed())
+				resource.Spec.VrfRef = &v1alpha1.LocalObjectReference{Name: "some-vrf"}
+				err := k8sClient.Update(ctx, resource)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("VrfRef is immutable"))
 			}).Should(Succeed())
 		})
 	})

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -39,6 +39,9 @@ import (
 	"github.com/ironcore-dev/network-operator/internal/resourcelock"
 )
 
+// bgpPeerBGPRefIndexKey is the field index key for BGPPeer.Spec.BgpRef.Name.
+const bgpPeerBGPRefIndexKey = ".spec.bgpRef.name"
+
 // BGPPeerReconciler reconciles a BGPPeer object
 type BGPPeerReconciler struct {
 	client.Client
@@ -66,6 +69,7 @@ type BGPPeerReconciler struct {
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgppeers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgppeers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgp,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=vrfs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -232,6 +236,13 @@ func (r *BGPPeerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		return err
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.BGPPeer{}, bgpPeerBGPRefIndexKey, func(obj client.Object) []string {
+		o := obj.(*v1alpha1.BGPPeer)
+		return []string{o.Spec.BgpRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.BGPPeer{}).
 		Named("bgppeer").
@@ -264,8 +275,7 @@ func (r *BGPPeerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			}),
 		).
 		// Watches enqueues BGPPeers for updates in BGP resources on the same device.
-		// Triggers on create, delete, and update events. For updates, only triggers
-		// when the BGP transitions from not-ready to ready.
+		// Only triggers on create, delete and update events when the BGP ready state changes.
 		Watches(
 			&v1alpha1.BGP{},
 			handler.EnqueueRequestsFromMapFunc(r.bgpToBGPPeers),
@@ -273,8 +283,21 @@ func (r *BGPPeerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					oldBGP := e.ObjectOld.(*v1alpha1.BGP)
 					newBGP := e.ObjectNew.(*v1alpha1.BGP)
-					// Only trigger when the BGP transitions from not-ready to ready.
 					return conditions.IsReady(oldBGP) != conditions.IsReady(newBGP)
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
+		// Watches enqueues BGPPeers for updates in VRF resources referenced by their BGP.
+		// Only triggers on create and delete events since VRF names are immutable.
+		Watches(
+			&v1alpha1.VRF{},
+			handler.EnqueueRequestsFromMapFunc(r.vrfToBGPPeers),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return false
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -328,6 +351,14 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (ret
 		return nil
 	}
 
+	var vrf *v1alpha1.VRF
+	if bgp.Spec.VrfRef != nil {
+		vrf, err = r.reconcileVRF(ctx, s.BGPPeer, bgp, s.Device)
+		if err != nil {
+			return err
+		}
+	}
+
 	var sourceInterface string
 	if addr := s.BGPPeer.Spec.LocalAddress; addr != nil {
 		intf := new(v1alpha1.Interface)
@@ -371,6 +402,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (ret
 		ProviderConfig:  s.ProviderConfig,
 		SourceInterface: sourceInterface,
 		BGP:             bgp,
+		VRF:             vrf,
 	})
 
 	cond := conditions.FromError(err)
@@ -383,6 +415,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (ret
 	status, err := s.Provider.GetPeerStatus(ctx, &provider.BGPPeerStatusRequest{
 		BGPPeer:        s.BGPPeer,
 		ProviderConfig: s.ProviderConfig,
+		VRF:            vrf,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get bgp peer status: %w", err)
@@ -430,9 +463,31 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (ret
 }
 
 func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (reterr error) {
-	bgp, err := r.reconcileBGP(ctx, s.BGPPeer, s.Device)
-	if err != nil {
-		return err
+	bgp := new(v1alpha1.BGP)
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      s.BGPPeer.Spec.BgpRef.Name,
+		Namespace: s.BGPPeer.Namespace,
+	}, bgp); err != nil {
+		// If the BGP is not found, we can assume it was deleted and with it the BGP peer reference, so we can proceed with deletion without error.
+		return client.IgnoreNotFound(err)
+	}
+	if bgp.Spec.DeviceRef.Name != s.Device.Name {
+		return reconcile.TerminalError(fmt.Errorf("bgp %s belongs to different device", s.BGPPeer.Spec.BgpRef.Name))
+	}
+
+	var vrf *v1alpha1.VRF
+	if bgp.Spec.VrfRef != nil {
+		vrf = new(v1alpha1.VRF)
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      bgp.Spec.VrfRef.Name,
+			Namespace: s.BGPPeer.Namespace,
+		}, vrf); err != nil {
+			// If the VRF is not found, we can assume it was deleted and with it the BGP peer reference, so we can proceed with deletion without error.
+			return client.IgnoreNotFound(err)
+		}
+		if vrf.Spec.DeviceRef.Name != s.Device.Name {
+			return reconcile.TerminalError(fmt.Errorf("vrf %s belongs to different device", bgp.Spec.VrfRef.Name))
+		}
 	}
 
 	if err := s.Provider.Connect(ctx, s.Connection); err != nil {
@@ -448,6 +503,7 @@ func (r *BGPPeerReconciler) finalize(ctx context.Context, s *bgpPeerScope) (rete
 		BGPPeer:        s.BGPPeer,
 		ProviderConfig: s.ProviderConfig,
 		BGP:            bgp,
+		VRF:            vrf,
 	})
 }
 
@@ -485,6 +541,39 @@ func (r *BGPPeerReconciler) reconcileBGP(ctx context.Context, peer *v1alpha1.BGP
 	return bgp, nil
 }
 
+// Returns nil when no VrfRef is set, meaning the default VRF should be used.
+// Sets ConfiguredCondition and returns a terminal error when the VRF is not found or belongs to a different device.
+func (r *BGPPeerReconciler) reconcileVRF(ctx context.Context, peer *v1alpha1.BGPPeer, bgp *v1alpha1.BGP, device *v1alpha1.Device) (*v1alpha1.VRF, error) {
+	vrf := new(v1alpha1.VRF)
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      bgp.Spec.VrfRef.Name,
+		Namespace: peer.Namespace,
+	}, vrf); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(peer, metav1.Condition{
+				Type:    v1alpha1.ConfiguredCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.VRFNotFoundReason,
+				Message: fmt.Sprintf("VRF %s not found", bgp.Spec.VrfRef.Name),
+			})
+			return nil, reconcile.TerminalError(fmt.Errorf("vrf %s not found", bgp.Spec.VrfRef.Name))
+		}
+		return nil, fmt.Errorf("failed to get VRF %s: %w", bgp.Spec.VrfRef.Name, err)
+	}
+
+	if vrf.Spec.DeviceRef.Name != device.Name {
+		conditions.Set(peer, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("VRF %s belongs to device %s, not %s", bgp.Spec.VrfRef.Name, vrf.Spec.DeviceRef.Name, device.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("vrf %s belongs to different device", bgp.Spec.VrfRef.Name))
+	}
+
+	return vrf, nil
+}
+
 // deviceToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
 // for BGPPeers when their referenced Device's effective pause state changes.
 func (r *BGPPeerReconciler) deviceToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
@@ -518,38 +607,6 @@ func (r *BGPPeerReconciler) deviceToBGPPeers(ctx context.Context, obj client.Obj
 	return requests
 }
 
-// bgpToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
-// for BGPPeers when a BGP resource is created, deleted or updated on the same device.
-func (r *BGPPeerReconciler) bgpToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
-	bgp, ok := obj.(*v1alpha1.BGP)
-	if !ok {
-		panic(fmt.Sprintf("Expected a BGP but got a %T", obj))
-	}
-
-	log := ctrl.LoggerFrom(ctx, "BGP", klog.KObj(bgp))
-
-	list := new(v1alpha1.BGPPeerList)
-	if err := r.List(ctx, list, client.InNamespace(bgp.Namespace)); err != nil {
-		log.Error(err, "Failed to list BGPPeers")
-		return nil
-	}
-
-	var requests []ctrl.Request
-	for _, i := range list.Items {
-		if i.Spec.BgpRef.Name == bgp.Name {
-			log.Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&i))
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      i.Name,
-					Namespace: i.Namespace,
-				},
-			})
-		}
-	}
-
-	return requests
-}
-
 // bgpPeersForProviderConfig is a [handler.MapFunc] to be used to enqueue requests for reconciliation
 // for a BGPPeer to update when one of its referenced provider configurations gets updated.
 func (r *BGPPeerReconciler) bgpPeersForProviderConfig(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -574,6 +631,83 @@ func (r *BGPPeerReconciler) bgpPeersForProviderConfig(ctx context.Context, obj c
 				NamespacedName: types.NamespacedName{
 					Name:      m.Name,
 					Namespace: m.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
+}
+
+// bgpToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for BGPPeers when a BGP resource is created, deleted or updated on the same device.
+func (r *BGPPeerReconciler) bgpToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
+	bgp, ok := obj.(*v1alpha1.BGP)
+	if !ok {
+		panic(fmt.Sprintf("Expected a BGP but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "BGP", klog.KObj(bgp))
+
+	list := new(v1alpha1.BGPPeerList)
+	if err := r.List(ctx, list,
+		client.InNamespace(bgp.Namespace),
+		client.MatchingFields{bgpPeerBGPRefIndexKey: bgp.Name},
+	); err != nil {
+		log.Error(err, "Failed to list BGPPeers")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(list.Items))
+	for _, i := range list.Items {
+		log.V(2).Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&i))
+		requests = append(requests, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      i.Name,
+				Namespace: i.Namespace,
+			},
+		})
+	}
+
+	return requests
+}
+
+// vrfToBGPPeers is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for BGPPeers when the VRF referenced by their BGP is created or deleted.
+func (r *BGPPeerReconciler) vrfToBGPPeers(ctx context.Context, obj client.Object) []ctrl.Request {
+	vrf, ok := obj.(*v1alpha1.VRF)
+	if !ok {
+		panic(fmt.Sprintf("Expected a VRF but got a %T", obj))
+	}
+
+	log := ctrl.LoggerFrom(ctx, "VRF", klog.KObj(vrf))
+
+	bgpList := new(v1alpha1.BGPList)
+	if err := r.List(ctx, bgpList,
+		client.InNamespace(vrf.Namespace),
+		client.MatchingFields{bgpVrfRefIndexKey: vrf.Name},
+	); err != nil {
+		log.Error(err, "Failed to list BGPs")
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for _, bgp := range bgpList.Items {
+		peerList := new(v1alpha1.BGPPeerList)
+		if err := r.List(ctx, peerList,
+			client.InNamespace(vrf.Namespace),
+			client.MatchingFields{bgpPeerBGPRefIndexKey: bgp.Name},
+		); err != nil {
+			log.Error(err, "Failed to list BGPPeers")
+			return nil
+		}
+
+		for _, p := range peerList.Items {
+			log.V(2).Info("Enqueuing BGPPeer for reconciliation", "BGPPeer", klog.KObj(&p))
+			requests = append(requests, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      p.Name,
+					Namespace: p.Namespace,
 				},
 			})
 		}

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -18,15 +18,11 @@ import (
 var _ = Describe("BGPPeer Controller", func() {
 	Context("When reconciling a resource", func() {
 		const host = "10.0.0.1"
-		var (
-			name   string
-			key    client.ObjectKey
-			bgpKey client.ObjectKey
-		)
+		var device *v1alpha1.Device
 
 		BeforeEach(func() {
 			By("Creating a Device resource for testing")
-			device := &v1alpha1.Device{
+			device = &v1alpha1.Device{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-bgppeer-",
 					Namespace:    metav1.NamespaceDefault,
@@ -38,9 +34,14 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
-			name = device.Name
-			key = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
+		})
 
+		AfterEach(func() {
+			By("Deleting the Device resource")
+			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+		})
+
+		It("Should successfully reconcile a BGP peer", func() {
 			By("Creating a BGP resource for the Device")
 			bgp := &v1alpha1.BGP{
 				ObjectMeta: metav1.ObjectMeta{
@@ -48,90 +49,72 @@ var _ = Describe("BGPPeer Controller", func() {
 					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
 					ASNumber:  intstr.FromInt(65000),
 					RouterID:  "10.0.0.10",
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			bgpKey = client.ObjectKey{Name: bgp.Name, Namespace: metav1.NamespaceDefault}
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+			})
 
 			By("Waiting for the BGP resource to be fully configured")
 			Eventually(func(g Gomega) {
-				bgp := &v1alpha1.BGP{}
-				g.Expect(k8sClient.Get(ctx, bgpKey, bgp)).To(Succeed())
-				g.Expect(conditions.IsReady(bgp)).To(BeTrue())
+				b := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b)).To(Succeed())
+				g.Expect(conditions.IsReady(b)).To(BeTrue())
 			}).Should(Succeed())
-		})
 
-		AfterEach(func() {
-			By("Cleaning up all BGPPeer resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.BGPPeer{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-
-			By("Cleaning up the BGP resource")
-			bgp := &v1alpha1.BGP{}
-			Expect(k8sClient.Get(ctx, bgpKey, bgp)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-
-			By("Cleaning up all Interface resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.Interface{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleaning up the test Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-
-			By("Verifying the BGP peer is removed from the provider")
-			Eventually(func(g Gomega) {
-				g.Expect(testProvider.BGPPeers.Has(host)).To(BeFalse(), "Provider should not have BGP peer configured")
-			}).Should(Succeed())
-		})
-
-		It("Should successfully reconcile a BGP peer", func() {
 			By("Creating a BGPPeer resource")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgp.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+				By("Verifying the BGP peer is removed from the provider")
+				Eventually(func(g Gomega) {
+					g.Expect(testProvider.BGPPeers.Has(host)).To(BeFalse(), "Provider should not have BGP peer configured")
+				}).Should(Succeed())
+			})
 
 			By("Verifying the controller adds a finalizer")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(controllerutil.ContainsFinalizer(resource, v1alpha1.FinalizerName)).To(BeTrue())
 			}).Should(Succeed())
 
 			By("Verifying the controller adds the device label")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
-				g.Expect(resource.Labels).To(HaveKeyWithValue(v1alpha1.DeviceLabel, name))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
+				g.Expect(resource.Labels).To(HaveKeyWithValue(v1alpha1.DeviceLabel, device.Name))
 			}).Should(Succeed())
 
 			By("Verifying the controller sets the device as owner reference")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.OwnerReferences).To(HaveLen(1))
 				g.Expect(resource.OwnerReferences[0].Kind).To(Equal("Device"))
-				g.Expect(resource.OwnerReferences[0].Name).To(Equal(name))
+				g.Expect(resource.OwnerReferences[0].Name).To(Equal(device.Name))
 			}).Should(Succeed())
 
 			By("Verifying the controller updates the status conditions")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(4))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
@@ -150,43 +133,73 @@ var _ = Describe("BGPPeer Controller", func() {
 		})
 
 		It("Should successfully reconcile a BGP peer with local address", func() {
+			By("Creating a BGP resource for the Device")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.10",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+			})
+
+			By("Waiting for the BGP resource to be fully configured")
+			Eventually(func(g Gomega) {
+				b := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b)).To(Succeed())
+				g.Expect(conditions.IsReady(b)).To(BeTrue())
+			}).Should(Succeed())
+
 			By("Creating a Loopback Interface resource on the same device")
 			intf := &v1alpha1.Interface{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-intf-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.InterfaceSpec{
-					DeviceRef:  v1alpha1.LocalObjectReference{Name: name},
+					DeviceRef:  v1alpha1.LocalObjectReference{Name: device.Name},
 					Name:       "Loopback0",
 					AdminState: v1alpha1.AdminStateUp,
 					Type:       v1alpha1.InterfaceTypeLoopback,
 				},
 			}
 			Expect(k8sClient.Create(ctx, intf)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
+			})
 
 			By("Creating a BGPPeer resource with LocalAddress pointing to the Interface")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgp.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 					LocalAddress: &v1alpha1.BGPPeerLocalAddress{
-						InterfaceRef: v1alpha1.LocalObjectReference{Name: name},
+						InterfaceRef: v1alpha1.LocalObjectReference{Name: intf.Name},
 					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			})
 
 			By("Verifying the controller updates the status conditions successfully")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(4))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
@@ -205,15 +218,39 @@ var _ = Describe("BGPPeer Controller", func() {
 		})
 
 		It("Should handle local address reference to non-existing Interface", func() {
+			By("Creating a BGP resource for the Device")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.10",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+			})
+
+			By("Waiting for the BGP resource to be fully configured")
+			Eventually(func(g Gomega) {
+				b := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b)).To(Succeed())
+				g.Expect(conditions.IsReady(b)).To(BeTrue())
+			}).Should(Succeed())
+
 			By("Creating a BGPPeer resource with LocalAddress pointing to a non-existent Interface")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgp.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 					LocalAddress: &v1alpha1.BGPPeerLocalAddress{
@@ -222,11 +259,14 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			})
 
 			By("Verifying the controller sets Interface not found status")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(4))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
@@ -241,11 +281,35 @@ var _ = Describe("BGPPeer Controller", func() {
 		})
 
 		It("Should reject local address reference to Interface on different device", func() {
+			By("Creating a BGP resource for the Device")
+			bgp := &v1alpha1.BGP{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bgppeer-bgp-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.BGPSpec{
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					ASNumber:  intstr.FromInt(65000),
+					RouterID:  "10.0.0.10",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
+			})
+
+			By("Waiting for the BGP resource to be fully configured")
+			Eventually(func(g Gomega) {
+				b := &v1alpha1.BGP{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b)).To(Succeed())
+				g.Expect(conditions.IsReady(b)).To(BeTrue())
+			}).Should(Succeed())
+
 			By("Creating a Loopback Interface resource on a different device")
 			intf := &v1alpha1.Interface{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-intf-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.InterfaceSpec{
 					DeviceRef:  v1alpha1.LocalObjectReference{Name: "different-device"},
@@ -255,29 +319,35 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, intf)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
+			})
 
 			By("Creating a BGPPeer resource with LocalAddress pointing to the cross-device Interface")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
-					BgpRef:    v1alpha1.LocalObjectReference{Name: bgpKey.Name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: bgp.Name},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 					LocalAddress: &v1alpha1.BGPPeerLocalAddress{
-						InterfaceRef: v1alpha1.LocalObjectReference{Name: name},
+						InterfaceRef: v1alpha1.LocalObjectReference{Name: intf.Name},
 					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			})
 
 			By("Verifying the BGP peer rejects the cross-device interface reference")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(4))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
@@ -295,22 +365,25 @@ var _ = Describe("BGPPeer Controller", func() {
 			By("Creating a BGPPeer with a non-existent bgpRef")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
 					BgpRef:    v1alpha1.LocalObjectReference{Name: "does-not-exist"},
 					Address:   host,
 					ASNumber:  intstr.FromInt(65000),
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			})
 
 			By("Verifying the controller sets ConfiguredCondition to False with BGPNotFoundReason")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(4))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
@@ -330,57 +403,48 @@ var _ = Describe("BGPPeer Controller", func() {
 		})
 
 		It("Should set Configured=False with WaitingForDependenciesReason when BGP exists but is not configured", func() {
-			By("Creating a separate Device")
-			unconfiguredDevice := &v1alpha1.Device{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bgppeer-uncfg-",
-					Namespace:    metav1.NamespaceDefault,
-				},
-				Spec: v1alpha1.DeviceSpec{
-					Endpoint: v1alpha1.Endpoint{
-						Address: "192.168.10.4:9339",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, unconfiguredDevice)).To(Succeed())
-			unconfiguredKey := client.ObjectKey{Name: unconfiguredDevice.Name, Namespace: metav1.NamespaceDefault}
-
 			By("Creating a paused BGP resource (will not be configured)")
-			bgp := &v1alpha1.BGP{
+			pausedBGP := &v1alpha1.BGP{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bgppeer-uncfg-bgp-",
+					GenerateName: "test-bgppeer-paused-bgp-",
 					Namespace:    metav1.NamespaceDefault,
 					Annotations: map[string]string{
-						v1alpha1.PausedAnnotation: "",
+						v1alpha1.PausedAnnotation: "true",
 					},
 				},
 				Spec: v1alpha1.BGPSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: unconfiguredDevice.Name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
 					ASNumber:  intstr.FromInt(65000),
 					RouterID:  "10.0.0.11",
 				},
 			}
-			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
+			Expect(k8sClient.Create(ctx, pausedBGP)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, pausedBGP)).To(Succeed())
+			})
 
-			By("Creating a BGPPeer referencing the unconfigured BGP")
+			By("Creating a BGPPeer referencing the paused BGP")
 			bgppeer := &v1alpha1.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      unconfiguredDevice.Name,
-					Namespace: metav1.NamespaceDefault,
+					GenerateName: "test-bgppeer-",
+					Namespace:    metav1.NamespaceDefault,
 				},
 				Spec: v1alpha1.BGPPeerSpec{
-					DeviceRef: v1alpha1.LocalObjectReference{Name: unconfiguredDevice.Name},
-					BgpRef:    v1alpha1.LocalObjectReference{Name: bgp.Name},
+					DeviceRef: v1alpha1.LocalObjectReference{Name: device.Name},
+					BgpRef:    v1alpha1.LocalObjectReference{Name: pausedBGP.Name},
 					Address:   "10.0.0.3",
 					ASNumber:  intstr.FromInt(65002),
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
+			})
 
 			By("Verifying the controller sets ConfiguredCondition to False with WaitingForDependenciesReason")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
-				g.Expect(k8sClient.Get(ctx, unconfiguredKey, resource)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
 				g.Expect(resource.Status.Conditions).To(HaveLen(4))
 				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
 				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
@@ -397,11 +461,6 @@ var _ = Describe("BGPPeer Controller", func() {
 			Consistently(func(g Gomega) {
 				g.Expect(testProvider.BGPPeers.Has("10.0.0.3")).To(BeFalse(), "Provider should not have BGP peer configured")
 			}).Should(Succeed())
-
-			By("Cleaning up test-specific resources")
-			Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, unconfiguredDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
 		})
 	})
 })

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -432,6 +432,7 @@ type Provider struct {
 	VRF             sets.Set[string]
 	PIM             *v1alpha1.PIM
 	BGP             *v1alpha1.BGP
+	BGPVRF          *v1alpha1.VRF
 	BGPPeers        sets.Set[string]
 	OSPF            sets.Set[string]
 	VLANs           sets.Set[int16]
@@ -736,6 +737,7 @@ func (p *Provider) EnsureBGP(_ context.Context, req *provider.EnsureBGPRequest) 
 	p.Lock()
 	defer p.Unlock()
 	p.BGP = req.BGP
+	p.BGPVRF = req.VRF
 	return nil
 }
 
@@ -743,6 +745,7 @@ func (p *Provider) DeleteBGP(context.Context, *provider.DeleteBGPRequest) error 
 	p.Lock()
 	defer p.Unlock()
 	p.BGP = nil
+	p.BGPVRF = nil
 	return nil
 }
 

--- a/internal/provider/cisco/nxos/bgp.go
+++ b/internal/provider/cisco/nxos/bgp.go
@@ -16,7 +16,16 @@ import (
 var (
 	_ gnmiext.DataElement = (*BGP)(nil)
 	_ gnmiext.DataElement = (*BGPDom)(nil)
+	_ gnmiext.DataElement = (*BGPDomItems)(nil)
+	_ gnmiext.DataElement = (*BGPPeerGroup)(nil)
 )
+
+// ownershipMarkerPeerGroup is written into every BGP domain managed by this
+// operator. It distinguishes operator-owned domains from those NX-OS creates
+// automatically (e.g. the default VRF dom created as a side effect of
+// configuring a non-default VRF BGP), and is used during deletion to decide
+// whether the BGP instance itself can be cleaned up.
+const ownershipMarkerPeerGroup = "__operator-managed__"
 
 type BGP struct {
 	AdminSt AdminSt `json:"adminSt"`
@@ -34,12 +43,40 @@ type BGPDom struct {
 	AfItems   struct {
 		DomAfList gnmiext.List[AddressFamily, *BGPDomAfItem] `json:"DomAf-list,omitzero"`
 	} `json:"af-items,omitzero"`
+	PeerContItems struct {
+		PeerContList gnmiext.List[string, *BGPPeerGroup] `json:"PeerCont-list,omitzero"`
+	} `json:"peercont-items,omitzero"`
 }
 
 func (*BGPDom) IsListItem() {}
 
+func (d *BGPDom) Key() string { return d.Name }
+
 func (d *BGPDom) XPath() string {
 	return "System/bgp-items/inst-items/dom-items/Dom-list[name=" + d.Name + "]"
+}
+
+// BGPDomItems is the container for all BGP domains configured on the device.
+type BGPDomItems struct {
+	DomList gnmiext.List[string, *BGPDom] `json:"Dom-list,omitzero"`
+}
+
+func (*BGPDomItems) XPath() string {
+	return "System/bgp-items/inst-items/dom-items"
+}
+
+// BGPPeerGroup is a template peer group under a BGP domain.
+type BGPPeerGroup struct {
+	VRFName string `json:"-"`
+	Name    string `json:"name"`
+}
+
+func (*BGPPeerGroup) IsListItem() {}
+
+func (g *BGPPeerGroup) Key() string { return g.Name }
+
+func (g *BGPPeerGroup) XPath() string {
+	return "System/bgp-items/inst-items/dom-items/Dom-list[name=" + g.VRFName + "]/peercont-items/PeerCont-list[name=" + g.Name + "]"
 }
 
 type BGPDomAfItem struct {
@@ -116,6 +153,7 @@ func (af *BGPDomAfItem) SetMultipath(m *v1alpha1.BGPMultipath) error {
 }
 
 type BGPPeer struct {
+	VRFName             string      `json:"-"`
 	Addr                string      `json:"addr"`
 	AdminSt             AdminSt     `json:"adminSt"`
 	Asn                 string      `json:"asn"`
@@ -131,7 +169,7 @@ type BGPPeer struct {
 func (*BGPPeer) IsListItem() {}
 
 func (p *BGPPeer) XPath() string {
-	return "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=" + p.Addr + "]"
+	return "System/bgp-items/inst-items/dom-items/Dom-list[name=" + p.VRFName + "]/peer-items/Peer-list[addr=" + p.Addr + "]"
 }
 
 type BGPPeerAfItem struct {
@@ -144,6 +182,7 @@ type BGPPeerAfItem struct {
 func (af *BGPPeerAfItem) Key() AddressFamily { return af.Type }
 
 type BGPPeerOperItems struct {
+	VRFName      string        `json:"-"`
 	Addr         string        `json:"addr"`
 	OperSt       BGPPeerOperSt `json:"operSt"`
 	LastFlapTime time.Time     `json:"lastFlapTs"`
@@ -155,7 +194,7 @@ type BGPPeerOperItems struct {
 func (*BGPPeerOperItems) IsListItem() {}
 
 func (p *BGPPeerOperItems) XPath() string {
-	return "System/bgp-items/inst-items/dom-items/Dom-list[name=default]/peer-items/Peer-list[addr=" + p.Addr + "]/ent-items/PeerEntry-list[addr=" + p.Addr + "]"
+	return "System/bgp-items/inst-items/dom-items/Dom-list[name=" + p.VRFName + "]/peer-items/Peer-list[addr=" + p.Addr + "]/ent-items/PeerEntry-list[addr=" + p.Addr + "]"
 }
 
 type BGPPeerAfOperItems struct {

--- a/internal/provider/cisco/nxos/bgp_test.go
+++ b/internal/provider/cisco/nxos/bgp_test.go
@@ -11,6 +11,9 @@ func init() {
 	})
 	Register("bgp_dom", bgpDom)
 
+	bgpDomVrf := &BGPDom{Name: "CC-MGMT", RtrID: "1.1.1.1", RtrIDAuto: AdminStDisabled}
+	Register("bgp_dom_vrf", bgpDomVrf)
+
 	bgpDomAdvPip := &BGPDom{Name: DefaultVRFName, RtrID: "1.1.1.1", RtrIDAuto: AdminStDisabled}
 	bgpDomAdvPip.AfItems.DomAfList.Set(&BGPDomAfItem{
 		Type:         AddressFamilyL2EVPN,
@@ -23,6 +26,7 @@ func init() {
 	Register("bgp", bgp)
 
 	bgpPeer := &BGPPeer{
+		VRFName: DefaultVRFName,
 		Addr:    "1.1.1.1",
 		AdminSt: AdminStEnabled,
 		Asn:     "65000",

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -292,7 +292,7 @@ func (p *Provider) DeleteBanner(ctx context.Context, req *provider.DeleteBannerR
 	return p.client.Delete(ctx, b)
 }
 
-func (p *Provider) EnsureBGP(ctx context.Context, req *provider.EnsureBGPRequest) (reterr error) {
+func (p *Provider) EnsureBGP(ctx context.Context, req *provider.EnsureBGPRequest) (reterr error) { //nolint:gocyclo
 	f := new(Feature)
 	f.Name = "bgp"
 	f.AdminSt = AdminStEnabled
@@ -301,7 +301,38 @@ func (p *Provider) EnsureBGP(ctx context.Context, req *provider.EnsureBGPRequest
 	f2.Name = "evpn"
 	f2.AdminSt = AdminStEnabled
 
+	if err := p.Update(ctx, f, f2); err != nil {
+		return err
+	}
+
+	// If a BGP instance already exists, ensure it has the same ASN and Router-ID as the requested one.
+	// This prevents accidentally overwriting an existing BGP configuration, either by another BGP CR
+	// or manually configured outside of the operator's control.
+	// If it doesn't exist (ErrNil), we'll create it with the correct ASN and Router-ID below.
 	b := new(BGP)
+	err := p.client.GetConfig(ctx, b)
+	if err != nil && !errors.Is(err, gnmiext.ErrNil) {
+		return err
+	}
+	if err == nil && b.Asn != req.BGP.Spec.ASNumber.String() {
+		return fmt.Errorf("BGP instance on device already uses ASN %s, cannot configure with ASN %s", b.Asn, req.BGP.Spec.ASNumber.String())
+	}
+
+	dom := new(BGPDom)
+	dom.Name = DefaultVRFName
+	if req.VRF != nil {
+		dom.Name = req.VRF.Spec.Name
+	}
+
+	err = p.client.GetConfig(ctx, dom)
+	if err != nil && !errors.Is(err, gnmiext.ErrNil) {
+		return err
+	}
+	if err == nil && dom.RtrID != req.BGP.Spec.RouterID {
+		return fmt.Errorf("BGP domain %q on device already uses router ID %s, cannot configure with router ID %s", dom.Name, dom.RtrID, req.BGP.Spec.RouterID)
+	}
+
+	b = new(BGP)
 	b.AdminSt = AdminStEnabled
 	if req.BGP.Spec.AdminState == v1alpha1.AdminStateDown {
 		b.AdminSt = AdminStDisabled
@@ -313,7 +344,6 @@ func (p *Provider) EnsureBGP(ctx context.Context, req *provider.EnsureBGPRequest
 		return err
 	}
 
-	var err error
 	switch {
 	case asf == "" && strings.Contains(b.Asn, "."):
 		asf = AsFormatAsDot
@@ -332,10 +362,16 @@ func (p *Provider) EnsureBGP(ctx context.Context, req *provider.EnsureBGPRequest
 		}
 	}
 
-	dom := new(BGPDom)
+	dom = new(BGPDom)
 	dom.Name = DefaultVRFName
+	if req.VRF != nil {
+		dom.Name = req.VRF.Spec.Name
+	}
 	dom.RtrID = req.BGP.Spec.RouterID
 	dom.RtrIDAuto = AdminStDisabled
+
+	// Mark the dom as operator-managed so deleteBGPDom can identify it.
+	dom.PeerContItems.PeerContList.Set(&BGPPeerGroup{Name: ownershipMarkerPeerGroup})
 
 	if req.BGP.Spec.AddressFamilies != nil {
 		if af := req.BGP.Spec.AddressFamilies.Ipv4Unicast; af != nil && af.Enabled {
@@ -373,23 +409,66 @@ func (p *Provider) EnsureBGP(ctx context.Context, req *provider.EnsureBGPRequest
 		}
 	}
 
-	return p.Patch(ctx, f, f2, b, dom)
+	return p.Patch(ctx, b, dom)
 }
 
 func (p *Provider) DeleteBGP(ctx context.Context, req *provider.DeleteBGPRequest) error {
+	// Delete the VRF-scoped BGP domain and, if it was the last operator-managed
+	// one, the global BGP instance as well.
+	vrfName := DefaultVRFName
+	if req.VRF != nil {
+		vrfName = req.VRF.Spec.Name
+	}
+	return p.deleteBGP(ctx, vrfName)
+}
+
+// deleteBGP deletes the BGP domain for a VRF. If no remaining domain carries the
+// ownership marker or has any SAFIs/peer groups configured, the global BGP instance
+// (System/bgp-items/inst-items) is deleted as well. This preserves any
+// manually configured BGP domains outside the operator's control.
+// The function is a no-op when the BGP feature is disabled.
+func (p *Provider) deleteBGP(ctx context.Context, vrfName string) error {
+	f := &Feature{Name: "bgp"}
+	if err := p.client.GetConfig(ctx, f); err != nil || f.AdminSt != AdminStEnabled {
+		return err
+	}
+
+	if err := p.client.Delete(ctx, &BGPDom{Name: vrfName}); err != nil {
+		return err
+	}
+
+	// Retain the global BGP instance if any remaining dom is operator-managed
+	// or has non-empty configuration (address families or peer groups).
+	items := new(BGPDomItems)
+	if err := p.client.GetConfig(ctx, items); err != nil && !errors.Is(err, gnmiext.ErrNil) {
+		return err
+	}
+	for _, d := range items.DomList {
+		if _, ok := d.PeerContItems.PeerContList.Get(ownershipMarkerPeerGroup); ok {
+			return nil
+		}
+		if len(d.AfItems.DomAfList) > 0 || len(d.PeerContItems.PeerContList) > 0 {
+			return nil
+		}
+	}
+
+	// No operator-managed or non-empty doms remain — delete the BGP instance.
 	return p.client.Delete(ctx, new(BGP))
 }
 
 func (p *Provider) EnsureBGPPeer(ctx context.Context, req *provider.EnsureBGPPeerRequest) error {
-	// Ensure that the BGP instance exists and is configured on the "default" domain
-	// and return an error if it does not exist.
+	// Ensure that the BGP domain exists before configuring a peer under it.
 	bgp := new(BGPDom)
 	bgp.Name = DefaultVRFName
+	if req.VRF != nil {
+		bgp.Name = req.VRF.Spec.Name
+	}
 	if err := p.client.GetConfig(ctx, bgp); err != nil {
-		return fmt.Errorf("bgp peer: failed to get bgp instance 'default': %w", err)
+		return fmt.Errorf("bgp peer: failed to get bgp instance %q: %w", bgp.Name, err)
 	}
 
 	pe := new(BGPPeer)
+	pe.VRFName = bgp.Name
 	pe.Addr = req.BGPPeer.Spec.Address
 	pe.AdminSt = AdminStEnabled
 	if req.BGPPeer.Spec.AdminState == v1alpha1.AdminStateDown {
@@ -438,12 +517,20 @@ func (p *Provider) EnsureBGPPeer(ctx context.Context, req *provider.EnsureBGPPee
 
 func (p *Provider) DeleteBGPPeer(ctx context.Context, req *provider.DeleteBGPPeerRequest) error {
 	b := new(BGPPeer)
+	b.VRFName = DefaultVRFName
+	if req.VRF != nil {
+		b.VRFName = req.VRF.Spec.Name
+	}
 	b.Addr = req.BGPPeer.Spec.Address
 	return p.client.Delete(ctx, b)
 }
 
 func (p *Provider) GetPeerStatus(ctx context.Context, req *provider.BGPPeerStatusRequest) (provider.BGPPeerStatus, error) {
 	ps := new(BGPPeerOperItems)
+	ps.VRFName = DefaultVRFName
+	if req.VRF != nil {
+		ps.VRFName = req.VRF.Spec.Name
+	}
 	ps.Addr = req.BGPPeer.Spec.Address
 	if err := p.client.GetState(ctx, ps); err != nil && !errors.Is(err, gnmiext.ErrNil) {
 		return provider.BGPPeerStatus{}, err
@@ -2401,7 +2488,13 @@ func (p *Provider) EnsureVRF(ctx context.Context, req *provider.VRFRequest) erro
 func (p *Provider) DeleteVRF(ctx context.Context, req *provider.VRFRequest) error {
 	v := new(VRF)
 	v.Name = req.VRF.Spec.Name
-	return p.client.Delete(ctx, v)
+	if err := p.client.Delete(ctx, v); err != nil {
+		return err
+	}
+	// NX-OS does not automatically remove the BGP domain when a VRF is deleted.
+	// deleteBGPDom handles the feature check, dom deletion, and potential
+	// inst-items cleanup if this was the last operator-managed domain.
+	return p.deleteBGP(ctx, req.VRF.Spec.Name)
 }
 
 func (p *Provider) EnsureSystemSettings(ctx context.Context, s *nxv1alpha1.System) error {

--- a/internal/provider/cisco/nxos/testdata/bgp_dom_vrf.json
+++ b/internal/provider/cisco/nxos/testdata/bgp_dom_vrf.json
@@ -1,0 +1,16 @@
+{
+  "bgp-items": {
+    "inst-items": {
+      "asn": "65000",
+      "dom-items": {
+        "Dom-list": [
+          {
+            "name": "CC-MGMT",
+            "rtrId": "1.1.1.1",
+            "rtrIdAuto": "disabled"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/bgp_dom_vrf.json.txt
+++ b/internal/provider/cisco/nxos/testdata/bgp_dom_vrf.json.txt
@@ -1,0 +1,3 @@
+router bgp 65000
+ vrf CC-MGMT
+  router-id 1.1.1.1

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -376,11 +376,17 @@ type BGPProvider interface {
 type EnsureBGPRequest struct {
 	BGP            *v1alpha1.BGP
 	ProviderConfig *ProviderConfig
+	// VRF is the resolved VRF referenced by BGP.Spec.VrfRef.
+	// When nil, the provider shall use the default VRF.
+	VRF *v1alpha1.VRF
 }
 
 type DeleteBGPRequest struct {
 	BGP            *v1alpha1.BGP
 	ProviderConfig *ProviderConfig
+	// VRF is the resolved VRF referenced by BGP.Spec.VrfRef.
+	// When nil, the provider shall use the default VRF.
+	VRF *v1alpha1.VRF
 }
 
 // BGPPeerProvider is the interface for the realization of the BGPPeer objects over different providers.
@@ -401,6 +407,9 @@ type EnsureBGPPeerRequest struct {
 	SourceInterface string
 	// BGP is the resolved BGP instance referenced by BGPPeer.Spec.BgpRef.
 	BGP *v1alpha1.BGP
+	// VRF is the resolved VRF referenced by BGP.Spec.VrfRef.
+	// When nil, the provider shall use the default VRF.
+	VRF *v1alpha1.VRF
 }
 
 type DeleteBGPPeerRequest struct {
@@ -408,11 +417,17 @@ type DeleteBGPPeerRequest struct {
 	ProviderConfig *ProviderConfig
 	// BGP is the resolved BGP instance referenced by BGPPeer.Spec.BgpRef.
 	BGP *v1alpha1.BGP
+	// VRF is the resolved VRF referenced by BGP.Spec.VrfRef.
+	// When nil, the provider shall use the default VRF.
+	VRF *v1alpha1.VRF
 }
 
 type BGPPeerStatusRequest struct {
 	BGPPeer        *v1alpha1.BGPPeer
 	ProviderConfig *ProviderConfig
+	// VRF is the resolved VRF referenced by the BGP instance of this peer.
+	// When nil, the provider shall use the default VRF.
+	VRF *v1alpha1.VRF
 }
 
 type BGPPeerStatus struct {


### PR DESCRIPTION
BGP.Spec gains an optional VrfRef field that scopes the BGP instance to a VRF. Both the BGP and BGPPeer controllers resolve this reference and pass the VRF to all provider calls.

The BGPPeer controller gains a reconcileVRF helper that resolves BGP.Spec.VrfRef and sets ConfiguredCondition on failure; it returns nil when unset so the provider uses the default VRF.

A vrfToBGPPeers mapper and VRF watcher (create/delete only) enqueue affected peers when their BGP's VRF definition changes. The BGP watcher predicate is extended to trigger on any ready state change and when VrfRef changes.