### PR TITLE
(fix): API validation error for 802.1ad interfaces

### DIFF
--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -197,10 +197,11 @@ const (
 type Encapsulation struct {
 	// +required
 	Type EncapType `json:"type"`
+
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4094
-	Tag int32 `json:"tag"`
+	Tag int32 `json:"tag,omitempty"`
 
 	// InnerTag specifies the inner VLAN ID for QinQ encapsulation.
 	// Only applicable when Type is set to "QinQ".


### PR DESCRIPTION
Omit empty vlan tag, as this violates our own validation rule for 802.ad interfaces (only innerTag and outerTag allowed).