### PR TITLE
fix(iosxr): Conflicting Key Count

### DIFF
--- a/internal/provider/cisco/iosxr/intf.go
+++ b/internal/provider/cisco/iosxr/intf.go
@@ -63,7 +63,7 @@ func (*Ifaces) XPath() string {
 // Iface represents physical and bundle interfaces as part of the same struct as they share a lot of common configuration
 // and only differ in a few attributes like the interface name and the presence of bundle configuration or not.
 type Iface struct {
-	Name         string        `json:"-"`
+	Name         string        `json:"interface-name"`
 	Description  string        `json:"description,omitzero"`
 	Statistics   Statistics    `json:"Cisco-IOS-XR-infra-statsd-cfg:statistics,omitzero"`
 	MTUs         MTUs          `json:"mtus,omitzero"`

--- a/internal/provider/cisco/iosxr/testdata/intf.json
+++ b/internal/provider/cisco/iosxr/testdata/intf.json
@@ -1,5 +1,6 @@
 {
   "interface-configuration": {
+    "interface-name": "TwentyFiveGigE0/0/0/14",
     "description": "random interface test",
     "Cisco-IOS-XR-infra-statsd-cfg:statistics": {
       "load-interval": 30


### PR DESCRIPTION
Fix conflicting key count error,configuring IOS-XR interfaces using the yang module Cisco-IOS-XR-ifmgr-cfg.

Looking at the yang module it has two keys: "active interface-name".