### PR TITLE
feat(helm): add custom labels to ServiceMonitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,11 @@ charts: FORCE install-kubebuilder generate
 	@$(SED) -i \
 	  -e '/certManager.enable/,/end/{s/^        - mountPath:/          - mountPath:/;s/^          name: webhook-certs/            name: webhook-certs/;s/^          readOnly: true/            readOnly: true/;s/^      - name: webhook-certs/        - name: webhook-certs/;s/^        secret:/          secret:/;s/^          secretName:/            secretName:/}' \
 	  charts/network-operator/templates/manager/manager.yaml
+	@# Add support for custom labels on ServiceMonitor (with omit filter to prevent overwriting managed labels)
+	@$(SED) -i \
+	  -e '/^metadata:/,/^spec:/{/control-plane: controller-manager$$/a\    {{- with .Values.prometheus.labels }}\n    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}\n    {{- toYaml . | nindent 4 }}\n    {{- end }}\n    {{- end }}' \
+	  -e '}' \
+	  charts/network-operator/templates/prometheus/controller-manager-metrics-monitor.yaml
 
 netop-provider:
 	@printf "\e[1;36m>> go build -o build/netop-provider ./hack/provider\e[0m\n"

--- a/charts/network-operator/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/charts/network-operator/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -8,6 +8,11 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
+    {{- with .Values.prometheus.labels }}
+    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
   name: {{ include "network-operator.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/network-operator/values.yaml
+++ b/charts/network-operator/values.yaml
@@ -174,6 +174,10 @@ webhook:
 prometheus:
   enable: false
 
+  ## Custom labels for ServiceMonitor resource.
+  ##
+  # labels: {}
+
 ## NetworkPolicy to restrict access to the controller manager.
 ##
 networkPolicy:


### PR DESCRIPTION
Add prometheus.labels field in values.yaml to allow custom labels on the ServiceMonitor resource. This enables integration with monitoring systems that use labels for scrape discovery.

The Makefile charts target preserves this change when kubebuilder regenerates templates.

Example:
```yaml
prometheus:
  enable: true
  labels:
    plugin: kube-monitoring
```