### PR TITLE
[NX-OS] Add local-as support to bgp peer provider

### DIFF
--- a/internal/provider/cisco/nxos/bgp.go
+++ b/internal/provider/cisco/nxos/bgp.go
@@ -187,18 +187,37 @@ func (af *BGPDomAfItem) SetMultipath(m *v1alpha1.BGPMultipath) error {
 }
 
 type BGPPeer struct {
-	VRFName             string      `json:"-"`
-	Addr                string      `json:"addr"`
-	AdminSt             AdminSt     `json:"adminSt"`
-	Asn                 string      `json:"asn"`
-	AsnType             PeerAsnType `json:"asnType"`
-	Name                string      `json:"name,omitempty"`
-	SrcIf               string      `json:"srcIf,omitempty"`
-	InheritContPeerCtrl string      `json:"inheritContPeerCtrl"`
-	AfItems             struct {
+	VRFName       string      `json:"-"`
+	Addr          string      `json:"addr"`
+	AdminSt       AdminSt     `json:"adminSt"`
+	Asn           string      `json:"asn"`
+	AsnType       PeerAsnType `json:"asnType"`
+	Name          string      `json:"name,omitempty"`
+	SrcIf         string      `json:"srcIf,omitempty"`
+	LocalAsnItems struct {
+		AsnPropagate AsnPropagate `json:"asnPropagate"`
+		LocalAsn     string       `json:"localAsn"`
+	} `json:"localasn-items,omitzero"`
+	AfItems struct {
 		PeerAfList gnmiext.List[AddressFamily, *BGPPeerAfItem] `json:"PeerAf-list,omitzero"`
 	} `json:"af-items,omitzero"`
 }
+
+type AsnPropagate string
+
+const (
+	// AsnPropagateNone sends the local-as with no additional options.
+	AsnPropagateNone AsnPropagate = "none"
+	// AsnPropagateNoPrep does not prepend the local-as number to updates
+	// received from the eBGP neighbor.
+	AsnPropagateNoPrep AsnPropagate = "no-prepend"
+	// AsnPropagateReplaceAs prepends only the local-as number to updates
+	// sent to the eBGP neighbor.
+	AsnPropagateReplaceAs AsnPropagate = "replace-as"
+	// AsnPropagateDualAs allows the peer to connect using either the
+	// local-as number or the real AS.
+	AsnPropagateDualAs AsnPropagate = "dual-as"
+)
 
 func (*BGPPeer) IsListItem() {}
 

--- a/internal/provider/cisco/nxos/bgp_test.go
+++ b/internal/provider/cisco/nxos/bgp_test.go
@@ -74,4 +74,15 @@ func init() {
 		ExportGwIP: AdminStEnabled,
 	})
 	Register("bgp_dom_exp", bgpDomExp)
+
+	bgpPeerLocalAs := &BGPPeer{
+		VRFName: DefaultVRFName,
+		Addr:    "1.1.1.1",
+		AdminSt: AdminStEnabled,
+		Asn:     "65001",
+		AsnType: PeerAsnTypeNone,
+	}
+	bgpPeerLocalAs.LocalAsnItems.AsnPropagate = AsnPropagateNone
+	bgpPeerLocalAs.LocalAsnItems.LocalAsn = "65002"
+	Register("bgp_peer_local_as", bgpPeerLocalAs)
 }

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -552,6 +552,17 @@ func (p *Provider) EnsureBGPPeer(ctx context.Context, req *provider.EnsureBGPPee
 		pe.SrcIf = srcIf
 	}
 
+	if req.BGPPeer.Spec.LocalASNumber != nil {
+		if req.BGPPeer.Spec.ASNumber.String() == req.BGP.Spec.ASNumber.String() {
+			return apistatus.NewInvalidArgumentError(apistatus.FieldViolation{
+				Field:       "spec.localAS",
+				Description: "local-as cannot be configured on iBGP peers",
+			})
+		}
+		pe.LocalAsnItems.LocalAsn = req.BGPPeer.Spec.LocalASNumber.String()
+		pe.LocalAsnItems.AsnPropagate = AsnPropagateNone
+	}
+
 	if req.BGPPeer.Spec.AddressFamilies != nil {
 		for t, af := range map[AddressFamily]*v1alpha1.BGPPeerAddressFamily{
 			AddressFamilyIPv4Unicast: req.BGPPeer.Spec.AddressFamilies.Ipv4Unicast,

--- a/internal/provider/cisco/nxos/testdata/bgp_dom_rp.json
+++ b/internal/provider/cisco/nxos/testdata/bgp_dom_rp.json
@@ -13,7 +13,6 @@
                   "adminSt": "enabled",
                   "asn": "65000",
                   "asnType": "none",
-                  "inheritContPeerCtrl": "",
                   "af-items": {
                     "PeerAf-list": [
                       {

--- a/internal/provider/cisco/nxos/testdata/bgp_peer.json
+++ b/internal/provider/cisco/nxos/testdata/bgp_peer.json
@@ -14,7 +14,6 @@
                   "asnType": "none",
                   "name": "EVPN peering with spine",
                   "srcIf": "lo0",
-                  "inheritContPeerCtrl": "",
                   "af-items": {
                     "PeerAf-list": [
                       {

--- a/internal/provider/cisco/nxos/testdata/bgp_peer_local_as.json
+++ b/internal/provider/cisco/nxos/testdata/bgp_peer_local_as.json
@@ -1,0 +1,28 @@
+{
+  "bgp-items": {
+    "inst-items": {
+      "asn": "65000",
+      "dom-items": {
+        "Dom-list": [
+          {
+            "name": "default",
+            "peer-items": {
+              "Peer-list": [
+                {
+                  "addr": "1.1.1.1",
+                  "adminSt": "enabled",
+                  "asn": "65001",
+                  "asnType": "none",
+                  "localasn-items": {
+                    "asnPropagate": "none",
+                    "localAsn": "65002"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/bgp_peer_local_as.json.txt
+++ b/internal/provider/cisco/nxos/testdata/bgp_peer_local_as.json.txt
@@ -1,0 +1,4 @@
+router bgp 65000
+  neighbor 1.1.1.1
+    remote-as 65001
+      local-as 65002


### PR DESCRIPTION
Add LocalAsnItems to BGPPeer struct with AsnPropagate enum matching the NX-OS YANG model (bgp_AsnPropagation). EnsureBGPPeer now sets localasn-items when Spec.LocalASNumber is configured, and rejects the field on iBGP peers with an InvalidArgument error.

Remove unused InheritContPeerCtrl field from BGPPeer.