### PR TITLE
Separate DeviceProvider into focused interfaces

### DIFF
--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -88,13 +88,6 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		return ctrl.Result{}, err
 	}
 
-	prov, ok := r.Provider().(provider.DeviceProvider)
-	if !ok {
-		err := errors.New("provider does not implement DeviceProvider interface")
-		log.Error(err, "failed to reconcile resource")
-		return ctrl.Result{}, err
-	}
-
 	if isPaused, requeue, err := paused.EnsureCondition(ctx, r.Client, obj, obj); isPaused || requeue || err != nil {
 		return ctrl.Result{Requeue: requeue}, err
 	}
@@ -191,9 +184,15 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		return ctrl.Result{}, nil
 
 	case v1alpha1.DevicePhaseRunning:
-		if err := r.reconcile(ctx, obj, prov, conn); err != nil {
-			log.Error(err, "Failed to reconcile resource")
-			return ctrl.Result{}, err
+		if prov, ok := r.Provider().(provider.DeviceProvider); ok {
+			if err := r.reconcile(ctx, obj, prov, conn); err != nil {
+				log.Error(err, "Failed to reconcile resource")
+				return ctrl.Result{}, err
+			}
+		} else {
+			if err := r.reconcileMinimal(ctx, obj, conn); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 
 	case v1alpha1.DevicePhaseFailed:
@@ -209,7 +208,7 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		obj.Status.Phase = v1alpha1.DevicePhaseRunning
 	}
 
-	if err := r.reconcileMaintenance(ctx, obj, prov, conn); err != nil {
+	if err := r.reconcileMaintenance(ctx, obj, conn); err != nil {
 		return ctrl.Result{}, reconcile.TerminalError(err)
 	}
 
@@ -364,7 +363,46 @@ func (r *DeviceReconciler) reconcile(ctx context.Context, device *v1alpha1.Devic
 	return nil
 }
 
-func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alpha1.Device, prov provider.DeviceProvider, conn *deviceutil.Connection) error {
+func (r *DeviceReconciler) reconcileMinimal(ctx context.Context, device *v1alpha1.Device, conn *deviceutil.Connection) (reterr error) {
+	prov := r.Provider()
+	if err := prov.Connect(ctx, conn); err != nil {
+		conditions.Set(device, metav1.Condition{
+			Type:    v1alpha1.ReachableCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.UnreachableReason,
+			Message: fmt.Sprintf("Failed to connect to device: %v", err),
+		})
+		conditions.Set(device, metav1.Condition{
+			Type:    v1alpha1.ReadyCondition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  v1alpha1.UnreachableReason,
+			Message: "Device is not reachable",
+		})
+		return nil
+	}
+	defer func() {
+		if err := prov.Disconnect(ctx, conn); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+	}()
+
+	conditions.Set(device, metav1.Condition{
+		Type:    v1alpha1.ReachableCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.ReachableReason,
+		Message: "Device is reachable",
+	})
+	conditions.Set(device, metav1.Condition{
+		Type:    v1alpha1.ReadyCondition,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.ReadyReason,
+		Message: "Device is healthy",
+	})
+
+	return nil
+}
+
+func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alpha1.Device, conn *deviceutil.Connection) error {
 	action, ok := obj.Annotations[v1alpha1.DeviceMaintenanceAnnotation]
 	if !ok {
 		return nil
@@ -373,6 +411,11 @@ func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alph
 
 	switch action {
 	case v1alpha1.DeviceMaintenanceReboot:
+		prov, ok := r.Provider().(provider.MaintenanceProvider)
+		if !ok {
+			r.Recorder.Eventf(obj, nil, "Warning", "MaintenanceUnsupported", "Maintenance", "Provider does not support maintenance operation: %s", action)
+			return nil
+		}
 		// Reboot triggers a device restart. The device remains in its current phase
 		// and will resume normal operation after the reboot completes.
 		r.Recorder.Eventf(obj, nil, "Normal", "RebootRequested", "Maintenance", "Device reboot has been requested")
@@ -388,6 +431,11 @@ func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alph
 		}
 
 	case v1alpha1.DeviceMaintenanceFactoryReset:
+		prov, ok := r.Provider().(provider.MaintenanceProvider)
+		if !ok {
+			r.Recorder.Eventf(obj, nil, "Warning", "MaintenanceUnsupported", "Maintenance", "Provider does not support maintenance operation: %s", action)
+			return nil
+		}
 		// FactoryReset erases all device configuration and returns it to its original state.
 		// After completion, the device phase is reset to Pending to restart the lifecycle.
 		r.Recorder.Eventf(obj, nil, "Normal", "FactoryResetRequested", "Maintenance", "Device factory reset has been requested")
@@ -404,6 +452,11 @@ func (r *DeviceReconciler) reconcileMaintenance(ctx context.Context, obj *v1alph
 		obj.Status.Phase = v1alpha1.DevicePhasePending
 
 	case v1alpha1.DeviceMaintenanceReprovision:
+		prov, ok := r.Provider().(provider.ProvisioningProvider)
+		if !ok {
+			r.Recorder.Eventf(obj, nil, "Warning", "MaintenanceUnsupported", "Maintenance", "Provider does not support provisioning operation: %s", action)
+			return nil
+		}
 		// Reprovision prepares the device for re-provisioning without a full factory reset.
 		// The provider initiates the provisioning process, then the phase is reset to Pending.
 		r.Recorder.Eventf(obj, nil, "Normal", "ReprovisionRequested", "Maintenance", "Device reprovisioning has been requested")

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -384,6 +384,7 @@ func detectTestBinaryDir() string {
 var (
 	_ provider.Provider                 = (*Provider)(nil)
 	_ provider.DeviceProvider           = (*Provider)(nil)
+	_ provider.MaintenanceProvider      = (*Provider)(nil)
 	_ provider.ProvisioningProvider     = (*Provider)(nil)
 	_ provider.InterfaceProvider        = (*Provider)(nil)
 	_ provider.BannerProvider           = (*Provider)(nil)

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -36,6 +36,7 @@ import (
 var (
 	_ provider.Provider                 = (*Provider)(nil)
 	_ provider.DeviceProvider           = (*Provider)(nil)
+	_ provider.MaintenanceProvider      = (*Provider)(nil)
 	_ provider.ProvisioningProvider     = (*Provider)(nil)
 	_ provider.ACLProvider              = (*Provider)(nil)
 	_ provider.BannerProvider           = (*Provider)(nil)
@@ -136,7 +137,7 @@ func (p *Provider) Reboot(ctx context.Context, conn *deviceutil.Connection) erro
 }
 
 func (p *Provider) FactoryReset(ctx context.Context, conn *deviceutil.Connection) error {
-	return ResetToFactoryDefaults(ctx, p.conn)
+	return FactoryReset(ctx, p.conn)
 }
 
 func (p *Provider) Reprovision(ctx context.Context, conn *deviceutil.Connection) (reterr error) {

--- a/internal/provider/cisco/nxos/system.go
+++ b/internal/provider/cisco/nxos/system.go
@@ -12,8 +12,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/openconfig/gnoi/factory_reset"
-	"github.com/openconfig/gnoi/system"
+	factoryresetpb "github.com/openconfig/gnoi/factory_reset"
+	systempb "github.com/openconfig/gnoi/system"
 
 	"github.com/ironcore-dev/network-operator/internal/transport/gnmiext"
 )
@@ -109,32 +109,30 @@ func (t *UnixTime) UnmarshalJSON(b []byte) error {
 }
 
 func Reboot(ctx context.Context, conn *grpc.ClientConn) error {
-	request := system.RebootRequest{
-		Method: system.RebootMethod_COLD,
-		// Message is not supported on NXOS
-		// Delay is not supported on NXOS
-		Force: true, // only Force true is supported
+	req := &systempb.RebootRequest{
+		Method:  systempb.RebootMethod_COLD,
+		Delay:   0,  // Unsupported on NX-OS, must be 0
+		Message: "", // Unsupported on NX-OS, must be empty
+		Force:   true,
 	}
-	c := system.NewSystemClient(conn)
-	_, err := c.Reboot(ctx, &request, grpc.WaitForReady(true))
+	c := systempb.NewSystemClient(conn)
+	_, err := c.Reboot(ctx, req, grpc.WaitForReady(true))
 	return err
 }
 
-func ResetToFactoryDefaults(ctx context.Context, conn *grpc.ClientConn) error {
-	request := factory_reset.StartRequest{
-		// True not supported on NXOS, NXOS makes sure running OS is preserved
-		FactoryOs:   false,
+func FactoryReset(ctx context.Context, conn *grpc.ClientConn) error {
+	req := &factoryresetpb.StartRequest{
+		FactoryOs:   false, // NX-OS does not support factory OS reset, it always ensures the running OS is preserved
 		ZeroFill:    true,
 		RetainCerts: false,
 	}
-	c := factory_reset.NewFactoryResetClient(conn)
-	response, err := c.Start(ctx, &request, grpc.WaitForReady(true))
+	c := factoryresetpb.NewFactoryResetClient(conn)
+	res, err := c.Start(ctx, req, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}
-	resetError := response.GetResetError()
-	if resetError != nil {
-		return fmt.Errorf("factory reset failed: %s", resetError.String())
+	if resetErr := res.GetResetError(); resetErr != nil {
+		return fmt.Errorf("factory reset failed: %s", resetErr.String())
 	}
 	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,18 +37,25 @@ type DeviceProvider interface {
 	GetDeviceInfo(context.Context) (*DeviceInfo, error)
 	// GetLastRebootTime retrieves the timestamp of the last device reboot.
 	GetLastRebootTime(context.Context) (time.Time, error)
+}
+
+// MaintenanceProvider is the interface for disruptive device lifecycle operations.
+type MaintenanceProvider interface {
+	Provider
+
 	// Reboot initiates a reboot of the device.
 	Reboot(context.Context, *deviceutil.Connection) error
 	// FactoryReset performs a factory reset of the device.
 	FactoryReset(context.Context, *deviceutil.Connection) error
-	// Reprovision prepares the device for reprovisioning by resetting it and reenabling provisioning mechanisms.
-	Reprovision(context.Context, *deviceutil.Connection) error
 }
 
 // ProvisioningProvider is the interface for the realization of the provisioning-related operations over different providers.
 type ProvisioningProvider interface {
-	// HashedPassword takes a plaintext password and returns the hashed password along with the hash type. This is necessary to securely provision user accounts on devices using a potentially insecure channel.
-	HashProvisioningPassword(password string) (string, string, error)
+	// Reprovision prepares the device for reprovisioning by resetting it and reenabling provisioning mechanisms.
+	Reprovision(context.Context, *deviceutil.Connection) error
+	// HashProvisioningPassword takes a plaintext password and returns the hashed password along with the hash type.
+	// This is necessary to securely provision user accounts on devices using a potentially insecure channel.
+	HashProvisioningPassword(password string) (hash string, algorithm string, err error)
 	// VerifyProvisioned checks if the provisioning process has been completed successfully on the device.
 	VerifyProvisioned(context.Context, *deviceutil.Connection, *v1alpha1.Device) bool
 }

--- a/internal/provisioning/http_test.go
+++ b/internal/provisioning/http_test.go
@@ -87,6 +87,10 @@ func (m *MockProvider) VerifyProvisioned(ctx context.Context, conn *deviceutil.C
 	return true
 }
 
+func (m *MockProvider) Reprovision(ctx context.Context, conn *deviceutil.Connection) error {
+	return nil
+}
+
 func TestGetClientIP(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -28,11 +28,11 @@ var (
 
 // image is the name of the image which will be build and loaded
 // with the code source changes to be tested.
-const image = "ironcore.dev/network-operator:test"
+const image = "ghcr.io/ironcore-dev/network-operator:latest"
 
 // serverImage is the name of the image which will be built and loaded
 // with the gNMI test server.
-const serverImage = "ironcore.dev/gnmi-test-server:latest"
+const serverImage = "ghcr.io/ironcore-dev/gnmi-test-server:latest"
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary environment to validate project changes with the purposed to be used in CI jobs.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Manager", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
 		By("deploying the controller-manager")
-		cmd = exec.CommandContext(ctx, "make", "deploy", "IMG="+image)
+		cmd = exec.CommandContext(ctx, "make", "deploy")
 		_, err = Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 	})


### PR DESCRIPTION
Split the monolithic DeviceProvider interface into three distinct interfaces based on their concerns:

- DeviceProvider: read-only device metadata (GetDeviceInfo, ListPorts, GetLastRebootTime)
- MaintenanceProvider: disruptive lifecycle operations (Reboot, FactoryReset)
- ProvisioningProvider: ZTP/POAP lifecycle (added Reprovision alongside existing HashProvisioningPassword and VerifyProvisioned)

The DeviceController no longer hard-gates on DeviceProvider. Providers that don't implement it (e.g. openconfig) now go through a minimal reconciliation path that tracks reachability without fetching hardware metadata. Maintenance actions probe for the correct interface per operation and emit a warning event if unsupported.

Fixes #278