### PR TITLE
fix(controller): abort provisioning when Spec.Provisioning is removed

### DIFF
--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -71,7 +71,7 @@ type DeviceReconciler struct {
 //
 // For more details about the method shape, read up here:
 // - https://ahmet.im/blog/controller-pitfalls/#reconcile-method-shape
-func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) { //nolint:gocyclo
 	log := ctrl.LoggerFrom(ctx)
 	log.V(3).Info("Reconciling resource")
 
@@ -148,6 +148,15 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		return ctrl.Result{}, nil
 
 	case v1alpha1.DevicePhaseProvisioning:
+		if obj.Spec.Provisioning == nil {
+			log.Info("Provisioning configuration was removed, resetting device into pending phase")
+			if activeProv := obj.GetActiveProvisioning(); activeProv != nil {
+				activeProv.EndTime = metav1.Now()
+			}
+			obj.Status.Phase = v1alpha1.DevicePhasePending
+			r.Recorder.Eventf(obj, nil, "Warning", "ProvisioningAborted", "Reconcile", "Provisioning configuration was removed, resetting device into pending phase")
+			return ctrl.Result{}, nil
+		}
 		activeProv := obj.GetActiveProvisioning()
 		if activeProv == nil {
 			log.Info("Device has not made a provisioning request yet")

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -525,6 +525,125 @@ var _ = Describe("Device Controller", func() {
 			}).Should(Succeed())
 		})
 
+		It("Should reset to Pending when Spec.Provisioning is removed before provisioning agent makes a request", func() {
+			By("Creating a Device with provisioning configured")
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+					Provisioning: &v1alpha1.Provisioning{
+						Image: v1alpha1.Image{
+							URL:          "http://example.com/nxos.bin",
+							Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
+							ChecksumType: v1alpha1.ChecksumTypeMD5,
+						},
+						BootScript: v1alpha1.TemplateSource{
+							Inline: new("boot nxos.bin"),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+
+			By("Waiting for the device to enter Provisioning phase (no active provisioning entry yet)")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
+				g.Expect(resource.Status.Provisioning).To(BeEmpty())
+			}).Should(Succeed())
+
+			By("Removing Spec.Provisioning from the device")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				patch := resource.DeepCopy()
+				patch.Spec.Provisioning = nil
+				g.Expect(k8sClient.Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
+			}).Should(Succeed())
+
+			By("Verifying the device transitions to Running phase (Pending with no provisioning skips to Running)")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
+			}).Should(Succeed())
+		})
+
+		It("Should close the active provisioning entry and transition to Running when Spec.Provisioning is removed after provisioning agent made a request", func() {
+			By("Creating a Device with provisioning configured")
+			device := &v1alpha1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DeviceSpec{
+					Endpoint: v1alpha1.Endpoint{
+						Address: "192.168.10.2:9339",
+						SecretRef: &v1alpha1.SecretReference{
+							Name: name,
+						},
+					},
+					Provisioning: &v1alpha1.Provisioning{
+						Image: v1alpha1.Image{
+							URL:          "http://example.com/nxos.bin",
+							Checksum:     "d41d8cd98f00b204e9800998ecf8427e",
+							ChecksumType: v1alpha1.ChecksumTypeMD5,
+						},
+						BootScript: v1alpha1.TemplateSource{
+							Inline: new("boot nxos.bin"),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
+
+			By("Waiting for the device to enter Provisioning phase")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseProvisioning))
+			}).Should(Succeed())
+
+			By("Injecting an active provisioning entry (simulating provisioning agent)")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				patch := resource.DeepCopy()
+				patch.Status.Provisioning = []v1alpha1.ProvisioningInfo{{
+					Token:     "test-token",
+					StartTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				}}
+				g.Expect(k8sClient.Status().Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
+			}).Should(Succeed())
+
+			By("Removing Spec.Provisioning from the device")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				patch := resource.DeepCopy()
+				patch.Spec.Provisioning = nil
+				g.Expect(k8sClient.Patch(ctx, patch, client.MergeFrom(resource))).To(Succeed())
+			}).Should(Succeed())
+
+			By("Verifying the device transitions to Running phase with the provisioning entry closed")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.Device{}
+				g.Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
+				g.Expect(resource.Status.Phase).To(Equal(v1alpha1.DevicePhaseRunning))
+				g.Expect(resource.Status.Provisioning).To(HaveLen(1))
+				g.Expect(resource.Status.Provisioning[0].EndTime).ToNot(BeNil())
+			}).Should(Succeed())
+		})
+
 		It("Should update LastRebootTime in status when the device reboots", func() {
 			By("Creating the custom resource for the Kind Device")
 			device := &v1alpha1.Device{


### PR DESCRIPTION
Check for nil Spec.Provisioning before the activeProv guard so the
abort path is reachable regardless of whether the provisioning agent
has started. Closes the open ProvisioningInfo entry to prevent
blocking a future provisioning cycle, and emits a ProvisioningAborted
event for observability.

Signed-off-by: Sebastian Wagner <sebastian.wagner02@sap.com>
