### PR TITLE
Wait for referenced VRF to be ready before configuring BGP

### DIFF
--- a/internal/controller/core/bgp_controller.go
+++ b/internal/controller/core/bgp_controller.go
@@ -300,13 +300,15 @@ func (r *BGPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) 
 			}),
 		).
 		// Watches enqueues BGPs for updates in referenced VRF resources.
-		// Only triggers on create and delete events since VRF names are immutable.
+		// Triggers on create, delete, and update events when the VRF's ready state changes.
 		Watches(
 			&v1alpha1.VRF{},
 			handler.EnqueueRequestsFromMapFunc(r.vrfToBGPs),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					return false
+					oldVRF := e.ObjectOld.(*v1alpha1.VRF)
+					newVRF := e.ObjectNew.(*v1alpha1.VRF)
+					return conditions.IsReady(oldVRF) != conditions.IsReady(newVRF)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -459,6 +461,18 @@ func (r *BGPReconciler) reconcileVRF(ctx context.Context, bgp *v1alpha1.BGP, dev
 		})
 		return nil, reconcile.TerminalError(fmt.Errorf("vrf %s belongs to different device", bgp.Spec.VrfRef.Name))
 	}
+
+	if !conditions.IsReady(vrf) {
+		// VRF uses ReadyCondition as its top-level configured state (no separate ConfiguredCondition).
+		conditions.Set(bgp, metav1.Condition{
+			Type:    v1alpha1.ReadyCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.WaitingForDependenciesReason,
+			Message: fmt.Sprintf("Waiting for VRF %s to become ready", bgp.Spec.VrfRef.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("vrf %s is not yet ready", bgp.Spec.VrfRef.Name))
+	}
+
 	return vrf, nil
 }
 

--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -323,13 +323,15 @@ func (r *BGPPeerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			}),
 		).
 		// Watches enqueues BGPPeers for updates in VRF resources referenced by their BGP.
-		// Only triggers on create and delete events since VRF names are immutable.
+		// Triggers on create, delete, and update events when the VRF's ready state changes.
 		Watches(
 			&v1alpha1.VRF{},
 			handler.EnqueueRequestsFromMapFunc(r.vrfToBGPPeers),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
-					return false
+					oldVRF := e.ObjectOld.(*v1alpha1.VRF)
+					newVRF := e.ObjectNew.(*v1alpha1.VRF)
+					return conditions.IsReady(oldVRF) != conditions.IsReady(newVRF)
 				},
 				GenericFunc: func(e event.GenericEvent) bool {
 					return false
@@ -625,6 +627,17 @@ func (r *BGPPeerReconciler) reconcileVRF(ctx context.Context, peer *v1alpha1.BGP
 			Message: fmt.Sprintf("VRF %s belongs to device %s, not %s", bgp.Spec.VrfRef.Name, vrf.Spec.DeviceRef.Name, device.Name),
 		})
 		return nil, reconcile.TerminalError(fmt.Errorf("vrf %s belongs to different device", bgp.Spec.VrfRef.Name))
+	}
+
+	if !conditions.IsReady(vrf) {
+		// VRF uses ReadyCondition as its top-level configured state (no separate ConfiguredCondition).
+		conditions.Set(peer, metav1.Condition{
+			Type:    v1alpha1.ConfiguredCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.WaitingForDependenciesReason,
+			Message: fmt.Sprintf("Waiting for VRF %s to become ready", bgp.Spec.VrfRef.Name),
+		})
+		return nil, reconcile.TerminalError(fmt.Errorf("vrf %s is not yet ready", bgp.Spec.VrfRef.Name))
 	}
 
 	return vrf, nil


### PR DESCRIPTION
The BGP and BGPPeer controllers now verify that the referenced VRF is ready before proceeding with provider configuration. If the VRF is not yet ready, a terminal error is returned and the VRF watch re-triggers reconciliation once the VRF becomes ready.