### PR TITLE
fix: use PrefixSet.Spec.Name for route-map prefix-list reference

### DIFF
--- a/internal/provider/cisco/nxos/routemap.go
+++ b/internal/provider/cisco/nxos/routemap.go
@@ -85,9 +85,9 @@ func (e *RouteMapEntry) SetExtCommunities(communities []string) error {
 }
 
 func (e *RouteMapEntry) SetPrefixSet(ps *v1alpha1.PrefixSet) {
-	tdn := "/System/rpm-items/pfxlistv4-items/RuleV4-list[name='" + ps.Name + "']"
+	tdn := "/System/rpm-items/pfxlistv4-items/RuleV4-list[name='" + ps.Spec.Name + "']"
 	if ps.Is6() {
-		tdn = "/System/rpm-items/pfxlistv6-items/RuleV6-list[name='" + ps.Name + "']"
+		tdn = "/System/rpm-items/pfxlistv6-items/RuleV6-list[name='" + ps.Spec.Name + "']"
 	}
 	e.MrtdstItems.RsrtDstAttItems.RsRtDstAttList.Set(&RsRtDstAtt{TDn: tdn})
 }


### PR DESCRIPTION
SetPrefixSet was using the Kubernetes object name instead of the
device-level name (Spec.Name) when building the tDn reference in the
NX-OS route-map match clause, causing it to reference a non-existent
prefix-list on the device.

Signed-off-by: Sebastian Wagner <sebastian.wagner02@sap.com>
