### PR TITLE
feat(iosxr): add support for 802.1Q and 802.1ad subinterfaces

### DIFF
--- a/internal/provider/cisco/iosxr/intf.go
+++ b/internal/provider/cisco/iosxr/intf.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	bundleEtherRE       = regexp.MustCompile(`^Bundle-Ether(\d+)(?:\.\d+)?$`)
+	bundleEtherRE       = regexp.MustCompile(`^(Bundle-Ether|bundle-ether)(\d+)(\.\d+)?$`)
 	physicalInterfaceRE = regexp.MustCompile(`^(TenGigE|TwentyFiveGigE|FortyGigE|HundredGigE|GigabitEthernet)(\d){1}(\/\d){2}(\/\d+){1}(.\d{1,5})?$`)
 	loopbackInterfaceRE = regexp.MustCompile(`^(Loopback|Lo)\d+$`)
 	mgmtEthInterfaceRe  = regexp.MustCompile(`^MgmtEth\d+\/RP\d+\/CPU\d+\/\d+$`)
@@ -269,58 +269,48 @@ func CheckInterfaceNameTypePhysical(name string) error {
 	return nil
 }
 
-func ExtractVlanTagFromName(name string) (vlanID int32, err error) {
-	res := strings.Split(name, ".")
-	switch len(res) {
-	case 1:
-		return 0, nil
-	case 2:
-		vlan, err := strconv.ParseInt(res[1], 10, 32)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse VLAN ID from interface name %q: %w", name, err)
-		}
-		return int32(vlan), nil
+// ExtractBundleAndSubinterfaceID extracts the subinterface ID and bundle ID from an interface name.
+// If the interface is a physical interface, the bundle ID will be 0 and the subinterface ID will be extracted if present.
+// TwentyFiveGigE0/0/0/3.4095 -> (0, 4095), Bundle-Ether200 -> (200, 0), Bundle-Ether200.4095 -> (200, 4095)
+func ExtractBundleAndSubinterfaceID(name string) (int32, int32, error) {
+	beMatchGroups := bundleEtherRE.FindStringSubmatch(name)
+	physMatchGroups := physicalInterfaceRE.FindStringSubmatch(name)
+
+	var bID string
+	var sID string
+
+	var bundleID int32
+	var subIfaceID int32
+
+	switch {
+	case len(beMatchGroups) == 3:
+		bID = beMatchGroups[2]
+	case len(beMatchGroups) == 4:
+		bID = beMatchGroups[2]
+		sID = strings.ReplaceAll(beMatchGroups[3], ".", "")
+	case len(physMatchGroups) == 6:
+		sID = strings.ReplaceAll(physMatchGroups[5], ".", "")
 	default:
-		return 0, fmt.Errorf("unexpected interface name format %q, expected <interface> or <interface>.<vlan>", name)
-	}
-}
-
-func ExtractBundleAndSubinterfaceID(name string) (bundleID, subinterfaceID int32, err error) {
-	// Extract bundle ID and optional subinterface ID from Bundle-Ether<id> or Bundle-Ether<id>.<subif_id>
-	// Examples: Bundle-Ether200 -> (200, 0), Bundle-Ether200.4095 -> (200, 4095)
-
-	// Remove the "Bundle-Ether" or "BE" prefix
-	var idPart string
-
-	if !bundleEtherRE.MatchString(name) {
-		return 0, 0, fmt.Errorf("interface name %q does not start with Bundle-Ether or bundle-ether", name)
-	}
-	idPart = strings.TrimPrefix(strings.TrimPrefix(name, "Bundle-Ether"), "bundle-ether")
-	parts := strings.Split(idPart, ".")
-
-	if len(parts) == 0 || parts[0] == "" {
-		return 0, 0, fmt.Errorf("failed to extract bundle ID from interface name %q", name)
+		return 0, 0, fmt.Errorf("interface name %q does not start with Bundle-Ether or bundle-ether or match physical interface pattern", name)
 	}
 
-	// Parse bundle ID
-	id, err := strconv.ParseInt(parts[0], 10, 32)
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to parse bundle ID from interface name %q: %w", name, err)
+	if bID != "" {
+		bundleIDInt, err := strconv.ParseInt(bID, 10, 32)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to parse bundle ID from interface name %q: %w", name, err)
+		}
+		bundleID = int32(bundleIDInt)
 	}
-	bundleID = int32(id)
 
-	// Parse subinterface ID if present
-	if len(parts) == 2 {
-		subIfaceIDInt, err := strconv.ParseInt(parts[1], 10, 32)
+	if sID != "" {
+		subIfaceIDInt, err := strconv.ParseInt(sID, 10, 32)
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to parse subinterface ID from interface name %q: %w", name, err)
 		}
-		subinterfaceID = int32(subIfaceIDInt)
-	} else if len(parts) > 2 {
-		return 0, 0, fmt.Errorf("unexpected interface name format %q, expected Bundle-Ether<id> or Bundle-Ether<id>.<subif_id>", name)
+		subIfaceID = int32(subIfaceIDInt)
 	}
 
-	return bundleID, subinterfaceID, nil
+	return bundleID, subIfaceID, nil
 }
 
 func CheckVlanRange(vlan string) error {

--- a/internal/provider/cisco/iosxr/intf_test.go
+++ b/internal/provider/cisco/iosxr/intf_test.go
@@ -83,6 +83,20 @@ func TestExtractBundleAndSubinterfaceID(t *testing.T) {
 			expectedSubIfaceID: 0,
 			wantErr:            true,
 		},
+		{
+			name:               "bundle-ether",
+			input:              "bundle-ether200",
+			expectedBundleID:   200,
+			expectedSubIfaceID: 0,
+			wantErr:            false,
+		},
+		{
+			name:               "TenGigE",
+			input:              "TenGigE0/0/0/1.100",
+			expectedBundleID:   0,
+			expectedSubIfaceID: 100,
+			wantErr:            false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -90,11 +104,11 @@ func TestExtractBundleAndSubinterfaceID(t *testing.T) {
 			bundleID, subIfaceID, err := ExtractBundleAndSubinterfaceID(tt.input)
 			if tt.wantErr {
 				if err == nil {
-					t.Errorf("ExtractBundleAndSubinterfaceId(%s) expected error, got nil", tt.input)
+					t.Errorf("ExtractBundleAndSubinterfaceID(%s) expected error, got nil", tt.input)
 				}
 			} else {
 				if err != nil {
-					t.Errorf("ExtractBundleAndSubinterfaceId(%s) unexpected error: %v", tt.input, err)
+					t.Errorf("ExtractBundleAndSubinterfaceID(%s) unexpected error: %v", tt.input, err)
 				}
 				if bundleID != tt.expectedBundleID {
 					t.Errorf("ExtractBundleAndSubinterfaceId(%s) bundleID = %v, want %v", tt.input, bundleID, tt.expectedBundleID)

--- a/internal/provider/cisco/iosxr/provider.go
+++ b/internal/provider/cisco/iosxr/provider.go
@@ -155,37 +155,13 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		if bundleName == "" {
 			iface.Statistics.LoadInterval = uint8(30)
 
-			vlan, err := ExtractVlanTagFromName(name)
+			// TODO(sven-rosenzweig): support IPv6 addresses, IPv6 neighbor config
+
+			ipv4, err := NewIPv4(req.Interface.Spec.IPv4)
 			if err != nil {
 				return err
 			}
-
-			// Configure Subinterface
-			if vlan != 0 {
-				iface.SubInterface = NewVlanSubinterface(vlan, 0, "vlan-type-dot1q")
-				iface.ModeNoPhysical = "default"
-			}
-
-			if req.Interface.Spec.IPv4 != nil {
-				if len(req.Interface.Spec.IPv4.Addresses) > 1 {
-					message := "multiple IPv4 addresses configured for interface " + name
-					return errors.New(message)
-				}
-
-				// (fixme): support IPv6 addresses, IPv6 neighbor config
-				prefix := req.Interface.Spec.IPv4.Addresses[0]
-				ip := prefix.Addr().String()
-				netmask := net.IP(net.CIDRMask(prefix.Bits(), 32)).String()
-
-				iface.IPv4Network = IPv4Network{
-					Addresses: AddressesIPv4{
-						Primary: Primary{
-							Address: ip,
-							Netmask: netmask,
-						},
-					},
-				}
-			}
+			iface.IPv4Network = ipv4
 
 			if req.Interface.Spec.MTU != 0 {
 				mtu, err := NewMTU(name, req.Interface.Spec.MTU)
@@ -221,6 +197,7 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		if req.Interface.Spec.AdminState == v1alpha1.AdminStateDown {
 			iface.Shutdown = gnmiext.Empty(true)
 		}
+		iface.Active = "act"
 		conf = append(conf, iface)
 
 		return updateInterface(ctx, p.client, conf...)
@@ -229,7 +206,13 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 			return err
 		}
 
-		iface := NewBundleInterface(req.Interface)
+		iface := Iface{
+			Name:           name,
+			Description:    req.Interface.Spec.Description,
+			Active:         "act",
+			ModeNoPhysical: "default",
+			Mode:           gnmiext.Empty(false),
+		}
 
 		bundleID, subinterfaceID, err := ExtractBundleAndSubinterfaceID(name)
 		if err != nil {
@@ -256,60 +239,63 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 				},
 			}
 			conf = append(conf, &iface)
-		} else {
-			// (fixme): introduce new interface type subresource first. comes via different PR
-			return fmt.Errorf("subinterfaces for bundle interfaces are not supported yet: %q", name)
-
-			// Bundle subinterface configuration
-			// make sure the parent bundle-ether interface bundle-ether<id> exits
-			// parentBunndle := strings.Split(name, ".")[0]
-			// tmp := cp.Deep(req.Interface)
-			// tmp.Spec.Name = parentBunndle
-			// bundle := NewBundleInterface(tmp)
-			// conf = append(conf, &bundle)
-
-			// Unset for bundle subinterfaces
-			// iface.Mode = gnmiext.Empty(false)
-			// iface.ModeNoPhysical = "default"
-			// iface.SubInterface = VlanSubInterface{
-			// 	VlanIdentifier: VlanIdentifier{
-			// 		FirstTag: req.Interface.Spec.Switchport.AccessVlan,
-			// 		VlanType: "vlan-type-dot1q",
-			// 	},
-			// }
-
-			// Subinterface configures QAndQ vlan
-			// if req.Interface.Spec.Switchport.InnerVlan != 0 {
-			//	iface.SubInterface.VlanIdentifier.SecondTag = req.Interface.Spec.Switchport.InnerVlan
-			//	iface.SubInterface.VlanIdentifier.VlanType = "vlan-type-dot1ad"
-			// }
-			// conf = append(conf, &iface)
 		}
 		return updateInterface(ctx, p.client, conf...)
-	case v1alpha1.InterfaceTypeLoopback, v1alpha1.InterfaceTypeRoutedVLAN, v1alpha1.InterfaceTypeSubinterface:
+	case v1alpha1.InterfaceTypeSubinterface:
+
+		// Set Interface mode to virtual is required for bundle interfaces
+		iface := Iface{
+			Name:           name,
+			Description:    req.Interface.Spec.Description,
+			Active:         "act",
+			Mode:           gnmiext.Empty(false),
+			ModeNoPhysical: "default",
+		}
+
+		_, subinterfaceID, err := ExtractBundleAndSubinterfaceID(name)
+		if err != nil {
+			return err
+		}
+
+		if subinterfaceID == 0 {
+			return fmt.Errorf("no subinterface ID in interfacename specified. pattern: <interface-name>.<subinterface-id>, got %q", name)
+		}
+
+		iface.SubInterface = VlanSubInterface{
+			VlanIdentifier: VlanIdentifier{
+				FirstTag: req.Interface.Spec.Encapsulation.Tag,
+				VlanType: "vlan-type-dot1q",
+			},
+		}
+
+		// Subinterface configures QAndQ vlan
+		if req.Interface.Spec.Encapsulation.InnerTag != 0 {
+			iface.SubInterface.VlanIdentifier.FirstTag = req.Interface.Spec.Encapsulation.OuterTag
+			iface.SubInterface.VlanIdentifier.SecondTag = req.Interface.Spec.Encapsulation.InnerTag
+			iface.SubInterface.VlanIdentifier.VlanType = "vlan-type-dot1ad"
+		}
+
+		if req.Interface.Spec.MTU != 0 {
+			mtu, err := NewMTU(name, req.Interface.Spec.MTU)
+			if err != nil {
+				return err
+			}
+			iface.MTUs = mtu
+		}
+
+		ipv4, err := NewIPv4(req.Interface.Spec.IPv4)
+		if err != nil {
+			return err
+		}
+		iface.IPv4Network = ipv4
+
+		conf = append(conf, &iface)
+		return updateInterface(ctx, p.client, conf...)
+	case v1alpha1.InterfaceTypeLoopback, v1alpha1.InterfaceTypeRoutedVLAN:
 		return fmt.Errorf("interface type %q is currently not supported", req.Interface.Spec.Type)
 	default:
 		return fmt.Errorf("unexpected interface type %q", req.Interface.Spec.Type)
 	}
-}
-
-func NewBundleInterface(req *v1alpha1.Interface) Iface {
-	bundle := Iface{
-		Name:        req.Spec.Name,
-		Description: req.Spec.Description,
-		// Set Interface mode to virtual for bundle interfaces
-		Mode: gnmiext.Empty(true),
-	}
-	return bundle
-}
-
-func NewVlanSubinterface(firstTag, secondTag int32, vlanType string) VlanSubInterface {
-	subInt := VlanSubInterface{}
-
-	subInt.VlanIdentifier.FirstTag = firstTag
-	subInt.VlanIdentifier.SecondTag = secondTag
-	subInt.VlanIdentifier.VlanType = vlanType
-	return subInt
 }
 
 func NewMTU(intName string, mtu int32) (MTUs, error) {
@@ -322,6 +308,29 @@ func NewMTU(intName string, mtu int32) (MTUs, error) {
 		MTU:   mtu,
 		Owner: string(owner),
 	}}}, nil
+}
+
+func NewIPv4(ips *v1alpha1.InterfaceIPv4) (IPv4Network, error) {
+	if ips == nil || len(ips.Addresses) == 0 {
+		return IPv4Network{}, nil
+	}
+
+	if len(ips.Addresses) > 1 {
+		return IPv4Network{}, errors.New("multiple IPv4 addresses configured for interface, only one is supported")
+	}
+
+	prefix := ips.Addresses[0]
+	ip := prefix.Addr().String()
+	netmask := net.IP(net.CIDRMask(prefix.Bits(), 32)).String()
+
+	return IPv4Network{
+		Addresses: AddressesIPv4{
+			Primary: Primary{
+				Address: ip,
+				Netmask: netmask,
+			},
+		},
+	}, nil
 }
 
 func updateInterface(ctx context.Context, client gnmiext.Client, conf ...gnmiext.DataElement) error {


### PR DESCRIPTION
Add support for configuring subinterfaces on both physical and
bundle interfaces.

Refactor code by removing the unused ExtractVlan method and
renaming/refactoring ExtractBundleInterface to extract the
subinterface ID generically.

Clean up IPv4 network configuration by introducing a helper
function.