### PR TITLE
Add timeout to Provisioned phase post-provisioning checks

### DIFF
--- a/internal/controller/core/device_controller.go
+++ b/internal/controller/core/device_controller.go
@@ -182,6 +182,11 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 			log.Info("Device is rebooting, requeuing")
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
+		if activeProv.StartTime.Add(time.Hour).Before(time.Now()) {
+			obj.Status.Phase = v1alpha1.DevicePhaseFailed
+			r.Recorder.Eventf(obj, nil, "Warning", "ProvisioningFailed", "Reconcile", "Device post-provisioning checks have timed out")
+			return ctrl.Result{}, nil
+		}
 		log.Info("Device provisioning completed, running post provisioning checks")
 		prov, _ := r.Provider().(provider.ProvisioningProvider)
 		if ok := prov.VerifyProvisioned(ctx, conn, obj); !ok {


### PR DESCRIPTION
Devices stuck in Provisioned with repeatedly failing VerifyProvisioned
would loop indefinitely. Transition to Failed after one hour from
StartTime, consistent with the Provisioning phase timeout.

Signed-off-by: Sebastian Wagner <sebastian.wagner02@sap.com>
