### PR TITLE
fix: decouple SetPrefixSet from k8s types

### DIFF
--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -2141,7 +2141,7 @@ func (p *Provider) EnsureRoutingPolicy(ctx context.Context, req *provider.Ensure
 		for _, cond := range stmt.Conditions {
 			switch v := cond.(type) {
 			case provider.MatchPrefixSetCondition:
-				e.SetPrefixSet(v.PrefixSet)
+				e.SetPrefixSet(v.PrefixSet.Spec.Name, v.PrefixSet.Is6())
 			default:
 				return fmt.Errorf("routing policy: unsupported condition type %T", cond)
 			}

--- a/internal/provider/cisco/nxos/routemap.go
+++ b/internal/provider/cisco/nxos/routemap.go
@@ -4,7 +4,6 @@
 package nxos
 
 import (
-	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 	"github.com/ironcore-dev/network-operator/internal/transport/gnmiext"
 )
 
@@ -84,10 +83,10 @@ func (e *RouteMapEntry) SetExtCommunities(communities []string) error {
 	return nil
 }
 
-func (e *RouteMapEntry) SetPrefixSet(ps *v1alpha1.PrefixSet) {
-	tdn := "/System/rpm-items/pfxlistv4-items/RuleV4-list[name='" + ps.Spec.Name + "']"
-	if ps.Is6() {
-		tdn = "/System/rpm-items/pfxlistv6-items/RuleV6-list[name='" + ps.Spec.Name + "']"
+func (e *RouteMapEntry) SetPrefixSet(name string, isV6 bool) {
+	tdn := "/System/rpm-items/pfxlistv4-items/RuleV4-list[name='" + name + "']"
+	if isV6 {
+		tdn = "/System/rpm-items/pfxlistv6-items/RuleV6-list[name='" + name + "']"
 	}
 	e.MrtdstItems.RsrtDstAttItems.RsRtDstAttList.Set(&RsRtDstAtt{TDn: tdn})
 }

--- a/internal/provider/cisco/nxos/routemap_test.go
+++ b/internal/provider/cisco/nxos/routemap_test.go
@@ -67,4 +67,24 @@ func init() {
 	setRM.Name = "RM-ASPATH-SET"
 	setRM.EntItems.EntryList.Set(setEntry)
 	Register("route_map_aspath_set", setRM)
+
+	pfxV4Entry := &RouteMapEntry{}
+	pfxV4Entry.Order = 10
+	pfxV4Entry.Action = ActionPermit
+	pfxV4Entry.SetPrefixSet("PL-DEVICE-V4", false)
+
+	pfxV4RM := &RouteMap{}
+	pfxV4RM.Name = "RM-PREFIXSET-V4"
+	pfxV4RM.EntItems.EntryList.Set(pfxV4Entry)
+	Register("route_map_prefixset_v4", pfxV4RM)
+
+	pfxV6Entry := &RouteMapEntry{}
+	pfxV6Entry.Order = 10
+	pfxV6Entry.Action = ActionPermit
+	pfxV6Entry.SetPrefixSet("PL-DEVICE-V6", true)
+
+	pfxV6RM := &RouteMap{}
+	pfxV6RM.Name = "RM-PREFIXSET-V6"
+	pfxV6RM.EntItems.EntryList.Set(pfxV6Entry)
+	Register("route_map_prefixset_v6", pfxV6RM)
 }

--- a/internal/provider/cisco/nxos/testdata/route_map_prefixset_v4.json
+++ b/internal/provider/cisco/nxos/testdata/route_map_prefixset_v4.json
@@ -1,0 +1,28 @@
+{
+  "rpm-items": {
+    "rtmap-items": {
+      "Rule-list": [
+        {
+          "name": "RM-PREFIXSET-V4",
+          "ent-items": {
+            "Entry-list": [
+              {
+                "action": "permit",
+                "order": 10,
+                "mrtdst-items": {
+                  "rsrtDstAtt-items": {
+                    "RsRtDstAtt-list": [
+                      {
+                        "tDn": "/System/rpm-items/pfxlistv4-items/RuleV4-list[name='PL-DEVICE-V4']"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/route_map_prefixset_v6.json
+++ b/internal/provider/cisco/nxos/testdata/route_map_prefixset_v6.json
@@ -1,0 +1,28 @@
+{
+  "rpm-items": {
+    "rtmap-items": {
+      "Rule-list": [
+        {
+          "name": "RM-PREFIXSET-V6",
+          "ent-items": {
+            "Entry-list": [
+              {
+                "action": "permit",
+                "order": 10,
+                "mrtdst-items": {
+                  "rsrtDstAtt-items": {
+                    "RsRtDstAtt-list": [
+                      {
+                        "tDn": "/System/rpm-items/pfxlistv6-items/RuleV6-list[name='PL-DEVICE-V6']"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Move the extraction of PrefixSet.Spec.Name and Is6() to the provider call site, so that SetPrefixSet takes plain parameters (name string, isV6 bool) instead of *v1alpha1.PrefixSet. This removes the k8s API import from routemap.go.

Add tests for for route-map prefix-set references covering both IPv4 and IPv6.