### PR TITLE
Fix size-label workflow always skipped

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -4,22 +4,17 @@
 name: Size Label
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:
   size-label:
     name: Label PR with size
-    if: >-
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
Switch from pull_request_target to pull_request event. The author_association field used in the job-level if condition is unreliable in pull_request_target event context, causing the job to be skipped for all PRs.

With pull_request, fork PRs automatically receive a read-only GITHUB_TOKEN that prevents label writes, making the explicit author_association guard unnecessary.