### PR TITLE
Add `internal/apistatus` package with typed terminal errors

### DIFF
--- a/internal/apistatus/apistatus.go
+++ b/internal/apistatus/apistatus.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package apistatus provides a typed terminal error for provider implementations.
+// Package apistatus provides a typed structured error for provider implementations.
 package apistatus
 
 import (
@@ -29,7 +29,10 @@ const (
 	CodeUnsupportedField
 
 	// CodeFailedPrecondition signals that a precondition on the device or
-	// environment is not met. Retrying will not resolve it.
+	// environment is not met. Unlike other codes, this is retryable — the
+	// precondition may become true on a future attempt (e.g. a BGP process
+	// configured out-of-band). [WrapTerminalError] does not promote these
+	// errors to terminal.
 	CodeFailedPrecondition
 )
 
@@ -65,9 +68,10 @@ type FieldViolation struct {
 	Description string
 }
 
-// StatusError is a terminal, non-retryable error returned by provider
-// implementations. It carries a Code, an optional top-level Message,
-// and an optional list of FieldViolations.
+// StatusError is a structured error returned by provider implementations.
+// It carries a Code, an optional top-level Message, and an optional list of
+// FieldViolations. Whether the error is terminal depends on the Code — see
+// [WrapTerminalError].
 type StatusError struct {
 	Code            Code
 	Message         string
@@ -115,7 +119,9 @@ func NewUnsupportedFieldError(violations ...FieldViolation) *StatusError {
 }
 
 // NewFailedPreconditionError returns a [StatusError] with [CodeFailedPrecondition]
-// for a precondition that is not met and cannot be resolved by retrying.
+// for a precondition that is not yet met. These errors are retryable —
+// controller-runtime exponential backoff will requeue the request so the
+// precondition can be rechecked on a future attempt.
 func NewFailedPreconditionError(message string) *StatusError {
 	return &StatusError{
 		Code:    CodeFailedPrecondition,
@@ -130,8 +136,12 @@ func FromError(err error) (*StatusError, bool) {
 	return se, ok
 }
 
-// WrapTerminalError wraps err as a [reconcile.TerminalError] if it is or
-// contains a [*StatusError]. All other errors are returned unchanged.
+// WrapTerminalError wraps err as a [reconcile.TerminalError] if it contains a
+// [*StatusError] with a non-retryable code ([CodeInvalidArgument] or
+// [CodeUnsupportedField]). [CodeFailedPrecondition] errors are returned
+// unchanged so the controller-runtime exponential backoff can requeue them —
+// the precondition may become true on a future attempt.
+// All other errors are also returned unchanged.
 //
 // Example usage in a controller:
 //
@@ -142,8 +152,13 @@ func FromError(err error) (*StatusError, bool) {
 //	    return apistatus.WrapTerminalError(err)
 //	}
 func WrapTerminalError(err error) error {
-	if errors.Is(err, &StatusError{}) {
-		return reconcile.TerminalError(err)
+	if se, ok := FromError(err); ok {
+		switch se.Code {
+		case CodeInvalidArgument, CodeUnsupportedField:
+			return reconcile.TerminalError(err)
+		default:
+			// Other codes are not considered terminal — return the original error
+		}
 	}
 	return err
 }

--- a/internal/apistatus/apistatus.go
+++ b/internal/apistatus/apistatus.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package apistatus provides a typed terminal error for provider implementations.
+package apistatus
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Code identifies the category of a [StatusError].
+// The zero value is not a valid code.
+type Code uint8
+
+const (
+	// CodeInvalidArgument signals that one or more spec field values have an
+	// incorrect format or structure. The field is supported, but the value
+	// does not meet the provider's requirements. The resource cannot be
+	// realized until the spec is corrected.
+	CodeInvalidArgument Code = iota + 1
+
+	// CodeUnsupportedField signals that one or more spec fields are not
+	// supported by the provider. The resource cannot be realized until
+	// the spec is changed.
+	CodeUnsupportedField
+
+	// CodeFailedPrecondition signals that a precondition on the device or
+	// environment is not met. Retrying will not resolve it.
+	CodeFailedPrecondition
+)
+
+// Valid reports whether c is a known, non-zero Code.
+func (c Code) Valid() bool {
+	switch c {
+	case CodeInvalidArgument, CodeUnsupportedField, CodeFailedPrecondition:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of c.
+func (c Code) String() string {
+	switch c {
+	case CodeInvalidArgument:
+		return "InvalidArgument"
+	case CodeUnsupportedField:
+		return "UnsupportedField"
+	case CodeFailedPrecondition:
+		return "FailedPrecondition"
+	default:
+		return fmt.Sprintf("Code(%d)", c)
+	}
+}
+
+// FieldViolation describes a problem with a specific spec field.
+type FieldViolation struct {
+	// Field is the dot-separated path to the field, e.g. "spec.mtu".
+	Field string
+	// Description explains why the field is invalid, e.g. "not supported on this platform".
+	Description string
+}
+
+// StatusError is a terminal, non-retryable error returned by provider
+// implementations. It carries a Code, an optional top-level Message,
+// and an optional list of FieldViolations.
+type StatusError struct {
+	Code            Code
+	Message         string
+	FieldViolations []FieldViolation
+}
+
+// Is implements the errors.Is interface, reporting whether target is a [*StatusError].
+// This allows [errors.Is] to be used for type detection in error chains.
+func (e *StatusError) Is(target error) bool {
+	_, ok := FromError(target) //nolint:errcheck
+	return ok
+}
+
+// Error implements the error interface.
+func (e *StatusError) Error() string {
+	parts := make([]string, 0, 1+len(e.FieldViolations))
+	if e.Message != "" {
+		parts = append(parts, e.Message)
+	}
+	for _, v := range e.FieldViolations {
+		parts = append(parts, fmt.Sprintf("field %s: %s", v.Field, v.Description))
+	}
+	if len(parts) == 0 {
+		return e.Code.String()
+	}
+	return e.Code.String() + ": " + strings.Join(parts, "; ")
+}
+
+// NewInvalidArgumentError returns a [StatusError] with [CodeInvalidArgument] for
+// one or more spec field values that have an incorrect format or structure.
+func NewInvalidArgumentError(violations ...FieldViolation) *StatusError {
+	return &StatusError{
+		Code:            CodeInvalidArgument,
+		FieldViolations: violations,
+	}
+}
+
+// NewUnsupportedFieldError returns a [StatusError] with [CodeUnsupportedField] for
+// one or more spec fields that are not supported by the provider.
+func NewUnsupportedFieldError(violations ...FieldViolation) *StatusError {
+	return &StatusError{
+		Code:            CodeUnsupportedField,
+		FieldViolations: violations,
+	}
+}
+
+// NewFailedPreconditionError returns a [StatusError] with [CodeFailedPrecondition]
+// for a precondition that is not met and cannot be resolved by retrying.
+func NewFailedPreconditionError(message string) *StatusError {
+	return &StatusError{
+		Code:    CodeFailedPrecondition,
+		Message: message,
+	}
+}
+
+// FromError extracts a [*StatusError] from err.
+// The boolean reports whether the extraction succeeded.
+func FromError(err error) (*StatusError, bool) {
+	se, ok := errors.AsType[*StatusError](err)
+	return se, ok
+}
+
+// WrapTerminalError wraps err as a [reconcile.TerminalError] if it is or
+// contains a [*StatusError]. All other errors are returned unchanged.
+//
+// Example usage in a controller:
+//
+//	err := s.Provider.EnsureBGPPeer(ctx, &provider.BGPPeerRequest{...})
+//	cond := conditions.FromError(err)
+//	conditions.Set(s.BGPPeer, cond)
+//	if err != nil {
+//	    return apistatus.WrapTerminalError(err)
+//	}
+func WrapTerminalError(err error) error {
+	if errors.Is(err, &StatusError{}) {
+		return reconcile.TerminalError(err)
+	}
+	return err
+}

--- a/internal/apistatus/apistatus_test.go
+++ b/internal/apistatus/apistatus_test.go
@@ -105,8 +105,11 @@ func TestWrapTerminalError(t *testing.T) {
 		err          error
 		wantTerminal bool
 	}{
-		{"StatusError", apistatus.NewFailedPreconditionError("BGP instance must be configured before BGP peers can be realized"), true},
-		{"Wrapped", fmt.Errorf("outer: %w", apistatus.NewFailedPreconditionError("BGP instance must be configured before BGP peers can be realized")), true},
+		{"InvalidArgument", apistatus.NewInvalidArgumentError(apistatus.FieldViolation{Field: "spec.mtu", Description: "x"}), true},
+		{"UnsupportedField", apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{Field: "spec.type", Description: "x"}), true},
+		{"WrappedUnsupportedField", fmt.Errorf("outer: %w", apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{Field: "spec.type", Description: "x"})), true},
+		{"FailedPrecondition", apistatus.NewFailedPreconditionError("BGP instance must be configured before BGP peers can be realized"), false},
+		{"WrappedFailedPrecondition", fmt.Errorf("outer: %w", apistatus.NewFailedPreconditionError("BGP instance must be configured")), false},
 		{"Plain", errors.New("transient"), false},
 		{"Nil", nil, false},
 	}

--- a/internal/apistatus/apistatus_test.go
+++ b/internal/apistatus/apistatus_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package apistatus_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
+)
+
+func TestCode(t *testing.T) {
+	tests := []struct {
+		code      apistatus.Code
+		wantStr   string
+		wantValid bool
+	}{
+		{apistatus.Code(0), "Code(0)", false},
+		{apistatus.CodeInvalidArgument, "InvalidArgument", true},
+		{apistatus.CodeUnsupportedField, "UnsupportedField", true},
+		{apistatus.CodeFailedPrecondition, "FailedPrecondition", true},
+		{apistatus.Code(99), "Code(99)", false},
+	}
+	for _, test := range tests {
+		if got := test.code.String(); got != test.wantStr {
+			t.Errorf("Code(%d).String() = %q, want %q", test.code, got, test.wantStr)
+		}
+		if got := test.code.Valid(); got != test.wantValid {
+			t.Errorf("Code(%d).Valid() = %v, want %v", test.code, got, test.wantValid)
+		}
+	}
+}
+
+func TestStatusError(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            *apistatus.StatusError
+		wantCode       apistatus.Code
+		wantMessage    string
+		wantViolations []apistatus.FieldViolation
+	}{
+		{
+			name:           "InvalidArgument",
+			err:            apistatus.NewInvalidArgumentError(apistatus.FieldViolation{Field: "spec.name", Description: "invalid interface format, expected e.g. eth1/1"}),
+			wantCode:       apistatus.CodeInvalidArgument,
+			wantViolations: []apistatus.FieldViolation{{Field: "spec.name", Description: "invalid interface format, expected e.g. eth1/1"}},
+		},
+		{
+			name:           "UnsupportedField",
+			err:            apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{Field: "spec.mtu", Description: "MTU configuration is not supported on this platform"}),
+			wantCode:       apistatus.CodeUnsupportedField,
+			wantViolations: []apistatus.FieldViolation{{Field: "spec.mtu", Description: "MTU configuration is not supported on this platform"}},
+		},
+		{
+			name:        "FailedPrecondition",
+			err:         apistatus.NewFailedPreconditionError("BGP instance must be configured before BGP peers can be realized"),
+			wantCode:    apistatus.CodeFailedPrecondition,
+			wantMessage: "BGP instance must be configured before BGP peers can be realized",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.err.Code != test.wantCode {
+				t.Errorf("Code = %v, want %v", test.err.Code, test.wantCode)
+			}
+			if test.wantMessage != "" && test.err.Message != test.wantMessage {
+				t.Errorf("Message = %q, want %q", test.err.Message, test.wantMessage)
+			}
+			if len(test.wantViolations) > 0 {
+				if len(test.err.FieldViolations) != len(test.wantViolations) || test.err.FieldViolations[0] != test.wantViolations[0] {
+					t.Errorf("FieldViolations = %+v, want %+v", test.err.FieldViolations, test.wantViolations)
+				}
+			}
+		})
+	}
+}
+
+func TestFromError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		ok   bool
+	}{
+		{"StatusError", apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{Field: "spec.mtu", Description: "x"}), true},
+		{"Wrapped", fmt.Errorf("outer: %w", apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{Field: "spec.mtu", Description: "x"})), true},
+		{"Plain", errors.New("plain error"), false},
+		{"Nil", nil, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, ok := apistatus.FromError(test.err); ok != test.ok { //nolint:errcheck
+				t.Errorf("FromError ok = %v, want %v", ok, test.ok)
+			}
+		})
+	}
+}
+
+func TestWrapTerminalError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantTerminal bool
+	}{
+		{"StatusError", apistatus.NewFailedPreconditionError("BGP instance must be configured before BGP peers can be realized"), true},
+		{"Wrapped", fmt.Errorf("outer: %w", apistatus.NewFailedPreconditionError("BGP instance must be configured before BGP peers can be realized")), true},
+		{"Plain", errors.New("transient"), false},
+		{"Nil", nil, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := apistatus.WrapTerminalError(test.err)
+			if errors.Is(got, reconcile.TerminalError(nil)) != test.wantTerminal {
+				t.Errorf("IsTerminalError = %v, want %v", !test.wantTerminal, test.wantTerminal)
+			}
+		})
+	}
+}

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 )
 
 // Getter defines methods that an API object should implement in order to
@@ -158,8 +159,9 @@ func Sort(conditions []metav1.Condition) {
 
 // FromError creates a [v1alpha1.ConfiguredCondition] from the given error.
 // If the error is nil, it returns a condition indicating success.
-// If the error is a gRPC status error, it extracts the code and message
-// to populate the condition's Reason and Message fields.
+// If the error is an [apistatus.StatusError], its Code and formatted message
+// are used to populate the condition's Reason and Message fields.
+// If the error is a gRPC status error, its code and message are used instead.
 func FromError(err error) metav1.Condition {
 	cond := metav1.Condition{
 		Type:    v1alpha1.ConfiguredCondition,
@@ -171,6 +173,13 @@ func FromError(err error) metav1.Condition {
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = v1alpha1.ErrorReason
 		cond.Message = err.Error()
+
+		// [apistatus.StatusError] takes precedence — checked before gRPC status.
+		if statusErr, ok := apistatus.FromError(err); ok {
+			cond.Reason = statusErr.Code.String()
+			cond.Message = statusErr.Error()
+			return cond
+		}
 
 		// If the error is a gRPC status error, extract the code and message
 		if statusErr, ok := grpcstatus.FromError(err); ok {

--- a/internal/controller/cisco/nx/bordergateway_controller.go
+++ b/internal/controller/cisco/nx/bordergateway_controller.go
@@ -29,6 +29,7 @@ import (
 
 	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	corecontroller "github.com/ironcore-dev/network-operator/internal/controller/core"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
@@ -188,7 +189,7 @@ func (r *BorderGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/cisco/nx/system_controller.go
+++ b/internal/controller/cisco/nx/system_controller.go
@@ -27,6 +27,7 @@ import (
 
 	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	corecontroller "github.com/ironcore-dev/network-operator/internal/controller/core"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
@@ -185,7 +186,7 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/cisco/nx/vpcdomain_controller.go
+++ b/internal/controller/cisco/nx/vpcdomain_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/paused"
 	"github.com/ironcore-dev/network-operator/internal/provider"
@@ -186,7 +187,7 @@ func (r *VPCDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err = r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: corecontroller.Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/acl_controller.go
+++ b/internal/controller/core/acl_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *AccessControlListReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/banner_controller.go
+++ b/internal/controller/core/banner_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/clientutil"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
@@ -199,7 +200,7 @@ func (r *BannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/bgp_controller.go
+++ b/internal/controller/core/bgp_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -208,7 +209,7 @@ func (r *BGPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -212,7 +213,7 @@ func (r *BGPPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/certificate_controller.go
+++ b/internal/controller/core/certificate_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/clientutil"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
@@ -198,7 +199,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/dhcprelay_controller.go
+++ b/internal/controller/core/dhcprelay_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -201,7 +202,7 @@ func (r *DHCPRelayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/dns_controller.go
+++ b/internal/controller/core/dns_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *DNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/evpninstance_controller.go
+++ b/internal/controller/core/evpninstance_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -197,7 +198,7 @@ func (r *EVPNInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/interface_controller.go
+++ b/internal/controller/core/interface_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -205,7 +206,7 @@ func (r *InterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/isis_controller.go
+++ b/internal/controller/core/isis_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -196,7 +197,7 @@ func (r *ISISReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/lldp_controller.go
+++ b/internal/controller/core/lldp_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -190,7 +191,7 @@ func (r *LLDPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/managementaccess_controller.go
+++ b/internal/controller/core/managementaccess_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *ManagementAccessReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/ntp_controller.go
+++ b/internal/controller/core/ntp_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *NTPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/nve_controller.go
+++ b/internal/controller/core/nve_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -196,7 +197,7 @@ func (r *NetworkVirtualizationEdgeReconciler) Reconcile(ctx context.Context, req
 
 	if err = r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/ospf_controller.go
+++ b/internal/controller/core/ospf_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -202,7 +203,7 @@ func (r *OSPFReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/pim_controller.go
+++ b/internal/controller/core/pim_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -196,7 +197,7 @@ func (r *PIMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/prefixset_controller.go
+++ b/internal/controller/core/prefixset_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *PrefixSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/routingpolicy_controller.go
+++ b/internal/controller/core/routingpolicy_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *RoutingPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/snmp_controller.go
+++ b/internal/controller/core/snmp_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *SNMPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/syslog_controller.go
+++ b/internal/controller/core/syslog_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -195,7 +196,7 @@ func (r *SyslogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/user_controller.go
+++ b/internal/controller/core/user_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/clientutil"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
@@ -198,7 +199,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/core/vlan_controller.go
+++ b/internal/controller/core/vlan_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -199,7 +200,7 @@ func (r *VLANReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{RequeueAfter: Jitter(r.RequeueInterval)}, nil

--- a/internal/controller/core/vrf_controller.go
+++ b/internal/controller/core/vrf_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/conditions"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/paused"
@@ -197,7 +198,7 @@ func (r *VRFReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 
 	if err := r.reconcile(ctx, s); err != nil {
 		log.Error(err, "Failed to reconcile resource")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, apistatus.WrapTerminalError(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/provider/cisco/nxos/name.go
+++ b/internal/provider/cisco/nxos/name.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 )
 
 var (
@@ -46,7 +48,10 @@ func ShortName(name string) (string, error) {
 	if matches := encapRoutedPoRe.FindStringSubmatch(name); matches != nil {
 		return "po" + matches[2] + "." + matches[3], nil
 	}
-	return "", fmt.Errorf("unsupported interface format %q, expected one of: %q, %q, %q, %q, %q, %q", name, mgmtRe.String(), ethernetRe.String(), loopbackRe.String(), portchannelRe.String(), vlanRe.String(), encapRoutedRe.String())
+	return "", apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+		Field:       "spec.name",
+		Description: fmt.Sprintf("unsupported interface format %q, expected one of: %q, %q, %q, %q, %q, %q", name, mgmtRe.String(), ethernetRe.String(), loopbackRe.String(), portchannelRe.String(), vlanRe.String(), encapRoutedRe.String()),
+	})
 }
 
 func ShortNamePortChannel(name string) (string, error) {
@@ -72,5 +77,8 @@ func shortNameWithPrefix(name, prefix string, re *regexp.Regexp) (string, error)
 	if matches := re.FindStringSubmatch(name); matches != nil {
 		return prefix + matches[2], nil
 	}
-	return "", fmt.Errorf("invalid interface format %q, expected %q", name, re.String())
+	return "", apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+		Field:       "spec.name",
+		Description: fmt.Sprintf("invalid interface format %q, expected %q", name, re.String()),
+	})
 }

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -26,6 +26,7 @@ import (
 
 	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/provider"
 	"github.com/ironcore-dev/network-operator/internal/transport/gnmiext"
@@ -268,11 +269,17 @@ func (p *Provider) EnsureBanner(ctx context.Context, req *provider.EnsureBannerR
 	// See: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/104x/configuration/fundamentals/cisco-nexus-9000-series-nx-os-fundamentals-configuration-guide-release-104x/m-basic-device-management.html#task_1174841
 	lines := strings.Split(req.Message, "\n")
 	if len(lines) > 40 {
-		return errors.New("banner: maximum of 40 lines allowed")
+		return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+			Field:       "spec.message",
+			Description: fmt.Sprintf("banner exceeds the 40-line limit on NX-OS (%d lines)", len(lines)),
+		})
 	}
 	for i, line := range lines {
 		if n := utf8.RuneCountInString(line); n > 255 {
-			return fmt.Errorf("banner: line %d exceeds 255 characters (%d)", i+1, n)
+			return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+				Field:       "spec.message",
+				Description: fmt.Sprintf("line %d exceeds the 255-character limit on NX-OS (%d characters)", i+1, n),
+			})
 		}
 	}
 
@@ -492,7 +499,7 @@ func (p *Provider) EnsureBGPPeer(ctx context.Context, req *provider.EnsureBGPPee
 		bgp.Name = req.VRF.Spec.Name
 	}
 	if err := p.client.GetConfig(ctx, bgp); err != nil {
-		return fmt.Errorf("bgp peer: failed to get bgp instance %q: %w", bgp.Name, err)
+		return apistatus.NewFailedPreconditionError(fmt.Sprintf("bgp peer: BGP instance %q must be configured on the device before peers can be realized: %v", bgp.Name, err))
 	}
 
 	pe := new(BGPPeer)
@@ -679,7 +686,9 @@ func (p *Provider) EnsureEVPNInstance(ctx context.Context, req *provider.EVPNIns
 		v := new(VLAN)
 		v.FabEncap = "vlan-" + strconv.FormatInt(int64(req.VLAN.Spec.ID), 10)
 		if err := p.client.GetConfig(ctx, v); err != nil {
-			return fmt.Errorf("evpn instance: failed to get vlan %d: %w", req.VLAN.Spec.ID, err)
+			return apistatus.NewFailedPreconditionError(
+				fmt.Sprintf("evpn instance: VLAN %d must exist on the device before an EVPN instance can be realized: %v", req.VLAN.Spec.ID, err),
+			)
 		}
 
 		vxlan := new(VXLAN)
@@ -1139,7 +1148,10 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		updates = append(updates, s)
 
 	default:
-		return fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)
+		return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
+			Field:       "spec.type",
+			Description: fmt.Sprintf("unsupported interface type: %s", req.Interface.Spec.Type),
+		})
 	}
 
 	if (req.Interface.Spec.Type == v1alpha1.InterfaceTypePhysical || req.Interface.Spec.Type == v1alpha1.InterfaceTypeAggregate) && req.IPv4 == nil && (req.AggregateParent == nil || req.AggregateParent.Spec.IPv4 == nil) {
@@ -1320,7 +1332,10 @@ func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceR
 		s.ID = name
 		deletes = append(deletes, s)
 	default:
-		return fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)
+		return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
+			Field:       "spec.type",
+			Description: fmt.Sprintf("unsupported interface type: %s", req.Interface.Spec.Type),
+		})
 	}
 
 	return p.client.Delete(ctx, deletes...)
@@ -1401,7 +1416,10 @@ func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.Interfa
 		operMsg = s.OperStQual
 
 	default:
-		return provider.InterfaceStatus{}, fmt.Errorf("unsupported interface type: %s", req.Interface.Spec.Type)
+		return provider.InterfaceStatus{}, apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
+			Field:       "spec.type",
+			Description: fmt.Sprintf("unsupported interface type: %s", req.Interface.Spec.Type),
+		})
 	}
 
 	// When an interface is operationally up, the operational message will be "none".
@@ -1749,14 +1767,20 @@ func (p *Provider) EnsureOSPF(ctx context.Context, req *provider.EnsureOSPFReque
 	dom.BwRefUnit = BwRefUnitMbps
 	if cfg.ReferenceBandwidthMbps != 0 {
 		if cfg.ReferenceBandwidthMbps < 1 || cfg.ReferenceBandwidthMbps > 999999 {
-			return fmt.Errorf("ospf: reference bandwidth %d is out of range (1-999999 Mbps)", cfg.ReferenceBandwidthMbps)
+			return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+				Field:       "providerConfig.referenceBandwidthMbps",
+				Description: fmt.Sprintf("reference bandwidth %d Mbps is out of range, must be between 1 and 999999 Mbps", cfg.ReferenceBandwidthMbps),
+			})
 		}
 		dom.BwRef = cfg.ReferenceBandwidthMbps
 	}
 	dom.Dist = DefaultDist
 	if cfg.Distance != 0 {
 		if cfg.Distance < 1 || cfg.Distance > 255 {
-			return fmt.Errorf("ospf: distance %d is out of range (1-255)", cfg.Distance)
+			return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+				Field:       "providerConfig.distance",
+				Description: fmt.Sprintf("distance %d is out of range, must be between 1 and 255", cfg.Distance),
+			})
 		}
 		dom.Dist = cfg.Distance
 	}
@@ -1949,7 +1973,10 @@ func (p *Provider) EnsurePIM(ctx context.Context, req *provider.EnsurePIMRequest
 		intf.ID = name
 		switch req.Interfaces[i].Mode {
 		case v1alpha1.PIMModeDense:
-			return errors.New("pim: dense mode is not supported on Cisco NX-OS devices")
+			return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
+				Field:       "spec.interfaces[*].mode",
+				Description: "PIM dense mode is not supported on Cisco NX-OS devices",
+			})
 		case v1alpha1.PIMModeSparse:
 			intf.PimSparseMode = true
 		}
@@ -2784,7 +2811,10 @@ func (p *Provider) EnsureBorderGatewaySettings(ctx context.Context, req *BorderG
 	bg.SiteID = strconv.FormatInt(req.BorderGateway.Spec.MultisiteID, 10)
 	bg.DelayRestoreSeconds = int64(math.Round(req.BorderGateway.Spec.DelayRestoreTime.Seconds()))
 	if bg.DelayRestoreSeconds < 30 || bg.DelayRestoreSeconds > 1000 {
-		return fmt.Errorf("border gateway: delay restore time %d seconds is out of range (30-1000)", bg.DelayRestoreSeconds)
+		return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+			Field:       "spec.delayRestoreTime",
+			Description: fmt.Sprintf("delay restore time %d seconds is out of range, must be between 30 and 1000 seconds", bg.DelayRestoreSeconds),
+		})
 	}
 	updates = append(updates, bg)
 
@@ -2796,7 +2826,10 @@ func (p *Provider) EnsureBorderGatewaySettings(ctx context.Context, req *BorderG
 		ctrl := new(StormControlItem)
 		f, err := strconv.ParseFloat(cfg.Level, 64)
 		if err != nil {
-			return fmt.Errorf("border gateway: invalid storm control level %q: %w", cfg.Level, err)
+			return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+				Field:       "spec.stormControl[*].level",
+				Description: fmt.Sprintf("storm control level %q is not a valid floating-point percentage", cfg.Level),
+			})
 		}
 		ctrl.Floatlevel = strconv.FormatFloat(f, 'f', 6, 64)
 		switch cfg.Traffic {
@@ -2807,7 +2840,10 @@ func (p *Provider) EnsureBorderGatewaySettings(ctx context.Context, req *BorderG
 		case nxv1alpha1.TrafficTypeUnicast:
 			ctrl.Name = StormControlTypeUnicast
 		default:
-			return fmt.Errorf("border gateway: unsupported storm control traffic type %q", cfg.Traffic)
+			return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
+				Field:       "spec.stormControl[*].traffic",
+				Description: fmt.Sprintf("storm control traffic type %q is not supported on this platform", cfg.Traffic),
+			})
 		}
 		sc.EvpnStormControlList.Set(ctrl)
 	}


### PR DESCRIPTION
Introduces internal/apistatus, a package that gives provider implementations a structured way to return non-retryable errors to controllers without coupling directly to reconcile.TerminalError.

The package defines a Code enum (CodeInvalidArgument, CodeUnsupportedField, CodeFailedPrecondition) with String() and Valid() methods, a StatusError struct carrying a Code, an optional Message, and optional FieldViolations, and constructor functions for each code. StatusError implements Is() so that errors.Is can be used for type detection across error chains. WrapTerminalError wraps any error containing a *StatusError as a reconcile.TerminalError, leaving all other errors unchanged.

conditions.FromError is extended to detect *StatusError before the existing gRPC status path, mapping the code to the condition Reason and the formatted message to the condition Message field.

The stub internal/controllerutil package, which this supersedes, has been removed as no code imported it.