### PR TITLE
[NX-OS] Fix invalid asFormat value

### DIFF
--- a/internal/provider/cisco/nxos/bgp.go
+++ b/internal/provider/cisco/nxos/bgp.go
@@ -322,7 +322,7 @@ func (AsFormat) XPath() string {
 }
 
 const (
-	AsFormatAsDot AsFormat = "as-dot"
+	AsFormatAsDot AsFormat = "asdot"
 )
 
 type PeerAsnType string


### PR DESCRIPTION
The l3vm_AsFormatType YANG enum expects "asdot" but the constant was set to "as-dot" (with a hyphen), causing the device to reject the Set RPC with an invalid-value error.