### PR TITLE
fix(iosxr): Fetching Hostname for Device Status

### DIFF
--- a/internal/provider/cisco/iosxr/provider.go
+++ b/internal/provider/cisco/iosxr/provider.go
@@ -80,6 +80,11 @@ func (p *Provider) ListPorts(ctx context.Context) ([]provider.DevicePort, error)
 
 func (p *Provider) GetDeviceInfo(ctx context.Context) (*provider.DeviceInfo, error) {
 	i := new(BasicDeviceInfo)
+	hostName := new(Hostname)
+
+	if err := p.client.GetConfig(ctx, hostName); err != nil {
+		return nil, err
+	}
 
 	if err := p.client.GetState(ctx, i); err != nil {
 		return nil, err
@@ -90,7 +95,7 @@ func (p *Provider) GetDeviceInfo(ctx context.Context) (*provider.DeviceInfo, err
 		Model:           i.Model,
 		SerialNumber:    i.SerialNumber,
 		FirmwareVersion: i.FirmwareVersion,
-		Hostname:        i.Hostname,
+		Hostname:        string(*hostName),
 	}, nil
 }
 

--- a/internal/provider/cisco/iosxr/system.go
+++ b/internal/provider/cisco/iosxr/system.go
@@ -7,6 +7,13 @@ import "time"
 
 const Manufacturer = "Cisco"
 
+// Hostname is the hostname of the device, e.g. "router1".
+type Hostname string
+
+func (*Hostname) XPath() string {
+	return "Cisco-IOS-XR-shellutil-cfg:host-names/host-name"
+}
+
 type BasicDeviceInfo struct {
 	// Model is the chassis model of the device, e.g. "NCS-57C3-MOD-SYS".
 	Model string `json:"model-name"`
@@ -16,9 +23,6 @@ type BasicDeviceInfo struct {
 
 	// FirmwareVersion is the firmware version of the device, e.g. "25.2.2".
 	FirmwareVersion string `json:"firmware-version"`
-
-	// Hostname is the hostname of the device, e.g. "router1".
-	Hostname string `json:"name"`
 }
 
 func (*BasicDeviceInfo) XPath() string {


### PR DESCRIPTION
The hostname is part of the Cisco-IOS-XR-shellutil-cfg yang model.