### PR TITLE
Fix PIM controller stuck in Ready=False permanently

### DIFF
--- a/internal/controller/core/pim_controller.go
+++ b/internal/controller/core/pim_controller.go
@@ -296,9 +296,6 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (reterr erro
 			return err
 		}
 	}
-	defer func() {
-		conditions.RecomputeReady(s.PIM)
-	}()
 
 	var interfaces []provider.PIMInterface
 	for _, intf := range s.PIM.Spec.InterfaceRefs {
@@ -306,7 +303,7 @@ func (r *PIMReconciler) reconcile(ctx context.Context, s *pimScope) (reterr erro
 		if err := r.Get(ctx, client.ObjectKey{Name: intf.Name, Namespace: s.PIM.Namespace}, res); err != nil {
 			if apierrors.IsNotFound(err) {
 				conditions.Set(s.PIM, metav1.Condition{
-					Type:    v1alpha1.ConfiguredCondition,
+					Type:    v1alpha1.ReadyCondition,
 					Status:  metav1.ConditionFalse,
 					Reason:  v1alpha1.InterfaceNotFoundReason,
 					Message: fmt.Sprintf("interface %q not found", intf.Name),

--- a/internal/controller/core/pim_controller_test.go
+++ b/internal/controller/core/pim_controller_test.go
@@ -177,11 +177,7 @@ var _ = Describe("PIM Controller", func() {
 				ready := meta.FindStatusCondition(resource.Status.Conditions, v1alpha1.ReadyCondition)
 				g.Expect(ready).NotTo(BeNil())
 				g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
-
-				configured := meta.FindStatusCondition(resource.Status.Conditions, v1alpha1.ConfiguredCondition)
-				g.Expect(configured).NotTo(BeNil())
-				g.Expect(configured.Status).To(Equal(metav1.ConditionFalse))
-				g.Expect(configured.Reason).To(Equal(v1alpha1.InterfaceNotFoundReason))
+				g.Expect(ready.Reason).To(Equal(v1alpha1.InterfaceNotFoundReason))
 			}).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
The PIM controller incorrectly used ConfiguredCondition for the "interface not found" error path while only initializing ReadyCondition. Combined with RecomputeReady (which recomputes Ready from all other conditions), this caused a permanent stuck state:

1. ConfiguredCondition was set to False on the "not found" path
2. RecomputeReady saw ConfiguredCondition=False and kept Ready=False
3. When the Interface later appeared and the watch re-triggered, RecomputeReady still saw the stale ConfiguredCondition=False (since it was never set back to True) and overwrote Ready=False

Fix by aligning with the Banner controller pattern: the PIM resource only has ReadyCondition (no ConfiguredCondition, no Operational), so remove RecomputeReady entirely and set ReadyCondition directly in all code paths.