### PR TITLE
Doc update: update overview page and architecture runtime flow/sequence diagrams

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -69,7 +69,10 @@ export default withMermaid({
         sidebar: [
             {
                 text: 'Overview',
-                items: [{ text: 'Index', link: '/overview/' }],
+                items: [
+                    { text: 'Index', link: '/overview/' },
+                    { text: 'Architecture Overview', link: '/architecture-overview' },
+                ],
             },
             {
                 text: 'Concepts',

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -71,7 +71,7 @@ export default withMermaid({
                 text: 'Overview',
                 items: [
                     { text: 'Index', link: '/overview/' },
-                    { text: 'Architecture Overview', link: '/architecture-overview' },
+                    { text: 'Architecture', link: '/architecture-overview' },
                 ],
             },
             {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,158 @@
+# Architecture Sequence Overview
+
+This diagram shows the high-level runtime flow of the Network Operator.
+It combines the two main paths in the project:
+
+- `Device` lifecycle reconciliation, including optional provisioning.
+- Per-resource configuration reconciliation for objects such as `Interface`, `BGP`, `VRF`, and `Certificate`.
+
+```mermaid
+sequenceDiagram
+	actor U as User / kubectl
+	participant API as Kubernetes API Server
+	participant WH as Validating Webhook
+	participant MGR as Controller Manager
+	participant DEV as DeviceReconciler
+	participant CFG as Config Reconciler
+	participant BOOT as Provisioning HTTP / TFTP
+	participant P as Provider / Transport
+	participant ND as Network Device
+
+	U->>API: Apply Device or config CR
+	opt Webhook registered for this kind
+		API->>WH: Validate request
+		WH-->>API: Allow or deny
+	end
+	API-->>U: Object persisted
+	API-)MGR: Watch event
+
+	alt Device reconciliation
+		MGR->>+DEV: Reconcile(Device)
+		DEV->>API: Read Device and referenced resources
+		DEV->>API: Initialize conditions if needed
+
+		alt Provisioning is configured and phase is Pending
+			DEV->>API: Set phase=Provisioning and Ready=False
+			DEV-->>API: Requeue for follow-up checks
+			ND->>+BOOT: Request bootstrap config
+			BOOT->>API: Read Device, secrets, and bootstrap assets
+			BOOT-->>ND: Return provisioning config, certs, or boot script
+			ND->>BOOT: Report provisioning progress
+			BOOT->>API: Update provisioning status
+			API-)MGR: Watch event for Device update
+		end
+
+		DEV->>+P: Connect to provider
+		P->>ND: Read device facts and ports
+		ND-->>P: Inventory and operational state
+		P-->>-DEV: Device details
+		DEV->>API: Patch status, labels, and Ready condition
+		DEV-->>-MGR: Reconcile complete
+
+	else Config reconciliation
+		MGR->>+CFG: Reconcile(config CR)
+		CFG->>API: Read resource and resolve spec.deviceRef
+		CFG->>API: Read target Device
+		CFG->>CFG: Check paused state
+		CFG->>CFG: Acquire per-device lock
+		CFG->>API: Ensure finalizer, device label, and owner reference
+		CFG->>+P: Connect using device endpoint and credentials
+		P->>ND: Ensure intended configuration
+		ND-->>P: Apply result
+		P-->>-CFG: Success or error
+		CFG->>API: Patch Ready condition and status
+		CFG->>CFG: Release per-device lock
+		CFG-->>-MGR: Reconcile complete
+	end
+
+	Note over DEV,CFG: Each config CR reconciles independently, but writes to the same device are serialized by a per-device lock.
+```
+
+## Reading Guide
+
+- `Device` is the central resource. Other configuration resources target a device through `spec.deviceRef`.
+- The admission webhook is optional and only runs for resource kinds that register validation webhooks.
+- Provisioning and inline TFTP are optional manager-hosted services used during device bootstrap.
+- After bootstrap, reconcilers connect through the provider and transport layer to push or verify device state.
+- Status and conditions are always written back to Kubernetes so the API remains the source of truth.
+
+## Device Provisioning Flow
+
+This diagram focuses only on the `Device` lifecycle, including optional provisioning, progress checks, and the transition into the running state.
+
+```mermaid
+sequenceDiagram
+	actor U as User / kubectl
+	participant API as Kubernetes API Server
+	participant MGR as Controller Manager
+	participant DEV as DeviceReconciler
+	participant BOOT as Provisioning HTTP / TFTP
+	participant P as Provider / Transport
+	participant ND as Network Device
+
+	U->>API: Apply Device CR
+	API-->>U: Object persisted
+	API-)MGR: Watch event
+
+	MGR->>+DEV: Reconcile(Device)
+	DEV->>API: Read Device and status
+	DEV->>API: Initialize conditions if needed
+
+	alt Provisioning configured and phase is Pending
+		DEV->>API: Set phase=Provisioning and Ready=False
+		DEV-->>API: Requeue for follow-up checks
+		ND->>+BOOT: Request bootstrap config
+		BOOT->>API: Read Device, secrets, and bootstrap assets
+		BOOT-->>ND: Return provisioning config, certs, or boot script
+		ND->>BOOT: Report provisioning progress
+		BOOT->>API: Update provisioning status
+		API-)MGR: Watch event for Device update
+		DEV->>API: Requeue until provisioning completes
+	end
+
+	DEV->>+P: Connect to provider
+	P->>ND: Read device facts and ports
+	ND-->>P: Inventory and operational state
+	P-->>-DEV: Device details
+	DEV->>API: Patch status, labels, and Ready condition
+	DEV-->>-MGR: Reconcile complete
+```
+
+## Config Reconcile Flow
+
+This diagram focuses on per-resource reconciliation for configuration CRs such as `Interface`, `BGP`, `VRF`, and `Certificate`.
+
+```mermaid
+sequenceDiagram
+	actor U as User / kubectl
+	participant API as Kubernetes API Server
+	participant WH as Validating Webhook
+	participant MGR as Controller Manager
+	participant CFG as Config Reconciler
+	participant P as Provider / Transport
+	participant ND as Network Device
+
+	U->>API: Apply config CR
+	opt Webhook registered for this kind
+		API->>WH: Validate request
+		WH-->>API: Allow or deny
+	end
+	API-->>U: Object persisted
+	API-)MGR: Watch event
+
+	MGR->>+CFG: Reconcile(config CR)
+	CFG->>API: Read resource and resolve spec.deviceRef
+	CFG->>API: Read target Device
+	CFG->>CFG: Check paused state
+	CFG->>CFG: Acquire per-device lock
+	CFG->>API: Ensure finalizer, device label, and owner reference
+	CFG->>+P: Connect using device endpoint and credentials
+	P->>ND: Ensure intended configuration
+	ND-->>P: Apply result
+	P-->>-CFG: Success or error
+	CFG->>API: Patch Ready condition and status
+	CFG->>CFG: Release per-device lock
+	CFG-->>-MGR: Reconcile complete
+
+	Note over CFG: Writes targeting the same device are serialized by the per-device lock.
+```

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -1,6 +1,6 @@
 # Overview
 
-The Network Operator is a Kubernetes Operator that manages the lifecycle and configuration of network devices using Kubernetes-native declarative APIs.
+The Network Operator is a Kubernetes-native solution for automating the provisioning and lifecycle management of network devices. It extends the Kubernetes API to provide a declarative, multi-vendor network automation, allowing you to manage your network infrastructure with the same tools and workflows you use for your applications. By representing network devices and their configurations as Kubernetes objects, the operator bridges the gap between your cloud-native environment and your networking hardware.
 
 Users create Custom Resources such as `Device`, `Interface`, `BGP`, `VLAN`, and `VRF`. The operator reconciles those desired states, applies changes to real network devices through providers, and continuously reports device status back to Kubernetes.
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -1,6 +1,31 @@
 # Overview
 
-The Network Operator is a Kubernetes-native solution for automating the provisioning and lifecycle management of network devices. It extends the Kubernetes API to provide a declarative, multi-vendor network automation, allowing you to manage your network infrastructure with the same tools and workflows you use for your applications. By representing network devices and their configurations as Kubernetes objects, the operator bridges the gap between your cloud-native environment and your networking hardware.
+The Network Operator is a Kubernetes Operator that manages the lifecycle and configuration of network devices using Kubernetes-native declarative APIs.
+
+Users create Custom Resources such as `Device`, `Interface`, `BGP`, `VLAN`, and `VRF`. The operator reconciles those desired states, applies changes to real network devices through providers, and continuously reports device status back to Kubernetes.
+
+## What This Operator Solves
+
+- Declarative network management: replace manual or script-based device configuration with Kubernetes CRDs.
+- Unified device state visibility: continuously sync device inventory and operational state back into Kubernetes.
+- Vendor and protocol abstraction: hide device- and protocol-specific differences behind a provider interface.
+- Built-in provisioning support: provide HTTP and TFTP services for device bootstrapping and initial provisioning.
+
+## Core Concepts
+
+- CRDs define intent.
+- Controllers reconcile intent.
+- Providers talk to devices.
+- Status is continuously synced back.
+
+## Main Building Blocks
+
+- API (CRDs): `Device`, `Interface`, `BGP`, `VLAN`, `VRF`
+- Controllers: reconcile desired vs actual state
+- Providers: abstract vendor and protocol differences
+- Provisioning services: embedded HTTP + TFTP
+
+For the execution flow and sequence-level behavior, see [Architecture Sequence Overview](../architecture-overview).
 
 ## Architecture
 


### PR DESCRIPTION
Description:
This PR refines the documentation structure for the Network Operator by updating the product overview and adding the runtime architecture details.

Summary:
Expanded the Overview page with a clearer product introduction, the problems the operator solves, core concepts, and main building blocks.
Added a dedicated Architecture Overview page for the runtime flow and sequence diagrams.
Kept the original high-level resource relationship diagram, while adding two focused sequence diagrams:
Device provisioning flow
Config reconciliation flow
Updated the docs sidebar so the new architecture page is easy to discover.

Why:
Reduces duplication between the overview and architecture content.
Makes the docs easier to scan for new readers.
Separates conceptual documentation from execution-level behavior.

Notes:
This change is documentation-only.
No code behavior was modified.
