### PR TITLE
feat(iosxr): Implement VRF provider

### DIFF
--- a/internal/provider/cisco/iosxr/provider.go
+++ b/internal/provider/cisco/iosxr/provider.go
@@ -124,10 +124,6 @@ func (p *Provider) Reprovision(_ context.Context, conn *deviceutil.Connection) e
 func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInterfaceRequest) error {
 	// TODO(sven-rosenweig): Make use of the VRF information in the request to assign the interface to the correct VRF.
 	// FIXME(sven-rosenweig): Use the ExtractOwnerFromInterfaceName function in the ValidateInterfaceName function
-	if p.client == nil {
-		return errors.New("client is not connected")
-	}
-
 	name := req.Interface.Spec.Name
 
 	if err := ValidateInterfaceName(name); err != nil {
@@ -351,10 +347,6 @@ func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceR
 	physif := &Iface{}
 	physif.Name = req.Interface.Spec.Name
 
-	if p.client == nil {
-		return errors.New("client is not connected")
-	}
-
 	err := p.client.Delete(ctx, physif)
 	if err != nil {
 		return fmt.Errorf("failed to delete interface %s: %w", req.Interface.Spec.Name, err)
@@ -365,10 +357,6 @@ func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceR
 func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.InterfaceRequest) (provider.InterfaceStatus, error) {
 	state := new(PhysIfState)
 	state.Name = req.Interface.Spec.Name
-
-	if p.client == nil {
-		return provider.InterfaceStatus{}, errors.New("client is not connected")
-	}
 
 	err := p.client.GetState(ctx, state)
 	if err != nil {

--- a/internal/provider/cisco/iosxr/provider.go
+++ b/internal/provider/cisco/iosxr/provider.go
@@ -23,6 +23,7 @@ var (
 	_ provider.Provider          = &Provider{}
 	_ provider.DeviceProvider    = &Provider{}
 	_ provider.InterfaceProvider = &Provider{}
+	_ provider.VRFProvider       = &Provider{}
 )
 
 type Provider struct {
@@ -121,6 +122,8 @@ func (p *Provider) Reprovision(_ context.Context, conn *deviceutil.Connection) e
 }
 
 func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInterfaceRequest) error {
+	// TODO(sven-rosenweig): Make use of the VRF information in the request to assign the interface to the correct VRF.
+	// FIXME(sven-rosenweig): Use the ExtractOwnerFromInterfaceName function in the ValidateInterfaceName function
 	if p.client == nil {
 		return errors.New("client is not connected")
 	}
@@ -380,6 +383,43 @@ func (p *Provider) GetInterfaceStatus(ctx context.Context, req *provider.Interfa
 func (p *Provider) InterfaceNameEqual(_ context.Context, a, b string) (bool, error) {
 	// TODO: implement provider specific logic to compare interface names
 	return a == b, nil
+}
+
+func (p *Provider) EnsureVRF(ctx context.Context, req *provider.VRFRequest) error {
+	vrf := &VRF{
+		Name:        req.VRF.Spec.Name,
+		Description: req.VRF.Spec.Description,
+	}
+
+	for _, routeTarget := range req.VRF.Spec.RouteTargets {
+		// Parse the route target value to extract ASN and index
+		// TODO(sven-rosenweig): Add support for two-byte (type 0) and IPv4 (type 1) route targets
+		// For now we assume that all route targets are in the format of four-byte ASNs with index: <asn>:<index>
+		rt, err := NewFourByteRT(routeTarget.Value)
+		if err != nil {
+			return fmt.Errorf("failed to parse route target %q for VRF %q: %w", routeTarget.Value, req.VRF.Spec.Name, err)
+		}
+		for _, af := range routeTarget.AddressFamilies {
+			switch af {
+			case v1alpha1.IPv4:
+				AppendAddressFamily(&vrf.AddrFamily.IPv4.Unicast, rt, routeTarget.Action)
+			case v1alpha1.IPv6:
+				AppendAddressFamily(&vrf.AddrFamily.IPv6.Unicast, rt, routeTarget.Action)
+			default:
+				return fmt.Errorf("unsupported address family %q for VRF %q", af, req.VRF.Spec.Name)
+			}
+		}
+	}
+
+	return p.client.Update(ctx, vrf)
+}
+
+func (p *Provider) DeleteVRF(ctx context.Context, req *provider.VRFRequest) error {
+	vrf := &VRF{
+		Name: req.VRF.Spec.Name,
+	}
+
+	return p.client.Delete(ctx, vrf)
 }
 
 func init() {

--- a/internal/provider/cisco/iosxr/testdata/vrf.json
+++ b/internal/provider/cisco/iosxr/testdata/vrf.json
@@ -1,0 +1,68 @@
+{
+  "vrf": {
+    "vrf-name": "vrf-name",
+    "description": "vrf-description",
+    "address-family": {
+      "ipv4": {
+        "unicast": {
+          "Cisco-IOS-XR-um-router-bgp-cfg:export": {
+            "route-target": {
+              "four-byte-as-route-targets": {
+                "four-byte-as-route-target": [
+                  {
+                    "four-byte-as-number": 4268359684,
+                    "asn4-index": 1101,
+                    "stitching": "disable"
+                  }
+                ]
+              }
+            }
+          },
+          "Cisco-IOS-XR-um-router-bgp-cfg:import": {
+            "route-target": {
+              "four-byte-as-route-targets": {
+                "four-byte-as-route-target": [
+                  {
+                    "four-byte-as-number": 4268359684,
+                    "asn4-index": 1101,
+                    "stitching": "disable"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "ipv6": {
+        "unicast": {
+          "Cisco-IOS-XR-um-router-bgp-cfg:export": {
+            "route-target": {
+              "four-byte-as-route-targets": {
+                "four-byte-as-route-target": [
+                  {
+                    "four-byte-as-number": 4268359684,
+                    "asn4-index": 1101,
+                    "stitching": "disable"
+                  }
+                ]
+              }
+            }
+          },
+          "Cisco-IOS-XR-um-router-bgp-cfg:import": {
+            "route-target": {
+              "four-byte-as-route-targets": {
+                "four-byte-as-route-target": [
+                  {
+                    "four-byte-as-number": 4268359684,
+                    "asn4-index": 1101,
+                    "stitching": "disable"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/provider/cisco/iosxr/testdata/vrf.json.txt
+++ b/internal/provider/cisco/iosxr/testdata/vrf.json.txt
@@ -1,0 +1,8 @@
+vrf vrf-name
+  description vrf-description
+  address-family ipv4 unicast
+    import route-target 4268359684:2012 
+    export route-target 4268359684:2012 
+  address-family ipv6 unicast
+    import route-target 4268359684:2012
+    export route-target 4268359684:2012

--- a/internal/provider/cisco/iosxr/vrf.go
+++ b/internal/provider/cisco/iosxr/vrf.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package iosxr
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/transport/gnmiext"
+)
+
+type StitchingType string
+
+const (
+	Enable  StitchingType = "enable"
+	Disable StitchingType = "disable"
+)
+
+var _ gnmiext.DataElement = (*VRF)(nil)
+
+type VRF struct {
+	Name        string        `json:"vrf-name"`
+	Description string        `json:"description"`
+	AddrFamily  AddressFamily `json:"address-family"`
+}
+
+type AddressFamily struct {
+	IPv4 UnicastFamily `json:"ipv4,omitzero"`
+	IPv6 UnicastFamily `json:"ipv6,omitzero"`
+}
+
+type UnicastFamily struct {
+	Unicast Unicast `json:"unicast"`
+}
+
+type Unicast struct {
+	Export RouteTarget `json:"Cisco-IOS-XR-um-router-bgp-cfg:export,omitzero"`
+	Import RouteTarget `json:"Cisco-IOS-XR-um-router-bgp-cfg:import,omitzero"`
+}
+
+type RouteTarget struct {
+	FourByteAS FourByteASRouteTargetList `json:"route-target"`
+}
+
+type FourByteASRouteTargetList struct {
+	Targets FourByteASRouteTargetWrapper `json:"four-byte-as-route-targets"`
+}
+
+type FourByteASRouteTargetWrapper struct {
+	Targets []FourByteASRouteTarget `json:"four-byte-as-route-target"`
+}
+
+type FourByteASRouteTarget struct {
+	ASNumber  uint32        `json:"four-byte-as-number"`
+	Index     uint32        `json:"asn4-index"`
+	Stitching StitchingType `json:"stitching"`
+}
+
+func (v *VRF) XPath() string {
+	return fmt.Sprintf("Cisco-IOS-XR-um-vrf-cfg:vrfs/vrf[vrf-name=%s]", v.Name)
+}
+
+func NewFourByteRT(value string) (FourByteASRouteTarget, error) {
+	asn, index, found := strings.Cut(value, ":")
+	if !found {
+		return FourByteASRouteTarget{}, fmt.Errorf("invalid route target format: %q", value)
+	}
+
+	asnInt, err := strconv.ParseUint(asn, 10, 32)
+	if err != nil {
+		return FourByteASRouteTarget{}, fmt.Errorf("invalid ASN in route target %q: %w", value, err)
+	}
+
+	indexInt, err := strconv.ParseUint(index, 10, 32)
+	if err != nil {
+		return FourByteASRouteTarget{}, fmt.Errorf("invalid index in route target %q: %w", value, err)
+	}
+
+	return FourByteASRouteTarget{
+		ASNumber:  uint32(asnInt),
+		Index:     uint32(indexInt),
+		Stitching: Disable,
+	}, nil
+}
+
+func AppendAddressFamily(unicast *Unicast, rt FourByteASRouteTarget, action v1alpha1.RouteTargetAction) {
+	switch action {
+	case v1alpha1.RouteTargetActionImport:
+		AppendRouteTarget(&unicast.Import.FourByteAS.Targets, rt)
+	case v1alpha1.RouteTargetActionExport:
+		AppendRouteTarget(&unicast.Export.FourByteAS.Targets, rt)
+	case v1alpha1.RouteTargetActionBoth:
+		AppendRouteTarget(&unicast.Import.FourByteAS.Targets, rt)
+		AppendRouteTarget(&unicast.Export.FourByteAS.Targets, rt)
+	default:
+	}
+}
+
+func AppendRouteTarget(wrapper *FourByteASRouteTargetWrapper, rt FourByteASRouteTarget) {
+	wrapper.Targets = append(wrapper.Targets, rt)
+}

--- a/internal/provider/cisco/iosxr/vrf_test.go
+++ b/internal/provider/cisco/iosxr/vrf_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package iosxr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFourByteRT(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedASN   uint32
+		expectedIndex uint32
+		expectedErr   string
+	}{
+		{
+			name:          "valid route target",
+			input:         "4268359684:1101",
+			expectedASN:   4268359684,
+			expectedIndex: 1101,
+		},
+		{
+			name:        "invalid route target without colon",
+			input:       "4268359684",
+			expectedErr: "invalid route target format",
+		},
+		{
+			name:        "invalid route target with invalid asn",
+			input:       "invalid:1101",
+			expectedErr: "invalid ASN",
+		},
+		{
+			name:        "invalid route target with invalid index",
+			input:       "4268359684:invalid",
+			expectedErr: "invalid index",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, err := NewFourByteRT(tt.input)
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedASN, rt.ASNumber)
+			assert.Equal(t, tt.expectedIndex, rt.Index)
+		})
+	}
+}
+
+func init() {
+	rt := RouteTarget{
+		FourByteAS: FourByteASRouteTargetList{
+			Targets: FourByteASRouteTargetWrapper{
+				Targets: []FourByteASRouteTarget{
+					{ASNumber: 4268359684, Index: 1101, Stitching: Disable},
+				},
+			},
+		},
+	}
+
+	Register("vrf", &VRF{
+		Name:        "vrf-name",
+		Description: "vrf-description",
+		AddrFamily: AddressFamily{
+			IPv4: UnicastFamily{
+				Unicast: Unicast{Import: rt, Export: rt},
+			},
+			IPv6: UnicastFamily{
+				Unicast: Unicast{Import: rt, Export: rt},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds basic VRF configuration support for IOS-XR routers.
    
Follow-ups:
* Set interfaces as member of the VRF
* Add support for 2-byte and IPv4 route targets
    