### PR TITLE
Use Option[string] for description and drop mtu omitempty

### DIFF
--- a/internal/provider/cisco/nxos/intf.go
+++ b/internal/provider/cisco/nxos/intf.go
@@ -35,12 +35,12 @@ var (
 	_ gnmiext.DataElement = (*FabricFwdIf)(nil)
 )
 
-// Loopback represents a loopback interface on a NX-OS device.
+// Loopback represents a loopback interface.
 type Loopback struct {
-	AdminSt       AdminSt2   `json:"adminSt"`
-	Descr         string     `json:"descr"`
-	ID            string     `json:"id"`
-	RtvrfMbrItems *VrfMember `json:"rtvrfMbr-items,omitempty"`
+	AdminSt       AdminSt2       `json:"adminSt"`
+	Descr         Option[string] `json:"descr"`
+	ID            string         `json:"id"`
+	RtvrfMbrItems *VrfMember     `json:"rtvrfMbr-items,omitempty"`
 }
 
 func (*Loopback) IsListItem() {}
@@ -64,15 +64,15 @@ const (
 	DefaultMTU       = 1500
 )
 
-// PhysIf represents a physical (ethernet) interface on a NX-OS device.
+// PhysIf represents a physical (ethernet) interface.
 type PhysIf struct {
 	AccessVlan    string         `json:"accessVlan"`
 	AdminSt       AdminSt2       `json:"adminSt,omitempty"`
-	Descr         string         `json:"descr"`
+	Descr         Option[string] `json:"descr"`
 	FecMode       FecMode        `json:"FECMode"`
 	ID            string         `json:"id"`
 	Layer         Layer          `json:"layer"`
-	MTU           int32          `json:"mtu,omitempty"`
+	MTU           int32          `json:"mtu"`
 	Medium        Medium         `json:"medium"`
 	Mode          SwitchportMode `json:"mode"`
 	NativeVlan    string         `json:"nativeVlan"`
@@ -219,14 +219,14 @@ func (i *ICMPIf) XPath() string {
 	return "System/icmpv4-items/inst-items/dom-items/Dom-list[name=default]/if-items/If-list[id=" + i.ID + "]"
 }
 
-// PortChannel represents a port-channel (LAG) interface on a NX-OS device.
+// PortChannel represents a port-channel (LAG) interface.
 type PortChannel struct {
 	AccessVlan    string          `json:"accessVlan"`
 	AdminSt       AdminSt2        `json:"adminSt"`
-	Descr         string          `json:"descr,omitempty"`
+	Descr         Option[string]  `json:"descr"`
 	ID            string          `json:"id"`
 	Layer         Layer           `json:"layer"`
-	MTU           int32           `json:"mtu,omitempty"`
+	MTU           int32           `json:"mtu"`
 	Medium        Medium          `json:"medium"`
 	Mode          SwitchportMode  `json:"mode"`
 	PcMode        PortChannelMode `json:"pcMode"`

--- a/internal/provider/cisco/nxos/intf.go
+++ b/internal/provider/cisco/nxos/intf.go
@@ -50,8 +50,9 @@ func (l *Loopback) XPath() string {
 }
 
 type LoopbackOperItems struct {
-	ID     string `json:"-"`
-	OperSt OperSt `json:"operSt"`
+	ID         string `json:"-"`
+	OperSt     OperSt `json:"operSt"`
+	OperStQual string `json:"operStQual"`
 }
 
 func (l *LoopbackOperItems) XPath() string {
@@ -110,8 +111,9 @@ func (p *PhysIf) Default() {
 }
 
 type PhysIfOperItems struct {
-	ID     string `json:"-"`
-	OperSt OperSt `json:"operSt"`
+	ID         string `json:"-"`
+	OperSt     OperSt `json:"operSt"`
+	OperStQual string `json:"operStQual"`
 }
 
 func (p *PhysIfOperItems) XPath() string {
@@ -265,7 +267,7 @@ func (p *PortChannel) XPath() string {
 type PortChannelOperItems struct {
 	ID         string `json:"-"`
 	OperSt     OperSt `json:"operSt"`
-	OperStQual string `json:"operStQual,omitempty"`
+	OperStQual string `json:"operStQual"`
 }
 
 func (p *PortChannelOperItems) XPath() string {
@@ -289,8 +291,9 @@ func (s *SwitchVirtualInterface) XPath() string {
 }
 
 type SwitchVirtualInterfaceOperItems struct {
-	ID     string `json:"-"`
-	OperSt OperSt `json:"operSt"`
+	ID         string `json:"-"`
+	OperSt     OperSt `json:"operSt"`
+	OperStQual string `json:"operStQual"`
 }
 
 func (*SwitchVirtualInterfaceOperItems) IsListItem() {}

--- a/internal/provider/cisco/nxos/intf_test.go
+++ b/internal/provider/cisco/nxos/intf_test.go
@@ -6,7 +6,7 @@ package nxos
 func init() {
 	Register("loopback", &Loopback{
 		ID:            "lo0",
-		Descr:         "Test",
+		Descr:         NewOption("Test"),
 		AdminSt:       AdminStUp,
 		RtvrfMbrItems: NewVrfMember("lo0", ManagementVRFName),
 	})
@@ -14,7 +14,7 @@ func init() {
 	Register("physif_rtd", &PhysIf{
 		AdminSt:       AdminStUp,
 		ID:            "eth1/1",
-		Descr:         "Leaf1 to Spine1",
+		Descr:         NewOption("Leaf1 to Spine1"),
 		FecMode:       FecModeAuto,
 		Layer:         Layer3,
 		MTU:           9216,
@@ -29,9 +29,10 @@ func init() {
 	Register("physif_switchport", &PhysIf{
 		AdminSt:       AdminStUp,
 		ID:            "eth1/10",
-		Descr:         "Leaf1 to Host1",
+		Descr:         NewOption("Leaf1 to Host1"),
 		FecMode:       FecModeAuto,
 		Layer:         Layer2,
+		MTU:           DefaultMTU,
 		Medium:        MediumBroadcast,
 		Mode:          SwitchportModeTrunk,
 		AccessVlan:    DefaultVLAN,
@@ -52,9 +53,10 @@ func init() {
 	pc := &PortChannel{
 		AccessVlan:    DefaultVLAN,
 		AdminSt:       AdminStUp,
-		Descr:         "vPC Leaf1 to Host1",
+		Descr:         NewOption("vPC Leaf1 to Host1"),
 		ID:            "po10",
 		Layer:         Layer2,
+		MTU:           DefaultMTU,
 		Medium:        MediumBroadcast,
 		Mode:          SwitchportModeTrunk,
 		PcMode:        PortChannelModeActive,
@@ -68,7 +70,7 @@ func init() {
 	Register("pc_rtd", &PortChannel{
 		AccessVlan:    "unknown",
 		AdminSt:       AdminStUp,
-		Descr:         "L3 Port-Channel to Spine1",
+		Descr:         NewOption("L3 Port-Channel to Spine1"),
 		ID:            "po20",
 		Layer:         Layer3,
 		MTU:           9216,

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -721,7 +721,9 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		p := new(PhysIf)
 		p.Default()
 		p.ID = name
-		p.Descr = req.Interface.Spec.Description
+		if req.Interface.Spec.Description != "" {
+			p.Descr = NewOption(req.Interface.Spec.Description)
+		}
 		if req.Interface.Spec.AdminState == v1alpha1.AdminStateUp {
 			p.AdminSt = AdminStUp
 		}
@@ -792,7 +794,9 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 	case v1alpha1.InterfaceTypeLoopback:
 		lb := new(Loopback)
 		lb.ID = name
-		lb.Descr = req.Interface.Spec.Description
+		if req.Interface.Spec.Description != "" {
+			lb.Descr = NewOption(req.Interface.Spec.Description)
+		}
 		lb.AdminSt = AdminStDown
 		if req.Interface.Spec.AdminState == v1alpha1.AdminStateUp {
 			lb.AdminSt = AdminStUp
@@ -816,7 +820,9 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 
 		pc := new(PortChannel)
 		pc.ID = name
-		pc.Descr = req.Interface.Spec.Description
+		if req.Interface.Spec.Description != "" {
+			pc.Descr = NewOption(req.Interface.Spec.Description)
+		}
 		pc.AdminSt = AdminStDown
 		if req.Interface.Spec.AdminState == v1alpha1.AdminStateUp {
 			pc.AdminSt = AdminStUp

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -1161,6 +1161,7 @@ func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.Interfa
 			return provider.InterfaceStatus{}, err
 		}
 		operSt = phys.OperSt
+		operMsg = phys.OperStQual
 
 	case v1alpha1.InterfaceTypeLoopback:
 		lb := new(LoopbackOperItems)
@@ -1169,6 +1170,7 @@ func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.Interfa
 			return provider.InterfaceStatus{}, err
 		}
 		operSt = lb.OperSt
+		operMsg = lb.OperStQual
 
 	case v1alpha1.InterfaceTypeAggregate:
 		pc := new(PortChannelOperItems)
@@ -1186,9 +1188,17 @@ func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.Interfa
 			return provider.InterfaceStatus{}, err
 		}
 		operSt = svi.OperSt
+		operMsg = svi.OperStQual
 
 	default:
 		return provider.InterfaceStatus{}, fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)
+	}
+
+	// When an interface is operationally up, the operational message will be "none".
+	// In this case, we return an empty string for the operational message to avoid confusion.
+	const operMsgNone = "none"
+	if operSt == OperStUp && operMsg == operMsgNone {
+		operMsg = ""
 	}
 
 	return provider.InterfaceStatus{

--- a/internal/provider/cisco/nxos/testdata/pc.json
+++ b/internal/provider/cisco/nxos/testdata/pc.json
@@ -8,6 +8,7 @@
           "descr": "vPC Leaf1 to Host1",
           "id": "po10",
           "layer": "Layer2",
+          "mtu": 1500,
           "medium": "broadcast",
           "mode": "trunk",
           "pcMode": "active",

--- a/internal/provider/cisco/nxos/testdata/physif_switchport.json
+++ b/internal/provider/cisco/nxos/testdata/physif_switchport.json
@@ -9,6 +9,7 @@
           "FECMode": "auto",
           "id": "eth1/10",
           "layer": "Layer2",
+          "mtu": 1500,
           "medium": "broadcast",
           "mode": "trunk",
           "nativeVlan": "vlan-1",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -133,6 +133,7 @@ type InterfaceStatus struct {
 	// OperStatus indicates whether the interface is operationally up (true) or down (false).
 	OperStatus bool
 	// OperMessage provides additional information about the operational status of the interface.
+	// Leave empty if the provider does not return any additional information.
 	OperMessage string
 }
 


### PR DESCRIPTION
Description is omitted completely in the YANG payload when unset or removed with 'no description', the field must be omitted entirely. Model this with Option[string] so the zero value removes the entry in YANG.

MTU is always present in the YANG payload (defaulting to 1500 when not explicitly configured), so remove the omitempty tag to ensure it is never omitted from the serialized payload.