### PR TITLE
Fix LLDP neighbor validation failing during startup

### DIFF
--- a/internal/controller/core/interface_controller.go
+++ b/internal/controller/core/interface_controller.go
@@ -700,9 +700,9 @@ func (r *InterfaceReconciler) validateLLDPAdjacencyThroughLabel(ctx context.Cont
 
 	log := ctrl.LoggerFrom(ctx, "LLDP validation", klog.KObj(intf))
 
-	remoteDevice, err := deviceutil.GetOwnerDevice(ctx, r, remoteIntf)
+	remoteDevice, err := deviceutil.GetDeviceByName(ctx, r, remoteIntf.Namespace, remoteIntf.Spec.DeviceRef.Name)
 	if err != nil {
-		return "", fmt.Errorf("could not find the device owning interface %q: %w", remoteIntf.Name, err)
+		return "", fmt.Errorf("could not find the device for interface %q: %w", remoteIntf.Name, err)
 	}
 
 	if remoteDevice.Status.Hostname == "" {


### PR DESCRIPTION
Use spec.deviceRef to resolve the remote device instead of relying on the ownerReference. The ownerReference is only set after the remote interface's own reconciliation completes, causing transient errors when the local interface reconciles first.

The deviceRef is a required, immutable field that is always present from creation time, eliminating the startup race condition.