### PR TITLE
Pause child resources while Device phase is not Running

### DIFF
--- a/internal/controller/cisco/nx/suite_test.go
+++ b/internal/controller/cisco/nx/suite_test.go
@@ -27,6 +27,7 @@ import (
 
 	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	core "github.com/ironcore-dev/network-operator/internal/controller/core"
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
 	"github.com/ironcore-dev/network-operator/internal/provider"
 	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos"
@@ -142,6 +143,19 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
+	// Register a DeviceReconciler so that Devices automatically transition to
+	// Running phase (when no provisioning is configured). Without this, child
+	// resources remain paused indefinitely waiting for their parent Device to
+	// reach Running phase.
+	err = (&core.DeviceReconciler{
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		Recorder:          recorder,
+		Provider:          prov,
+		HeartbeatInterval: 10 * time.Minute,
+	}).SetupWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)
@@ -193,7 +207,10 @@ type MockProvider struct {
 	VPCDomain     *nxv1alpha1.VPCDomain
 }
 
-var _ Provider = (*MockProvider)(nil)
+var (
+	_ Provider                = (*MockProvider)(nil)
+	_ provider.DeviceProvider = (*MockProvider)(nil)
+)
 
 func NewMockProvider() *MockProvider {
 	return &MockProvider{}
@@ -201,6 +218,21 @@ func NewMockProvider() *MockProvider {
 
 func (p *MockProvider) Connect(context.Context, *deviceutil.Connection) error    { return nil }
 func (p *MockProvider) Disconnect(context.Context, *deviceutil.Connection) error { return nil }
+
+func (p *MockProvider) ListPorts(context.Context) ([]provider.DevicePort, error) { return nil, nil }
+func (p *MockProvider) GetDeviceInfo(context.Context) (*provider.DeviceInfo, error) {
+	return &provider.DeviceInfo{}, nil
+}
+
+func (p *MockProvider) GetLastRebootTime(context.Context) (time.Time, error) { return time.Time{}, nil }
+func (p *MockProvider) Reboot(context.Context, *deviceutil.Connection) error { return nil }
+func (p *MockProvider) FactoryReset(context.Context, *deviceutil.Connection) error {
+	return nil
+}
+
+func (p *MockProvider) Reprovision(context.Context, *deviceutil.Connection) error {
+	return nil
+}
 
 func (p *MockProvider) EnsureSystemSettings(ctx context.Context, s *nxv1alpha1.System) error {
 	p.Lock()

--- a/internal/paused/paused.go
+++ b/internal/paused/paused.go
@@ -95,7 +95,7 @@ func computeCondition(device *v1alpha1.Device, obj Object) metav1.Condition {
 		// own phase or reachability — it needs to keep reconciling to
 		// reach Running and to set the Reachable condition.
 		if device != obj {
-			if device.Status.Phase != "" && device.Status.Phase != v1alpha1.DevicePhaseRunning {
+			if device.Status.Phase != v1alpha1.DevicePhaseRunning {
 				condition.Status = metav1.ConditionTrue
 				condition.Reason = v1alpha1.PausedReason
 				condition.Message = "Device is not in phase Running"
@@ -128,14 +128,14 @@ func DevicePausedChanged(oldObj, newObj client.Object) bool {
 	if oldDevice.Spec.Paused != newDevice.Spec.Paused {
 		return true
 	}
-	oldPhasePaused := oldDevice.Status.Phase != "" && oldDevice.Status.Phase != v1alpha1.DevicePhaseRunning
-	newPhasePaused := newDevice.Status.Phase != "" && newDevice.Status.Phase != v1alpha1.DevicePhaseRunning
-	if oldPhasePaused != newPhasePaused {
+	oldPhaseRunning := oldDevice.Status.Phase == v1alpha1.DevicePhaseRunning
+	newPhaseRunning := newDevice.Status.Phase == v1alpha1.DevicePhaseRunning
+	if oldPhaseRunning != newPhaseRunning {
 		return true
 	}
 	oldReachable := conditions.Get(oldDevice, v1alpha1.ReachableCondition)
 	newReachable := conditions.Get(newDevice, v1alpha1.ReachableCondition)
-	oldUnreachable := oldReachable != nil && oldReachable.Status != metav1.ConditionTrue
-	newUnreachable := newReachable != nil && newReachable.Status != metav1.ConditionTrue
-	return oldUnreachable != newUnreachable
+	oldIsReachable := oldReachable == nil || oldReachable.Status == metav1.ConditionTrue
+	newIsReachable := newReachable == nil || newReachable.Status == metav1.ConditionTrue
+	return oldIsReachable != newIsReachable
 }


### PR DESCRIPTION
Previously, computeCondition only paused child resources when the Device phase was a non-empty value other than Running. A freshly created Device starts with an empty phase before the DeviceReconciler sets it to Pending/Running. During this window, children were not paused and could attempt reconciliation against a device that is not yet ready.

Remove the empty-phase exclusion in computeCondition so that any phase other than Running (including empty) pauses child resources.

Align DevicePausedChanged with this semantic: previously it also excluded the empty phase from its change detection, meaning the transition from "" to "Running" was invisible to the watch predicate and children were never re-triggered to unpause. Rewrite the predicate using positive-form comparisons (==) for clarity.

Add a DeviceReconciler to the cisco/nx controller test suite so that test Devices automatically transition to Running when no provisioning is configured, matching production behavior.