### PR TITLE
Add kubebuilder markers for ApplyConfiguration generation

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -16,6 +16,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: Interface
@@ -27,6 +28,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: Device
@@ -35,6 +37,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: Banner
@@ -43,6 +46,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: User
@@ -51,6 +55,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: DNS
@@ -59,6 +64,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: NTP
@@ -67,6 +73,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: AccessControlList
@@ -75,6 +82,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: Certificate
@@ -83,6 +91,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: SNMP
@@ -91,6 +100,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: Syslog
@@ -99,6 +109,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: ManagementAccess
@@ -107,6 +118,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: ISIS
@@ -115,6 +127,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: VRF
@@ -126,6 +139,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: metal.ironcore.dev
   group: networking
@@ -135,6 +149,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: BGP
@@ -146,6 +161,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: BGPPeer
@@ -157,6 +173,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: OSPF
@@ -165,6 +182,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
@@ -174,6 +192,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
   kind: ManagementAccessConfig
@@ -182,6 +201,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: VLAN
@@ -190,6 +210,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: EVPNInstance
@@ -198,6 +219,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: PrefixSet
@@ -209,6 +231,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: RoutingPolicy
@@ -220,6 +243,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
@@ -229,6 +253,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
@@ -238,6 +263,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: NetworkVirtualizationEdge
@@ -249,6 +275,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
   kind: NetworkVirtualizationEdgeConfig
@@ -260,6 +287,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
   kind: InterfaceConfig
@@ -268,6 +296,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: LLDP
@@ -276,6 +305,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   domain: cisco.networking.metal.ironcore.dev
   group: nx
   kind: BGPConfig
@@ -284,6 +314,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+    ssa: true
   controller: true
   domain: networking.metal.ironcore.dev
   kind: DHCPRelay

--- a/api/cisco/nx/v1alpha1/bgpconfig_types.go
+++ b/api/cisco/nx/v1alpha1/bgpconfig_types.go
@@ -51,6 +51,7 @@ type BGPConfigUnicastAddressFamily struct {
 	ExportGatewayIP *bool `json:"exportGatewayIP,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=bgpconfigs
 // +kubebuilder:resource:singular=bgpconfig

--- a/api/cisco/nx/v1alpha1/bordergateway_types.go
+++ b/api/cisco/nx/v1alpha1/bordergateway_types.go
@@ -156,6 +156,7 @@ type BorderGatewayStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=bordergateways

--- a/api/cisco/nx/v1alpha1/doc.go
+++ b/api/cisco/nx/v1alpha1/doc.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package v1alpha1 contains API Schema definitions for the nx.cisco.networking.metal.ironcore.dev v1alpha1 API group.
+// +kubebuilder:ac:generate=true
+// +kubebuilder:ac:output:package="applyconfiguration"
 // +kubebuilder:validation:Required
 // +kubebuilder:object:generate=true
 // +groupName=nx.cisco.networking.metal.ironcore.dev

--- a/api/cisco/nx/v1alpha1/interfaceconfig_types.go
+++ b/api/cisco/nx/v1alpha1/interfaceconfig_types.go
@@ -79,6 +79,7 @@ const (
 	SpanningTreePortTypeNetwork SpanningTreePortType = "Network"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=interfaceconfigs
 // +kubebuilder:resource:singular=interfaceconfig

--- a/api/cisco/nx/v1alpha1/lldpconfig_types.go
+++ b/api/cisco/nx/v1alpha1/lldpconfig_types.go
@@ -28,6 +28,7 @@ type LLDPConfigSpec struct {
 	HoldTime int16 `json:"holdTime,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=lldpconfigs
 // +kubebuilder:resource:singular=lldpconfig

--- a/api/cisco/nx/v1alpha1/managementaccessconfig_types.go
+++ b/api/cisco/nx/v1alpha1/managementaccessconfig_types.go
@@ -44,6 +44,7 @@ type SSH struct {
 	AccessControlListName string `json:"accessControlListName,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=managementaccessconfigs
 // +kubebuilder:resource:singular=managementaccessconfig

--- a/api/cisco/nx/v1alpha1/nveconfig_types.go
+++ b/api/cisco/nx/v1alpha1/nveconfig_types.go
@@ -53,6 +53,7 @@ type VLANListItem struct {
 	RangeMax int16 `json:"rangeMax,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=networkvirtualizationedgeconfigs
 // +kubebuilder:resource:singular=networkvirtualizationedgeconfig

--- a/api/cisco/nx/v1alpha1/system_types.go
+++ b/api/cisco/nx/v1alpha1/system_types.go
@@ -53,6 +53,7 @@ type SystemStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=systems

--- a/api/cisco/nx/v1alpha1/vpcdomain_types.go
+++ b/api/cisco/nx/v1alpha1/vpcdomain_types.go
@@ -262,6 +262,7 @@ const (
 	StatusDown    Status = "Down"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=vpcdomains

--- a/api/cisco/xe/v1alpha1/doc.go
+++ b/api/cisco/xe/v1alpha1/doc.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package v1alpha1 contains API Schema definitions for the xe.cisco.networking.metal.ironcore.dev v1alpha1 API group.
+// +kubebuilder:ac:generate=true
+// +kubebuilder:ac:output:package="applyconfiguration"
 // +kubebuilder:validation:Required
 // +kubebuilder:object:generate=true
 // +groupName=xe.cisco.networking.metal.ironcore.dev

--- a/api/cisco/xr/v1alpha1/doc.go
+++ b/api/cisco/xr/v1alpha1/doc.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package v1alpha1 contains API Schema definitions for the xr.cisco.networking.metal.ironcore.dev v1alpha1 API group.
+// +kubebuilder:ac:generate=true
+// +kubebuilder:ac:output:package="applyconfiguration"
 // +kubebuilder:validation:Required
 // +kubebuilder:object:generate=true
 // +groupName=xr.cisco.networking.metal.ironcore.dev

--- a/api/core/v1alpha1/acl_types.go
+++ b/api/core/v1alpha1/acl_types.go
@@ -112,6 +112,7 @@ type AccessControlListStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=accesscontrollists

--- a/api/core/v1alpha1/banner_types.go
+++ b/api/core/v1alpha1/banner_types.go
@@ -59,6 +59,7 @@ type BannerStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=banners

--- a/api/core/v1alpha1/bgp_peer_types.go
+++ b/api/core/v1alpha1/bgp_peer_types.go
@@ -226,6 +226,7 @@ const (
 	BGPAddressFamilyL2vpnEvpn BGPAddressFamilyType = "L2vpnEvpn"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=bgppeers

--- a/api/core/v1alpha1/bgp_types.go
+++ b/api/core/v1alpha1/bgp_types.go
@@ -173,6 +173,7 @@ type BGPStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=bgp

--- a/api/core/v1alpha1/certificate_types.go
+++ b/api/core/v1alpha1/certificate_types.go
@@ -48,6 +48,7 @@ type CertificateStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=certificates

--- a/api/core/v1alpha1/device_types.go
+++ b/api/core/v1alpha1/device_types.go
@@ -274,6 +274,7 @@ const (
 	DevicePhaseFailed DevicePhase = "Failed"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=devices

--- a/api/core/v1alpha1/dhcprelay_types.go
+++ b/api/core/v1alpha1/dhcprelay_types.go
@@ -68,6 +68,7 @@ type DHCPRelayStatus struct {
 	ConfiguredInterfaces []string `json:"configuredInterfaces,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=dhcprelays

--- a/api/core/v1alpha1/dns_types.go
+++ b/api/core/v1alpha1/dns_types.go
@@ -75,6 +75,7 @@ type DNSStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=dns

--- a/api/core/v1alpha1/doc.go
+++ b/api/core/v1alpha1/doc.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package v1alpha1 contains API Schema definitions for the networking.metal.ironcore.dev v1alpha1 API group.
+// +kubebuilder:ac:generate=true
+// +kubebuilder:ac:output:package="applyconfiguration"
 // +kubebuilder:validation:Required
 // +kubebuilder:object:generate=true
 // +groupName=networking.metal.ironcore.dev

--- a/api/core/v1alpha1/evpninstance_types.go
+++ b/api/core/v1alpha1/evpninstance_types.go
@@ -108,6 +108,7 @@ type EVPNInstanceStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=evpninstances

--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -537,6 +537,7 @@ const (
 	NeighborPortMismatch NeighborValidation = "PortMismatch"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=interfaces

--- a/api/core/v1alpha1/isis_types.go
+++ b/api/core/v1alpha1/isis_types.go
@@ -102,6 +102,7 @@ type ISISStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=isis

--- a/api/core/v1alpha1/lldp_types.go
+++ b/api/core/v1alpha1/lldp_types.go
@@ -63,6 +63,7 @@ type LLDPStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=lldps

--- a/api/core/v1alpha1/managementaccess_types.go
+++ b/api/core/v1alpha1/managementaccess_types.go
@@ -129,6 +129,7 @@ type ManagementAccessStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=managementaccesses

--- a/api/core/v1alpha1/ntp_types.go
+++ b/api/core/v1alpha1/ntp_types.go
@@ -72,6 +72,7 @@ type NTPStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=ntp

--- a/api/core/v1alpha1/nve_types.go
+++ b/api/core/v1alpha1/nve_types.go
@@ -123,6 +123,7 @@ type NetworkVirtualizationEdgeStatus struct {
 	HostReachability string `json:"hostReachability,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=networkvirtualizationedges

--- a/api/core/v1alpha1/ospf_types.go
+++ b/api/core/v1alpha1/ospf_types.go
@@ -175,6 +175,7 @@ const (
 	OSPFNeighborStateFull OSPFNeighborState = "Full"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=ospf

--- a/api/core/v1alpha1/pim_types.go
+++ b/api/core/v1alpha1/pim_types.go
@@ -89,6 +89,7 @@ type PIMStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=pim

--- a/api/core/v1alpha1/prefixset_types.go
+++ b/api/core/v1alpha1/prefixset_types.go
@@ -87,6 +87,7 @@ type PrefixSetStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=prefixsets

--- a/api/core/v1alpha1/routingpolicy_types.go
+++ b/api/core/v1alpha1/routingpolicy_types.go
@@ -199,6 +199,7 @@ type RoutingPolicyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=routingpolicies

--- a/api/core/v1alpha1/snmp_types.go
+++ b/api/core/v1alpha1/snmp_types.go
@@ -127,6 +127,7 @@ type SNMPStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=snmp

--- a/api/core/v1alpha1/syslog_types.go
+++ b/api/core/v1alpha1/syslog_types.go
@@ -102,6 +102,7 @@ type SyslogStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=syslogs

--- a/api/core/v1alpha1/user_types.go
+++ b/api/core/v1alpha1/user_types.go
@@ -82,6 +82,7 @@ type UserStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=users

--- a/api/core/v1alpha1/vlan_types.go
+++ b/api/core/v1alpha1/vlan_types.go
@@ -65,6 +65,7 @@ type VLANStatus struct {
 	BridgedBy *LocalObjectReference `json:"bridgedBy,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=vlans

--- a/api/core/v1alpha1/vrf_types.go
+++ b/api/core/v1alpha1/vrf_types.go
@@ -111,6 +111,7 @@ type VRFStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=vrfs


### PR DESCRIPTION
Add `+kubebuilder:ac:generate` and `+kubebuilder:ac:output:package` markers to API doc.go files to enable automatic generation of typed ApplyConfiguration builders for all API groups.

ApplyConfiguration types are required for Server-Side Apply (SSA), which allows controllers to declaratively manage individual fields of shared resources without conflicts. Generated builders provide type-safe construction of partial objects used in Apply calls, replacing unstructured patches and reducing the risk of runtime errors.

Additionally, set `ssa: true` in the PROJECT file for all resources and add missing +genclient markers to ensure controller-runtime generates the corresponding Apply method on typed clients.