### PR TITLE
Fix YAML indentation in manager Helm template

### DIFF
--- a/charts/network-operator/templates/manager/manager.yaml
+++ b/charts/network-operator/templates/manager/manager.yaml
@@ -136,9 +136,9 @@ spec:
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
         {{- if .Values.certManager.enable }}
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-certs
-          readOnly: true
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: webhook-certs
+            readOnly: true
         {{- end }}
       securityContext:
         {{- if .Values.manager.podSecurityContext }}
@@ -155,8 +155,8 @@ spec:
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
       {{- if .Values.certManager.enable }}
-      - name: webhook-certs
-        secret:
-          secretName: webhook-server-cert
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Align cert-manager volumeMounts and volumes entries with the indentation used by extraVolumeMounts/extraVolumes to produce valid YAML.

Ref: https://github.com/kubernetes-sigs/kubebuilder/issues/5677