### PR TITLE
Restrict size-label workflow to trusted actors

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   size-label:
     name: Label PR with size
+    if: >-
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
The pull_request_target trigger runs with base repo privileges, making it exploitable by malicious fork PRs. Add an actor restriction so the job only runs for repository owners, members, and collaborators.