### PR TITLE
[NXOS] Enable `fabric forwarding` feature at NVE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,10 +229,10 @@ install-setup-envtest: FORCE
 # To add additional flags or values (before the default ones), specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.
 # To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.
 GO_BUILDFLAGS +=
-GO_LDFLAGS +=
-GO_TESTFLAGS +=
-GO_TESTENV +=
-GO_BUILDENV += CGO_ENABLED=0
+GO_LDFLAGS    +=
+GO_TESTFLAGS  +=
+GO_TESTENV    +=
+GO_BUILDENV   += CGO_ENABLED=0
 
 # These definitions are overridable, e.g. to provide fixed version/commit values when
 # no .git directory is present or to provide a fixed build date for reproducibility.
@@ -284,7 +284,7 @@ run-golangci-lint: FORCE install-golangci-lint
 
 run-shellcheck: FORCE install-shellcheck
 	@printf "\e[1;36m>> shellcheck\e[0m\n"
-	@find .  -type f \( -name '*.bash' -o -name '*.ksh' -o -name '*.zsh' -o -name '*.sh' -o -name '*.shlib' \) -exec shellcheck  {} +
+	@find . \( -path '*/docs/node_modules/*/*' -prune \) -o \( -path 'docs/node_modules/*' -prune \) -o -type f \( -name '*.bash' -o -name '*.ksh' -o -name '*.zsh' -o -name '*.sh' -o -name '*.shlib' \) -exec shellcheck  {} +
 
 run-typos: FORCE install-typos
 	@printf "\e[1;36m>> typos\e[0m\n"

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -31,6 +31,10 @@ golangciLint:
     - internal/provider/openconfig
   timeout: 10m
 
+shellCheck:
+  ignorePaths:
+    - 'docs/node_modules/*'
+
 goReleaser:
   createConfig: true
 

--- a/internal/provider/cisco/nxos/nve.go
+++ b/internal/provider/cisco/nxos/nve.go
@@ -123,7 +123,7 @@ func (*NVEOper) IsListItem() {}
 // Should use only PATCH operations: `FabricFwdIf` also modifies this model.
 type FabricFwd struct {
 	// AdminSt defines the administrative state of fabric forwarding
-	AdminSt string `json:"adminSt"`
+	AdminSt AdminSt `json:"adminSt"`
 	// Address defines the anycast gateway MAC address
 	Address string `json:"amac"`
 }

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -2723,15 +2723,26 @@ func (p *Provider) ResetBorderGatewaySettings(ctx context.Context) error {
 // EnsureNVE ensures that the NVE configuration on the device matches the desired state specified in the NVE custom resource.
 // If no provider config is provided then the provider will use default settings.
 func (p *Provider) EnsureNVE(ctx context.Context, req *provider.NVERequest) error {
+	features := make([]gnmiext.DataElement, 0, 3)
+
 	f1 := new(Feature)
 	f1.Name = "evpn"
 	f1.AdminSt = AdminStEnabled
+	features = append(features, f1)
 
 	f2 := new(Feature)
 	f2.Name = "nvo"
 	f2.AdminSt = AdminStEnabled
+	features = append(features, f2)
 
-	if err := p.Patch(ctx, f1, f2); err != nil {
+	if req.NVE.Spec.AnycastGateway != nil {
+		f3 := new(Feature)
+		f3.Name = "hmm"
+		f3.AdminSt = AdminStEnabled
+		features = append(features, f3)
+	}
+
+	if err := p.Patch(ctx, features...); err != nil {
 		return err
 	}
 
@@ -2808,8 +2819,9 @@ func (p *Provider) EnsureNVE(ctx context.Context, req *provider.NVERequest) erro
 	}
 
 	ag := new(FabricFwd)
+	ag.AdminSt = AdminStDisabled
 	if req.NVE.Spec.AnycastGateway != nil {
-		ag.AdminSt = string(AdminStEnabled)
+		ag.AdminSt = AdminStEnabled
 		ag.Address = req.NVE.Spec.AnycastGateway.VirtualMAC
 	}
 	patches = append(patches, ag)


### PR DESCRIPTION
NVE resources that use an Anycast Gateway require the ‘fabric forwarding’ feature on NX-OS. We now enable this feature automatically when ensuring NVE configuration.