### PR TITLE
Add local kind registry for Tilt development setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,7 @@ kind-create: FORCE
 	  echo "Kind is not installed. Please install Kind manually."; \
 	  exit 1; \
 	}
-	@kind get clusters | grep -q $(KIND_CLUSTER) || { \
-	  printf "\e[1;36m>> kind create cluster --name=$(KIND_CLUSTER)\e[0m\n"; \
-	  kind create cluster --name=$(KIND_CLUSTER); \
-	}
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL) ./hack/kind-with-registry.sh
 
 # Delete the Kind cluster created for local development and testing.
 kind-delete: FORCE
@@ -123,7 +120,8 @@ kind-delete: FORCE
 	  exit 1; \
 	}
 	@printf "\e[1;36m>> kind delete cluster --name=$(KIND_CLUSTER)\e[0m\n"
-	@kind delete cluster --name=$(KIND_CLUSTER)
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_TOOL) kind delete cluster --name=$(KIND_CLUSTER)
+	$(CONTAINER_TOOL) stop kind-registry && $(CONTAINER_TOOL) rm kind-registry
 
 tilt-up: FORCE kind-create
 	@command -v tilt >/dev/null 2>&1 || { \

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -149,10 +149,7 @@ verbatim: |
       echo "Kind is not installed. Please install Kind manually."; \
       exit 1; \
     }
-    @kind get clusters | grep -q $(KIND_CLUSTER) || { \
-      printf "\e[1;36m>> kind create cluster --name=$(KIND_CLUSTER)\e[0m\n"; \
-      kind create cluster --name=$(KIND_CLUSTER); \
-    }
+    KIND_CLUSTER_NAME=$(KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL) ./hack/kind-with-registry.sh
 
   # Delete the Kind cluster created for local development and testing.
   kind-delete: FORCE
@@ -161,7 +158,8 @@ verbatim: |
       exit 1; \
     }
     @printf "\e[1;36m>> kind delete cluster --name=$(KIND_CLUSTER)\e[0m\n"
-    @kind delete cluster --name=$(KIND_CLUSTER)
+    KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_TOOL) kind delete cluster --name=$(KIND_CLUSTER)
+    $(CONTAINER_TOOL) stop kind-registry && $(CONTAINER_TOOL) rm kind-registry
 
   tilt-up: FORCE kind-create
     @command -v tilt >/dev/null 2>&1 || { \

--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+export KIND_EXPERIMENTAL_PROVIDER="${CONTAINER_TOOL}"
+
+# Exit early if the cluster already exists
+if kind get clusters | grep -q "^${KIND_CLUSTER_NAME}$"; then
+  echo "Cluster ${KIND_CLUSTER_NAME} already exists"
+  exit 0
+fi
+
+# 1. Create registry container unless it already exists
+REGISTRY_NAME='kind-registry'
+REGISTRY_PORT="${KIND_REGISTRY_PORT:-5000}"
+if [ "$("${CONTAINER_TOOL}" inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || true)" != 'true' ]; then
+  "${CONTAINER_TOOL}" run -d --restart=always -p "127.0.0.1:${REGISTRY_PORT}:5000" --network bridge --name "${REGISTRY_NAME}" registry:3
+fi
+
+# 2. Create kind cluster
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ${KIND_CLUSTER_NAME}
+nodes:
+- role: control-plane
+  labels:
+    topology.kubernetes.io/zone: eu-de-1a
+EOF
+
+# 3. Add the registry config to the nodes
+#
+# This is necessary because localhost resolves to loopback addresses that are
+# network-namespace local.
+# In other words: localhost in the container is not localhost on the host.
+#
+# We want a consistent name that works from both ends, so we tell containerd to
+# alias localhost:${reg_port} to the registry container when pulling images
+REGISTRY_DIR="/etc/containerd/certs.d/localhost:${REGISTRY_PORT}"
+for node in $(kind get nodes); do
+  "${CONTAINER_TOOL}" exec "${node}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | "${CONTAINER_TOOL}" exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+[host."http://${REGISTRY_NAME}:5000"]
+EOF
+done
+
+# 4. Connect the registry to the cluster network if not already connected
+# This allows kind to bootstrap the network but ensures they're on the same network
+if [ "$("${CONTAINER_TOOL}" inspect -f='{{json .NetworkSettings.Networks.kind}}' "${REGISTRY_NAME}")" = 'null' ]; then
+  "${CONTAINER_TOOL}" network connect "kind" "${REGISTRY_NAME}"
+fi
+
+# 5. Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${REGISTRY_PORT}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+kubectl wait --for=condition=Ready --timeout=300s "node/${KIND_CLUSTER_NAME}-control-plane"


### PR DESCRIPTION
This change introduces hack/kind-with-registry.sh, adapted from https://kind.sigs.k8s.io/docs/user/local-registry and inspired by the now-archived https://github.com/tilt-dev/kind-local, and wires it into the make kind-create and make kind-delete targets.

A local registry is preferred over alternatives such as 'kind load docker-image' because Docker layer caching applies when pushing to a registry: layers that already exist in the registry are skipped, so only the changed layers are transferred. With kind load every push uploads the full image regardless of what changed. In addition, all traffic stays on the local machine with no network round-trips to a remote registry. Tilt (v0.12.0+) auto-detects the registry through the KEP-1755 local-registry-hosting ConfigMap published in kube-public and handles the image-tagging dance automatically.

The script starts a registry:3 container bound to localhost:5000, creates the kind cluster (requires kind v0.27.0+), configures each node's containerd to resolve localhost:5000 to the registry container via /etc/containerd/certs.d/localhost:<port>/hosts.toml, connects the registry container to the kind Docker network so that the nodes can reach it by name, and publishes the local-registry-hosting ConfigMap. make kind-delete tears down both the cluster and the registry container.