### PR TITLE
L3 subinterface configuration for Cisco NX-OS Provider

### DIFF
--- a/api/core/v1alpha1/groupversion_info.go
+++ b/api/core/v1alpha1/groupversion_info.go
@@ -208,6 +208,15 @@ const (
 
 	// VRFNotFoundReason indicates that a referenced VRF was not found.
 	VRFNotFoundReason = "VRFNotFound"
+
+	// ParentInterfaceNotFoundReason indicates that a referenced parent interface for a subinterface was not found.
+	ParentInterfaceNotFoundReason = "ParentInterfaceNotFound"
+
+	// ParentInterfaceNotConfiguredReason indicates that the parent interface of a subinterface is not configured.
+	ParentInterfaceNotConfiguredReason = "ParentInterfaceNotConfigured"
+
+	// InvalidParentInterfaceTypeReason indicates that a referenced parent interface type is not supported.
+	InvalidParentInterfaceTypeReason = "InvalidParentInterfaceType"
 )
 
 // Reasons that are specific to [Device] objects.

--- a/internal/controller/core/interface_controller.go
+++ b/internal/controller/core/interface_controller.go
@@ -215,6 +215,7 @@ const (
 	interfaceUnnumberedRefKey = ".spec.ipv4.unnumbered.interfaceRef.name"
 	interfaceVlanRefKey       = ".spec.vlanRef.name"
 	interfaceVrfRefKey        = ".spec.vrfRef.name"
+	interfaceParentRefKey     = ".spec.parentInterfaceRef.name"
 )
 
 // SetupWithManager sets up the controller with the Manager.
@@ -277,6 +278,16 @@ func (r *InterfaceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		return err
 	}
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1alpha1.Interface{}, interfaceParentRefKey, func(obj client.Object) []string {
+		intf := obj.(*v1alpha1.Interface)
+		if intf.Spec.ParentInterfaceRef == nil {
+			return nil
+		}
+		return []string{intf.Spec.ParentInterfaceRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Interface{}).
 		Named("interface").
@@ -299,6 +310,19 @@ func (r *InterfaceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		Watches(
 			&v1alpha1.Interface{},
 			handler.EnqueueRequestsFromMapFunc(r.interfaceToUnnumbered),
+			builder.WithPredicates(predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return false
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
+		// Watches enqueues subinterfaces when their parent interface changes.
+		Watches(
+			&v1alpha1.Interface{},
+			handler.EnqueueRequestsFromMapFunc(r.parentToSubinterfaces),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return false
@@ -409,8 +433,9 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (reterr e
 
 	s.Interface.Labels[v1alpha1.DeviceLabel] = s.Device.Name
 
-	// Ensure the Interface is owned by the Device.
-	if !controllerutil.HasControllerReference(s.Interface) {
+	// Ensure the Interface (except subinterfaces) is owned by the Device.
+	// Subinterfaces have their parent interface as owner, and the parent interface is owned by the Device.
+	if !controllerutil.HasControllerReference(s.Interface) && s.Interface.Spec.Type != v1alpha1.InterfaceTypeSubinterface {
 		if err := controllerutil.SetOwnerReference(s.Device, s.Interface, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
 			return err
 		}
@@ -438,6 +463,13 @@ func (r *InterfaceReconciler) reconcile(ctx context.Context, s *scope) (reterr e
 				return fmt.Errorf("failed to get aggregate parent %q: %w", s.Interface.Status.MemberOf.Name, err)
 			}
 			aggregateParent = nil
+		}
+	}
+
+	if s.Interface.Spec.Type == v1alpha1.InterfaceTypeSubinterface {
+		err := r.reconcileSubinterfaces(ctx, s)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -763,6 +795,79 @@ func (r *InterfaceReconciler) reconcileMemberInterfaces(ctx context.Context, s *
 	return members, nil
 }
 
+// reconcileSubinterfaces ensures that the parent interfaces exist and belong to the same device as the subinterface.
+// It also updates the subinterfaces owner reference to the parent interface
+func (r *InterfaceReconciler) reconcileSubinterfaces(ctx context.Context, s *scope) error {
+	parentIntf := new(v1alpha1.Interface)
+
+	key := client.ObjectKey{Name: s.Interface.Spec.ParentInterfaceRef.Name, Namespace: s.Interface.Namespace}
+	if err := r.Get(ctx, key, parentIntf); err != nil {
+		if apierrors.IsNotFound(err) {
+			conditions.Set(s.Interface, metav1.Condition{
+				Type:    v1alpha1.ConfiguredCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.ParentInterfaceNotFoundReason,
+				Message: fmt.Sprintf("referenced parent interface %q for not found", key),
+			})
+			return reconcile.TerminalError(fmt.Errorf("failed to get parent interface %q: %w", s.Interface.Spec.ParentInterfaceRef.Name, err))
+		}
+		return err
+	}
+
+	// Check matching device reference
+	if parentIntf.Spec.DeviceRef.Name != s.Device.Name {
+		conditions.Set(s.Interface, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.CrossDeviceReferenceReason,
+			Message: fmt.Sprintf("parent interface %q belongs to a different device", key),
+		})
+		return reconcile.TerminalError(fmt.Errorf("parent interface %q belongs to device %q in not ready state", s.Interface.Spec.ParentInterfaceRef.Name, parentIntf.Spec.DeviceRef.Name))
+	}
+
+	// Check if parent interface is an aggregate or physical interface
+	if parentIntf.Spec.Type != v1alpha1.InterfaceTypePhysical && parentIntf.Spec.Type != v1alpha1.InterfaceTypeAggregate {
+		conditions.Set(s.Interface, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.InvalidParentInterfaceTypeReason,
+			Message: fmt.Sprintf("parent interface %q is not of type Physical or Aggregate, got %q", key, parentIntf.Spec.Type),
+		})
+		return reconcile.TerminalError(fmt.Errorf("parent interface %q is not of type Physical or Aggregate, got %q", s.Interface.Spec.ParentInterfaceRef.Name, parentIntf.Spec.Type))
+	}
+
+	// L2 interfaces do not support subinterfaces config
+	if parentIntf.Spec.Switchport != nil {
+		conditions.Set(s.Interface, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.InvalidInterfaceTypeReason,
+			Message: fmt.Sprintf("parent interface %q is an L2 interface", key),
+		})
+		return reconcile.TerminalError(fmt.Errorf("parent interface %q is an L2 interface", s.Interface.Spec.ParentInterfaceRef.Name))
+	}
+
+	// Ensure the Subinterface is owned by the parent interface.
+	if !controllerutil.HasControllerReference(s.Interface) {
+		if err := controllerutil.SetOwnerReference(parentIntf, s.Interface, r.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+			return reconcile.TerminalError(err)
+		}
+	}
+
+	// Parent interface must be configured
+	if !conditions.IsConfigured(parentIntf) {
+		conditions.Set(s.Interface, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.ParentInterfaceNotConfiguredReason,
+			Message: fmt.Sprintf("parent interface %q not ready", key),
+		})
+		return reconcile.TerminalError(fmt.Errorf("parent interface %q in not ready state", s.Interface.Spec.ParentInterfaceRef.Name))
+	}
+
+	return nil
+}
+
 func (r *InterfaceReconciler) finalize(ctx context.Context, s *scope) (reterr error) {
 	if s.Interface.Spec.Aggregation != nil {
 		if err := r.finalizeMemberInterfaces(ctx, s); err != nil {
@@ -938,6 +1043,43 @@ func (r *InterfaceReconciler) aggregateToMembers(ctx context.Context, obj client
 				Namespace: intf.Namespace,
 			},
 		})
+	}
+
+	return requests
+}
+
+// parentToSubinterfaces is a [handler.MapFunc] to be used to enqueue requests for reconciliation
+// for Subinterfaces based on their parent Interface.
+func (r *InterfaceReconciler) parentToSubinterfaces(ctx context.Context, obj client.Object) []ctrl.Request {
+	intf, ok := obj.(*v1alpha1.Interface)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Interface but got a %T", obj))
+	}
+
+	if intf.Spec.Type != v1alpha1.InterfaceTypePhysical && intf.Spec.Type != v1alpha1.InterfaceTypeAggregate {
+		return nil
+	}
+
+	log := ctrl.LoggerFrom(ctx, "Interface", klog.KObj(intf))
+	interfaces := new(v1alpha1.InterfaceList)
+
+	// List all interfaces in the same namespace with a parent interface reference to the physical interface.
+	if err := r.List(ctx, interfaces, client.InNamespace(intf.Namespace), client.MatchingFields{interfaceParentRefKey: intf.Name}); err != nil {
+		log.Error(err, "Failed to list Interfaces")
+		return nil
+	}
+
+	requests := []ctrl.Request{}
+	for _, i := range interfaces.Items {
+		if i.Spec.ParentInterfaceRef != nil && i.Spec.ParentInterfaceRef.Name == intf.Name {
+			log.V(2).Info("Enqueuing SubInterface for reconciliation", "SubInterface", klog.KObj(&i))
+			requests = append(requests, ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      i.Name,
+					Namespace: i.Namespace,
+				},
+			})
+		}
 	}
 
 	return requests

--- a/internal/controller/core/interface_controller_test.go
+++ b/internal/controller/core/interface_controller_test.go
@@ -754,6 +754,143 @@ var _ = Describe("Interface Controller", func() {
 			}).Should(Succeed())
 		})
 
+		It("Should fail reconcile when parent interface does not exist for subinterface", func() {
+			By("Creating a Subinterface referencing a non-existent parent")
+			subintf := &v1alpha1.Interface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.InterfaceSpec{
+					DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
+					Name:        name + ".100",
+					AdminState:  v1alpha1.AdminStateUp,
+					Description: "Subinterface without parent",
+					Type:        v1alpha1.InterfaceTypeSubinterface,
+					ParentInterfaceRef: &v1alpha1.LocalObjectReference{
+						Name: "non-existent-parent",
+					},
+					Encapsulation: &v1alpha1.Encapsulation{
+						Type: v1alpha1.EncapsulationTypeDot1Q,
+						Tag:  100,
+					},
+					IPv4: &v1alpha1.InterfaceIPv4{
+						Addresses: []v1alpha1.IPPrefix{{Prefix: netip.MustParsePrefix("10.0.0.100/24")}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, subintf)).To(Succeed())
+
+			By("Verifying the controller sets parent interface not ready status")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Interface{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).To(HaveLen(4))
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.ConfiguredCondition))
+				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(resource.Status.Conditions[1].Reason).To(Equal(v1alpha1.ParentInterfaceNotFoundReason))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.OperationalCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionUnknown))
+				g.Expect(resource.Status.Conditions[3].Type).To(Equal(v1alpha1.PausedCondition))
+				g.Expect(resource.Status.Conditions[3].Status).To(Equal(metav1.ConditionFalse))
+			}).Should(Succeed())
+		})
+
+		It("Should successfully reconcile parent Physical interface and Subinterface", func() {
+			const parentName = "test-parent-eth"
+			const subinterfaceName = "test-subintf"
+
+			By("Creating a Physical parent interface")
+			parentIntf := &v1alpha1.Interface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      parentName,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.InterfaceSpec{
+					DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
+					Name:        parentName,
+					AdminState:  v1alpha1.AdminStateUp,
+					Description: "Parent Physical Interface",
+					MTU:         9000,
+					Type:        v1alpha1.InterfaceTypePhysical,
+				},
+			}
+			Expect(k8sClient.Create(ctx, parentIntf)).To(Succeed())
+
+			By("Verifying the parent Physical interface is ready")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Interface{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: parentName, Namespace: metav1.NamespaceDefault}, resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).To(HaveLen(4))
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.ConfiguredCondition))
+				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed())
+
+			By("Creating a Subinterface referencing the parent")
+			subintf := &v1alpha1.Interface{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subinterfaceName,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.InterfaceSpec{
+					DeviceRef:   v1alpha1.LocalObjectReference{Name: name},
+					Name:        parentName + ".100",
+					AdminState:  v1alpha1.AdminStateUp,
+					Description: "Subinterface with 802.1q encapsulation",
+					Type:        v1alpha1.InterfaceTypeSubinterface,
+					ParentInterfaceRef: &v1alpha1.LocalObjectReference{
+						Name: parentName,
+					},
+					Encapsulation: &v1alpha1.Encapsulation{
+						Type: v1alpha1.EncapsulationTypeDot1Q,
+						Tag:  100,
+					},
+					IPv4: &v1alpha1.InterfaceIPv4{
+						Addresses: []v1alpha1.IPPrefix{{Prefix: netip.MustParsePrefix("10.0.100.1/24")}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, subintf)).To(Succeed())
+
+			By("Verifying the controller sets the parent interface as owner reference")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Interface{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: subinterfaceName, Namespace: metav1.NamespaceDefault}, resource)).To(Succeed())
+				g.Expect(resource.OwnerReferences).To(HaveLen(1))
+				g.Expect(resource.OwnerReferences[0].Kind).To(Equal("Interface"))
+				g.Expect(resource.OwnerReferences[0].Name).To(Equal(parentName))
+			}).Should(Succeed())
+
+			By("Verifying the subinterface status is ready")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Interface{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: subinterfaceName, Namespace: metav1.NamespaceDefault}, resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).To(HaveLen(4))
+				g.Expect(resource.Status.Conditions[0].Type).To(Equal(v1alpha1.ReadyCondition))
+				g.Expect(resource.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(resource.Status.Conditions[1].Type).To(Equal(v1alpha1.ConfiguredCondition))
+				g.Expect(resource.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(resource.Status.Conditions[2].Type).To(Equal(v1alpha1.OperationalCondition))
+				g.Expect(resource.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(resource.Status.Conditions[3].Type).To(Equal(v1alpha1.PausedCondition))
+				g.Expect(resource.Status.Conditions[3].Status).To(Equal(metav1.ConditionFalse))
+			}).Should(Succeed())
+
+			By("Verifying the Subinterface is configured in the provider")
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.Ports.Has(parentName+".100")).To(BeTrue(), "Provider should have Subinterface configured")
+			}).Should(Succeed())
+
+			By("Verifying the parent Physical interface is configured in the provider")
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.Ports.Has(parentName)).To(BeTrue(), "Provider should have parent Physical Interface configured")
+			}).Should(Succeed())
+		})
+
 		It("Should handle unnumbered reference to non-Loopback Interface", func() {
 			By("Creating a Physical Interface to be referenced")
 			phys := &v1alpha1.Interface{

--- a/internal/provider/cisco/nxos/intf.go
+++ b/internal/provider/cisco/nxos/intf.go
@@ -31,6 +31,8 @@ var (
 	_ gnmiext.DataElement = (*PortChannelOperItems)(nil)
 	_ gnmiext.DataElement = (*SwitchVirtualInterface)(nil)
 	_ gnmiext.DataElement = (*SwitchVirtualInterfaceOperItems)(nil)
+	_ gnmiext.DataElement = (*EncapRoutedInterface)(nil)
+	_ gnmiext.DataElement = (*EncapRoutedInterfaceOperItems)(nil)
 	_ gnmiext.DataElement = (*AddrItem)(nil)
 	_ gnmiext.DataElement = (*FabricFwdIf)(nil)
 )
@@ -118,6 +120,34 @@ type PhysIfOperItems struct {
 
 func (p *PhysIfOperItems) XPath() string {
 	return "System/intf-items/phys-items/PhysIf-list[id=" + p.ID + "]/phys-items"
+}
+
+// EncapRoutedInterface represents an Encapsulated Routed Subinterface.
+type EncapRoutedInterface struct {
+	ID            string         `json:"id"`
+	Medium        Medium         `json:"mediumType"`
+	MTU           int32          `json:"mtu"`
+	MTUInherit    bool           `json:"mtuInherit"`
+	Encap         string         `json:"encap"`
+	AdminSt       AdminSt2       `json:"adminSt"`
+	Descr         Option[string] `json:"descr"`
+	RtvrfMbrItems *VrfMember     `json:"rtvrfMbr-items,omitempty"`
+}
+
+func (*EncapRoutedInterface) IsListItem() {}
+
+func (s *EncapRoutedInterface) XPath() string {
+	return "System/intf-items/encrtd-items/EncRtdIf-list[id=" + s.ID + "]"
+}
+
+type EncapRoutedInterfaceOperItems struct {
+	ID         string `json:"-"`
+	OperSt     OperSt `json:"operSt"`
+	OperStQual string `json:"operStQual"`
+}
+
+func (s *EncapRoutedInterfaceOperItems) XPath() string {
+	return "System/intf-items/encrtd-items/EncRtdIf-list[id=" + s.ID + "]/encrtdif-items"
 }
 
 // VrfMember represents a VRF associtation for an interface.
@@ -475,6 +505,12 @@ func Exists(ctx context.Context, client gnmiext.Client, names ...string) (bool, 
 		}
 		if matches := vlanRe.FindStringSubmatch(name); matches != nil {
 			e = &SwitchVirtualInterface{ID: "vlan" + matches[2]}
+		}
+		if matches := encapRoutedRe.FindStringSubmatch(name); matches != nil {
+			e = &EncapRoutedInterface{ID: "eth" + matches[2] + "." + matches[3]}
+		}
+		if matches := encapRoutedPoRe.FindStringSubmatch(name); matches != nil {
+			e = &EncapRoutedInterface{ID: "po" + matches[2] + "." + matches[3]}
 		}
 		if e == nil {
 			return false, fmt.Errorf("unsupported interface format %q, expected one of: %s, %s, %s, %s, %s", name, mgmtRe.String(), ethernetRe.String(), loopbackRe.String(), portchannelRe.String(), vlanRe.String())

--- a/internal/provider/cisco/nxos/intf_test.go
+++ b/internal/provider/cisco/nxos/intf_test.go
@@ -41,6 +41,16 @@ func init() {
 		UserCfgdFlags: UserFlagAdminState,
 	})
 
+	Register("subinterface", &EncapRoutedInterface{
+		ID:         "eth1/1.100",
+		MTU:        1500,
+		Medium:     MediumBroadcast,
+		MTUInherit: false,
+		Encap:      "100",
+		AdminSt:    AdminStUp,
+		Descr:      NewOption("L3 Subinterface on eth1/1"),
+	})
+
 	intfAddr4 := &AddrItem{ID: "lo0", Vrf: DefaultVRFName}
 	intfAddr4.AddrItems.AddrList.Set(&IntfAddr{
 		Addr: "10.0.0.10/32",

--- a/internal/provider/cisco/nxos/name.go
+++ b/internal/provider/cisco/nxos/name.go
@@ -10,11 +10,13 @@ import (
 )
 
 var (
-	mgmtRe        = regexp.MustCompile(`(?i)^mgmt0$`)
-	ethernetRe    = regexp.MustCompile(`(?i)^(ethernet|eth)(\d+/\d+)$`)
-	loopbackRe    = regexp.MustCompile(`(?i)^(loopback|lo)(\d+)$`)
-	portchannelRe = regexp.MustCompile(`(?i)^(port-channel|po)(\d+)$`)
-	vlanRe        = regexp.MustCompile(`(?i)^(vlan)(\d+)$`)
+	mgmtRe          = regexp.MustCompile(`(?i)^mgmt0$`)
+	ethernetRe      = regexp.MustCompile(`(?i)^(ethernet|eth)(\d+/\d+)$`)
+	loopbackRe      = regexp.MustCompile(`(?i)^(loopback|lo)(\d+)$`)
+	portchannelRe   = regexp.MustCompile(`(?i)^(port-channel|po)(\d+)$`)
+	encapRoutedRe   = regexp.MustCompile(`(?i)^(ethernet|eth)(\d+/\d+)\.(\d+)$`)
+	encapRoutedPoRe = regexp.MustCompile(`(?i)^(port-channel|po)(\d+)\.(\d+)$`)
+	vlanRe          = regexp.MustCompile(`(?i)^(vlan)(\d+)$`)
 )
 
 // ShortName converts a full interface name to its short form.
@@ -38,7 +40,13 @@ func ShortName(name string) (string, error) {
 	if mgmtRe.MatchString(name) {
 		return "mgmt0", nil
 	}
-	return "", fmt.Errorf("unsupported interface format %q, expected one of: %q, %q, %q, %q, %q", name, mgmtRe.String(), ethernetRe.String(), loopbackRe.String(), portchannelRe.String(), vlanRe.String())
+	if matches := encapRoutedRe.FindStringSubmatch(name); matches != nil {
+		return "eth" + matches[2] + "." + matches[3], nil
+	}
+	if matches := encapRoutedPoRe.FindStringSubmatch(name); matches != nil {
+		return "po" + matches[2] + "." + matches[3], nil
+	}
+	return "", fmt.Errorf("unsupported interface format %q, expected one of: %q, %q, %q, %q, %q, %q", name, mgmtRe.String(), ethernetRe.String(), loopbackRe.String(), portchannelRe.String(), vlanRe.String(), encapRoutedRe.String())
 }
 
 func ShortNamePortChannel(name string) (string, error) {

--- a/internal/provider/cisco/nxos/name_test.go
+++ b/internal/provider/cisco/nxos/name_test.go
@@ -89,6 +89,8 @@ func TestShortName(t *testing.T) {
 			expected: "",
 			wantErr:  true,
 		},
+
+		// Valid Port-Channel interface names
 		{
 			name:     "port-channel full name",
 			input:    "Port-Channel10",
@@ -132,6 +134,20 @@ func TestShortName(t *testing.T) {
 			input:    "mgmt1",
 			expected: "",
 			wantErr:  true,
+		},
+
+		// Valid Subinterface names
+		{
+			name:     "physical subinterface name",
+			input:    "Ethernet1/1.100",
+			expected: "eth1/1.100",
+			wantErr:  false,
+		},
+		{
+			name:     "port-channel subinterface name",
+			input:    "Port-Channel10.100",
+			expected: "po10.100",
+			wantErr:  false,
 		},
 	}
 

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -965,6 +965,45 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 				return err
 			}
 		}
+	case v1alpha1.InterfaceTypeSubinterface:
+		s := new(EncapRoutedInterface)
+		s.ID = name
+
+		if req.Interface.Spec.Description != "" {
+			s.Descr = NewOption(req.Interface.Spec.Description)
+		}
+
+		s.AdminSt = AdminStDown
+		if req.Interface.Spec.AdminState == v1alpha1.AdminStateUp {
+			s.AdminSt = AdminStUp
+		}
+
+		s.MTUInherit = true
+		s.MTU = DefaultMTU
+		if req.Interface.Spec.MTU != 0 {
+			s.MTU = req.Interface.Spec.MTU
+			s.MTUInherit = false
+		}
+
+		var encap string
+		switch req.Interface.Spec.Encapsulation.Type {
+		case v1alpha1.EncapsulationTypeDot1Q:
+			encap = "vlan-" + strconv.FormatInt(int64(req.Interface.Spec.Encapsulation.Tag), 10)
+		default:
+			return fmt.Errorf("unsupported encapsulation type: %s", req.Interface.Spec.Encapsulation.Type)
+		}
+		s.Encap = encap
+
+		if req.IPv4 != nil {
+			s.RtvrfMbrItems = NewVrfMember(name, vrf)
+		}
+
+		s.Medium = MediumBroadcast
+		if isPointToPoint(req.Interface.Spec.IPv4) {
+			s.Medium = MediumPointToPoint
+		}
+
+		updates = append(updates, s)
 
 	default:
 		return fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)
@@ -1141,7 +1180,10 @@ func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceR
 		svi := new(SwitchVirtualInterface)
 		svi.ID = name
 		deletes = append(deletes, svi)
-
+	case v1alpha1.InterfaceTypeSubinterface:
+		s := new(EncapRoutedInterface)
+		s.ID = name
+		deletes = append(deletes, s)
 	default:
 		return fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)
 	}
@@ -1195,6 +1237,15 @@ func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.Interfa
 		}
 		operSt = svi.OperSt
 		operMsg = svi.OperStQual
+
+	case v1alpha1.InterfaceTypeSubinterface:
+		s := new(EncapRoutedInterfaceOperItems)
+		s.ID = name
+		if err := p.client.GetState(ctx, s); err != nil && !errors.Is(err, gnmiext.ErrNil) {
+			return provider.InterfaceStatus{}, err
+		}
+		operSt = s.OperSt
+		operMsg = s.OperStQual
 
 	default:
 		return provider.InterfaceStatus{}, fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)

--- a/internal/provider/cisco/nxos/testdata/subinterface.json
+++ b/internal/provider/cisco/nxos/testdata/subinterface.json
@@ -1,0 +1,17 @@
+{
+  "intf-items": {
+    "encrtd-items": {
+      "EncRtdIf-list": [
+        {
+          "id": "eth1/1.100",
+          "mtu": 1500,
+          "mediumType": "broadcast",
+          "mtuInherit": false,
+          "encap": "100",
+          "adminSt": "up",
+          "descr": "L3 Subinterface on eth1/1"
+        }
+      ]
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/subinterface.json.txt
+++ b/internal/provider/cisco/nxos/testdata/subinterface.json.txt
@@ -1,0 +1,5 @@
+interface eth1/1.100
+ encapsulation dot1q 100
+ description L3 Subinterface on eth1/1
+ mtu 1500
+ no shutdown


### PR DESCRIPTION
Implement basic CRUD for SubInterface resources:
* Validate that the parent interface exists and is in a configured state before applying subinterface;
  halt reconciliation otherwise
* Ensure parent interface is Layer 3 (no switchport configuration)
* Watch parent interface for create/update events to trigger reconciliation when it becomes available
* Cascade deletion: removing the parent interface also deletes associated subinterfaces
 
To support the cascading deletion of interfaces, we set owner reference on subinterface to parent
interface. Omitting device owner reference on subinterface as this 
blocks deletion until device gets deleted.