### PR TITLE
e2e-tests (2/4): Add parallel cluster-based e2e tests via  `gingko` 

### DIFF
--- a/.license-scan-overrides.jsonl
+++ b/.license-scan-overrides.jsonl
@@ -1,6 +1,7 @@
 {"name": "github.com/chzyer/logex", "licenceType": "MIT"}
 {"name": "github.com/grpc-ecosystem/go-grpc-middleware/v2", "licenceType": "Apache-2.0"}
 {"name": "github.com/hashicorp/vault/api/auth/approle", "licenceType": "MPL-2.0"}
+{"name": "github.com/ironcore-dev/gnmi-test-server", "licenceType": "Apache-2.0"}
 {"name": "github.com/jpillora/longestcommon", "licenceType": "MIT"}
 {"name": "github.com/logrusorgru/aurora", "licenceType": "Unlicense"}
 {"name": "github.com/mattn/go-localereader", "licenceType": "MIT"}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /workspace
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,source=go.mod,target=go.mod \
     --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=test/gnmi,target=test/gnmi \
     go mod download -x
 
 RUN --mount=type=bind,target=. \

--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,13 @@ lint: FORCE bin/golangci-lint-custom ## Run golangci-lint linter
 	@bin/golangci-lint-custom config verify
 	@bin/golangci-lint-custom run
 
-# PROVIDER defines which provider to test (cisco-nxos-gnmi, cisco-iosxr-gnmi, openconfig).
-# Used by test-e2e-cluster and test-e2e-envtest to filter tests.
-PROVIDER ?= cisco-nxos-gnmi
-
 fmt: FORCE install-gofumpt
 	@printf "\e[1;36m>> gofumpt -l -w .\e[0m\n"
 	@gofumpt -l -w $(shell git ls-files '*.go' | grep -v '^internal/provider/openconfig')
+
+# PROVIDER defines which provider to test (cisco-nxos-gnmi, cisco-iosxr-gnmi, openconfig).
+# Used by test-e2e-cluster and test-e2e-envtest to filter tests.
+PROVIDER ?= cisco-nxos-gnmi
 
 # Run the scaffolded e2e tests (unchanged from Kubebuilder).
 test-e2e: FORCE
@@ -104,13 +104,8 @@ test-e2e-cluster: FORCE install-ginkgo
 	  echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
 	  exit 1; \
 	}
-	@printf "\e[1;36m>> ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=15m -v ./test/e2e/ (PROVIDER=$(PROVIDER))\e[0m\n"
-	@KIND_CLUSTER=$(KIND_CLUSTER) E2E_PROVIDER=$(PROVIDER) ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=15m -v ./test/e2e/
-
-# Run gNMI controller tests in envtest mode (no cluster required).
-test-e2e-envtest: FORCE install-setup-envtest
-	@printf "\e[1;36m>> go test ./test/e2e/ -tags=envtest -v -ginkgo.v (PROVIDER=$(PROVIDER))\e[0m\n"
-	@KUBEBUILDER_ASSETS=$$(setup-envtest use 1.32 -p path) E2E_PROVIDER=$(PROVIDER) go test ./test/e2e/ -tags=envtest -v -ginkgo.v
+	@printf "\e[1;36m>> ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=20m -v ./test/e2e/ (PROVIDER=$(PROVIDER))\e[0m\n"
+	@KIND_CLUSTER=$(KIND_CLUSTER) E2E_PROVIDER=$(PROVIDER) ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=20m -v ./test/e2e/
 
 docker-build: FORCE
 	@printf "\e[1;36m>> $(CONTAINER_TOOL) build --tag=$(IMG) .\e[0m\n"

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ $(LOCALBIN):
 install-gofumpt: FORCE
 	@if ! hash gofumpt 2>/dev/null; then printf "\e[1;36m>> Installing gofumpt...\e[0m\n"; go install mvdan.cc/gofumpt@latest; fi
 
+install-ginkgo: FORCE
+	@if ! hash ginkgo 2>/dev/null; then printf "\e[1;36m>> Installing ginkgo...\e[0m\n"; go install github.com/onsi/ginkgo/v2/ginkgo@latest; fi
+
 install-kubebuilder: FORCE
 	@set -eou pipefail;  if ! hash kubebuilder 2>/dev/null; then printf "\e[1;36m>> Installing kubebuilder...\e[0m\n"; if command -v curl >/dev/null 2>&1; then GET="curl -sLo"; elif command -v wget >/dev/null 2>&1; then GET="wget -O"; else echo "Didn't find curl or wget to download kubebuilder"; exit 2; fi; BIN=$$(go env GOBIN); if [[ -z $$BIN ]]; then BIN=$$(go env GOPATH)/bin; fi; $$GET "$$BIN/kubebuilder" "https://go.kubebuilder.io/dl/latest/$$(go env GOOS)/$$(go env GOARCH)"; chmod +x "$$BIN/kubebuilder"; fi
 
@@ -68,11 +71,15 @@ lint: FORCE bin/golangci-lint-custom ## Run golangci-lint linter
 	@bin/golangci-lint-custom config verify
 	@bin/golangci-lint-custom run
 
+# PROVIDER defines which provider to test (cisco-nxos-gnmi, cisco-iosxr-gnmi, openconfig).
+# Used by test-e2e-cluster and test-e2e-envtest to filter tests.
+PROVIDER ?= cisco-nxos-gnmi
+
 fmt: FORCE install-gofumpt
 	@printf "\e[1;36m>> gofumpt -l -w .\e[0m\n"
 	@gofumpt -l -w $(shell git ls-files '*.go' | grep -v '^internal/provider/openconfig')
 
-# Run the e2e tests against a k8s cluster.
+# Run the scaffolded e2e tests (unchanged from Kubebuilder).
 test-e2e: FORCE
 	@command -v kind >/dev/null 2>&1 || { \
 	  echo "Kind is not installed. Please install Kind manually."; \
@@ -84,6 +91,26 @@ test-e2e: FORCE
 	}
 	@printf "\e[1;36m>> go test ./test/e2e/ -v -ginkgo.v\e[0m\n"
 	@KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+
+# Run gNMI controller tests in cluster mode (requires Kind cluster).
+# Uses ginkgo for parallel execution.
+GINKGO_PROCS ?= 4
+test-e2e-cluster: FORCE install-ginkgo
+	@command -v kind >/dev/null 2>&1 || { \
+	  echo "Kind is not installed. Please install Kind manually."; \
+	  exit 1; \
+	}
+	@kind get clusters | grep -q $(KIND_CLUSTER) || { \
+	  echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
+	  exit 1; \
+	}
+	@printf "\e[1;36m>> ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=15m -v ./test/e2e/ (PROVIDER=$(PROVIDER))\e[0m\n"
+	@KIND_CLUSTER=$(KIND_CLUSTER) E2E_PROVIDER=$(PROVIDER) ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=15m -v ./test/e2e/
+
+# Run gNMI controller tests in envtest mode (no cluster required).
+test-e2e-envtest: FORCE install-setup-envtest
+	@printf "\e[1;36m>> go test ./test/e2e/ -tags=envtest -v -ginkgo.v (PROVIDER=$(PROVIDER))\e[0m\n"
+	@KUBEBUILDER_ASSETS=$$(setup-envtest use 1.32 -p path) E2E_PROVIDER=$(PROVIDER) go test ./test/e2e/ -tags=envtest -v -ginkgo.v
 
 docker-build: FORCE
 	@printf "\e[1;36m>> $(CONTAINER_TOOL) build --tag=$(IMG) .\e[0m\n"
@@ -98,15 +125,16 @@ build-installer: FORCE generate install-kustomize
 	@printf "\e[1;36m>> kustomize build config/default > dist/install.yaml\e[0m\n"
 	@mkdir -p dist; kustomize build config/default > dist/install.yaml
 
-# Deploy controller to the k8s cluster
+# Deploy controller to the k8s cluster.
+# Use PROVIDER to set the provider (default: cisco-nxos-gnmi).
 deploy: FORCE generate install-kustomize
-	@printf "\e[1;36m>> kustomize build config/default | kubectl apply -f -\e[0m\n"
-	@kustomize build config/default | kubectl apply -f -
+	@printf "\e[1;36m>> deploying controller-manager (PROVIDER=$(PROVIDER))\e[0m\n"
+	@kustomize build config/develop | sed 's/--provider=openconfig/--provider=$(PROVIDER)/' | kubectl apply -f -
 
 # Undeploy controller from the k8s cluster
 undeploy: FORCE install-kustomize
-	@printf "\e[1;36m>> kustomize build config/default | kubectl delete -f -\e[0m\n"
-	@kustomize build config/default | kubectl delete --ignore-not-found=true -f -
+	@printf "\e[1;36m>> undeploying controller-manager\e[0m\n"
+	@kustomize build config/develop | kubectl delete --ignore-not-found=true -f -
 
 # Install CRDs into the k8s cluster
 deploy-crds: FORCE generate install-kustomize

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -92,6 +92,9 @@ verbatim: |
   install-gofumpt: FORCE
     @if ! hash gofumpt 2>/dev/null; then printf "\e[1;36m>> Installing gofumpt...\e[0m\n"; go install mvdan.cc/gofumpt@latest; fi
 
+  install-ginkgo: FORCE
+    @if ! hash ginkgo 2>/dev/null; then printf "\e[1;36m>> Installing ginkgo...\e[0m\n"; go install github.com/onsi/ginkgo/v2/ginkgo@latest; fi
+
   install-kubebuilder: FORCE
     @set -eou pipefail;  if ! hash kubebuilder 2>/dev/null; then printf "\e[1;36m>> Installing kubebuilder...\e[0m\n"; if command -v curl >/dev/null 2>&1; then GET="curl -sLo"; elif command -v wget >/dev/null 2>&1; then GET="wget -O"; else echo "Didn't find curl or wget to download kubebuilder"; exit 2; fi; BIN=$$(go env GOBIN); if [[ -z $$BIN ]]; then BIN=$$(go env GOPATH)/bin; fi; $$GET "$$BIN/kubebuilder" "https://go.kubebuilder.io/dl/latest/$$(go env GOOS)/$$(go env GOARCH)"; chmod +x "$$BIN/kubebuilder"; fi
 
@@ -114,7 +117,11 @@ verbatim: |
     @printf "\e[1;36m>> gofumpt -l -w .\e[0m\n"
     @gofumpt -l -w $(shell git ls-files '*.go' | grep -v '^internal/provider/openconfig')
 
-  # Run the e2e tests against a k8s cluster.
+  # PROVIDER defines which provider to test (cisco-nxos-gnmi, cisco-iosxr-gnmi, openconfig).
+  # Used by test-e2e-cluster and test-e2e-envtest to filter tests.
+  PROVIDER ?= cisco-nxos-gnmi
+
+  # Run the scaffolded e2e tests (unchanged from Kubebuilder).
   test-e2e: FORCE
     @command -v kind >/dev/null 2>&1 || { \
       echo "Kind is not installed. Please install Kind manually."; \
@@ -126,6 +133,21 @@ verbatim: |
     }
     @printf "\e[1;36m>> go test ./test/e2e/ -v -ginkgo.v\e[0m\n"
     @KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+
+  # Run gNMI controller tests in cluster mode (requires Kind cluster).
+  # Uses ginkgo for parallel execution.
+  GINKGO_PROCS ?= 4
+  test-e2e-cluster: FORCE install-ginkgo
+    @command -v kind >/dev/null 2>&1 || { \
+      echo "Kind is not installed. Please install Kind manually."; \
+      exit 1; \
+    }
+    @kind get clusters | grep -q $(KIND_CLUSTER) || { \
+      echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
+      exit 1; \
+    }
+    @printf "\e[1;36m>> ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=20m -v ./test/e2e/ (PROVIDER=$(PROVIDER))\e[0m\n"
+    @KIND_CLUSTER=$(KIND_CLUSTER) E2E_PROVIDER=$(PROVIDER) ginkgo -procs=$(GINKGO_PROCS) -tags=cluster -timeout=20m -v ./test/e2e/
 
   docker-build: FORCE
     @printf "\e[1;36m>> $(CONTAINER_TOOL) build --tag=$(IMG) .\e[0m\n"
@@ -140,15 +162,16 @@ verbatim: |
     @printf "\e[1;36m>> kustomize build config/default > dist/install.yaml\e[0m\n"
     @mkdir -p dist; kustomize build config/default > dist/install.yaml
 
-  # Deploy controller to the k8s cluster
+  # Deploy controller to the k8s cluster.
+  # Use PROVIDER to set the provider (default: cisco-nxos-gnmi).
   deploy: FORCE generate install-kustomize
-    @printf "\e[1;36m>> kustomize build config/default | kubectl apply -f -\e[0m\n"
-    @kustomize build config/default | kubectl apply -f -
+    @printf "\e[1;36m>> deploying controller-manager (PROVIDER=$(PROVIDER))\e[0m\n"
+    @kustomize build config/develop | sed 's/--provider=openconfig/--provider=$(PROVIDER)/' | kubectl apply -f -
 
   # Undeploy controller from the k8s cluster
   undeploy: FORCE install-kustomize
-    @printf "\e[1;36m>> kustomize build config/default | kubectl delete -f -\e[0m\n"
-    @kustomize build config/default | kubectl delete --ignore-not-found=true -f -
+    @printf "\e[1;36m>> undeploying controller-manager\e[0m\n"
+    @kustomize build config/develop | kubectl delete --ignore-not-found=true -f -
 
   # Install CRDs into the k8s cluster
   deploy-crds: FORCE generate install-kustomize

--- a/config/develop/gnmi-test-server.yaml
+++ b/config/develop/gnmi-test-server.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: gnmi-test-server
         image: ghcr.io/ironcore-dev/gnmi-test-server:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         ports:
         - containerPort: 9339
           name: grpc

--- a/config/develop/manager_patch.yaml
+++ b/config/develop/manager_patch.yaml
@@ -1,6 +1,7 @@
 - op: replace
   path: /spec/template/spec/containers/0/args
   value:
+    - --metrics-bind-address=:8443
     - --leader-elect=false
     - --health-probe-bind-address=:8081
     - --provider=openconfig

--- a/go.mod
+++ b/go.mod
@@ -129,3 +129,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace github.com/ironcore-dev/gnmi-test-server => ./test/gnmi

--- a/test/e2e/cluster_suite_test.go
+++ b/test/e2e/cluster_suite_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cluster
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/ironcore-dev/network-operator/test/e2e/testutil"
+)
+
+// TestCluster runs the e2e test suite in cluster mode.
+// Named differently from TestE2E to avoid conflict with scaffolded e2e_suite_test.go.
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting network-operator tests in CLUSTER mode\n")
+	RunSpecs(t, "e2e suite (cluster)")
+}
+
+// SynchronizedBeforeSuite enables parallel test execution:
+// - Process 1: Builds images, installs Prometheus/CertManager, deploys manager (runs first, alone)
+// - All processes: Create ClusterEnvironment connection (runs after process 1 completes)
+var _ = SynchronizedBeforeSuite(
+	// First function: runs ONLY on process 1, before other processes start
+	func(ctx SpecContext) []byte {
+		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+		// Note: Timeout is set in the second function for all processes
+
+		By("Ensure that Prometheus is enabled")
+		cwd, err := testutil.GetProjectDir()
+		Expect(err).NotTo(HaveOccurred(), "Failed to get project directory")
+
+		err = testutil.UncommentCode(cwd+"/config/default/kustomization.yaml", "#- ../prometheus", "#")
+		Expect(err).NotTo(HaveOccurred(), "Failed to enable Prometheus")
+
+		// Build and load images to Kind (only process 1)
+		buildAndLoadImages(ctx)
+
+		// Setup Prometheus and CertManager (only process 1)
+		setupClusterDependencies(ctx)
+
+		// Deploy controller-manager (includes CRDs via make deploy)
+		By("deploying controller-manager")
+		tmpEnv := testutil.NewClusterEnvironment()
+		Expect(tmpEnv.Setup(ctx)).To(Succeed())
+		Expect(tmpEnv.DeployManager(ctx)).To(Succeed())
+
+		return nil // No data to pass to other processes
+	},
+	// Second function: runs on ALL processes after the first function completes
+	func(ctx SpecContext, _ []byte) {
+		SetDefaultEventuallyTimeout(testutil.DefaultTimeout)
+		SetDefaultEventuallyPollingInterval(time.Second)
+
+		// All processes create their own ClusterEnvironment connection
+		By("initializing cluster environment")
+		testEnv = testutil.NewClusterEnvironment()
+		Expect(testEnv.Setup(ctx)).To(Succeed())
+	},
+)
+
+// SynchronizedAfterSuite enables parallel test cleanup:
+// - All processes: Local cleanup (runs on all processes)
+// - Process 1: Uninstall shared dependencies (runs last, alone)
+var _ = SynchronizedAfterSuite(
+	// First function: runs on ALL processes
+	func(ctx SpecContext) {
+		// Perform local cleanup (will run only once even if called from signal handler)
+		performCleanup()
+
+		// Wait for all test namespaces to be fully deleted before returning.
+		// This ensures DeferCleanup hooks have finished deleting resources and their
+		// finalizers have been processed by the controller. Without this, the second
+		// function (UndeployManager) may delete the CRDs while resources still exist,
+		// causing finalizers to be stuck forever.
+		if testEnv != nil {
+			_ = testEnv.WaitForTestNamespacesGone(ctx) //nolint:errcheck // best-effort cleanup
+		}
+	},
+	// Second function: runs ONLY on process 1, after all other processes complete
+	func(ctx SpecContext) {
+		// Undeploy the controller-manager
+		tmpEnv := testutil.NewClusterEnvironment()
+		_ = tmpEnv.Setup(ctx)           //nolint:errcheck // best-effort cleanup
+		_ = tmpEnv.UndeployManager(ctx) //nolint:errcheck // best-effort cleanup
+
+		// Uninstall Prometheus and CertManager
+		cleanupClusterDependencies(ctx)
+	},
+)

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cluster
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/tools/txtar"
+
+	"github.com/ironcore-dev/network-operator/test/e2e/testutil"
+)
+
+// namespace where the project is deployed in
+// tests create resources in separate namespaces
+const namespace = "network-operator-system"
+
+// serviceAccountName created for the project
+const serviceAccountName = "network-operator-controller-manager"
+
+// metricsServiceName is the name of the metrics service of the project
+const metricsServiceName = "network-operator-controller-manager-metrics-service"
+
+// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
+const metricsRoleBindingName = "network-operator-metrics-binding"
+
+// image is the name of the image which will be build and loaded
+// with the code source changes to be tested.
+const image = "ghcr.io/ironcore-dev/network-operator:latest"
+
+// serverImage is the name of the image which will be built and loaded
+// with the gNMI test server.
+const serverImage = "ghcr.io/ironcore-dev/gnmi-test-server:latest"
+
+var (
+	// Optional Environment Variables:
+	// - PROMETHEUS_INSTALL_SKIP=true: Skips Prometheus Operator installation during test setup.
+	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
+	// These variables are useful if Prometheus or CertManager is already installed, avoiding re-installation and conflicts.
+	skipPrometheusInstall  = os.Getenv("PROMETHEUS_INSTALL_SKIP") == "true"
+	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
+	// isPrometheusOperatorAlreadyInstalled will be set true when prometheus CRDs be found on the cluster
+	isPrometheusOperatorAlreadyInstalled = false
+	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
+	isCertManagerAlreadyInstalled = false
+)
+
+var (
+	cleanupOnce sync.Once
+	// testEnv is the cluster test environment.
+	testEnv *testutil.ClusterEnvironment
+)
+
+func init() {
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting network-operator tests in CLUSTER mode\n")
+}
+
+// Manager Setup tests run serially on a single Ginkgo process.
+// These tests deploy and verify the controller-manager before reconciliation tests run in parallel.
+var _ = Describe("Manager Setup", Serial, Ordered, func() {
+	var controllerPodName string
+
+	// Before running the tests, set up the environment by creating the namespace,
+	// enforce the restricted security policy to the namespace, installing CRDs,
+	// and deploying the controller.
+	BeforeAll(func(ctx SpecContext) {
+		By("creating manager namespace")
+		cmd := exec.CommandContext(ctx, "kubectl", "create", "ns", namespace, "--dry-run=client", "-o", "yaml")
+		nsYaml, err := testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to generate namespace YAML")
+		cmd = exec.CommandContext(ctx, "kubectl", "apply", "-f", "-")
+		cmd.Stdin = bytes.NewBufferString(nsYaml)
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+		By("labeling the namespace to enforce the restricted security policy")
+		cmd = exec.CommandContext(ctx, "kubectl", "label", "--overwrite", "ns", namespace, "pod-security.kubernetes.io/enforce=restricted")
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+
+		By("installing CRDs")
+		cmd = exec.CommandContext(ctx, "make", "deploy-crds")
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+		By("deploying the controller-manager")
+		cmd = exec.CommandContext(ctx, "make", "deploy")
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+	})
+
+	// After all setup tests complete, clean up the manager.
+	// Note: CRDs are left installed for the parallel reconciliation tests.
+	AfterAll(func(ctx SpecContext) {
+		By("cleaning up the ClusterRoleBinding of the service account to allow access to metrics")
+		cmd := exec.CommandContext(ctx, "kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
+		_, err := testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to delete ClusterRoleBinding")
+
+		By("cleaning up the curl pod for metrics")
+		cmd = exec.CommandContext(ctx, "kubectl", "delete", "pod", "curl-metrics", "-n", namespace, "--ignore-not-found")
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to delete curl-metrics pod")
+	})
+
+	// After each test, check for failures and collect logs, events,
+	// and pod descriptions for debugging.
+	AfterEach(func(ctx SpecContext) {
+		if specReport := CurrentSpecReport(); specReport.Failed() {
+			By("Fetching controller manager pod logs")
+			cmd := exec.CommandContext(ctx, "kubectl", "logs", controllerPodName, "-n", namespace)
+			controllerLogs, err := testutil.Run(cmd, GinkgoWriter)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s", err)
+			}
+
+			By("Fetching Kubernetes events")
+			cmd = exec.CommandContext(ctx, "kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+			eventsOutput, err := testutil.Run(cmd, GinkgoWriter)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
+			}
+
+			By("Fetching curl-metrics logs")
+			cmd = exec.CommandContext(ctx, "kubectl", "logs", "curl-metrics", "-n", namespace)
+			metricsOutput, err := testutil.Run(cmd, GinkgoWriter)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
+			}
+
+			By("Fetching controller manager pod description")
+			cmd = exec.CommandContext(ctx, "kubectl", "describe", "pod", controllerPodName, "-n", namespace)
+			podDescription, err := testutil.Run(cmd, GinkgoWriter)
+			if err == nil {
+				fmt.Println("Pod description:\n", podDescription)
+			} else {
+				fmt.Println("Failed to describe controller pod")
+			}
+		}
+	})
+
+	BeforeEach(func() {
+		SetDefaultEventuallyTimeout(testutil.LongTimeout)
+		SetDefaultEventuallyPollingInterval(time.Second)
+	})
+
+	It("should run successfully", func(ctx SpecContext) {
+		By("validating that the controller-manager pod is running as expected")
+		verifyControllerUp := func(g Gomega) {
+			// Get the name of the controller-manager pod
+			cmd := exec.CommandContext(
+				ctx, "kubectl", "get",
+				"pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", namespace,
+			)
+
+			podOutput, err := testutil.Run(cmd, GinkgoWriter)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to retrieve controller-manager pod information")
+			podNames := testutil.GetNonEmptyLines(podOutput)
+			g.Expect(podNames).To(HaveLen(1), "expected 1 controller pod running")
+			controllerPodName = podNames[0]
+			g.Expect(controllerPodName).To(ContainSubstring("controller-manager"))
+
+			// Validate the pod's status
+			cmd = exec.CommandContext(ctx, "kubectl", "get", "pods", controllerPodName, "-o", "jsonpath={.status.phase}", "-n", namespace)
+			output, err := testutil.Run(cmd, GinkgoWriter)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Running"), "Incorrect controller-manager pod status")
+		}
+		Eventually(verifyControllerUp).Should(Succeed())
+	})
+
+	It("should ensure the metrics endpoint is serving metrics", func(ctx SpecContext) {
+		By("creating a ClusterRoleBinding for the service account to allow access to metrics")
+		// #nosec G204
+		cmd := exec.CommandContext(ctx, "kubectl", "create", "clusterrolebinding", metricsRoleBindingName, "--clusterrole=network-operator-metrics-reader", fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName))
+		_, err := testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+
+		By("validating that the metrics service is available")
+		cmd = exec.CommandContext(ctx, "kubectl", "get", "service", metricsServiceName, "-n", namespace)
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
+
+		By("validating that the ServiceMonitor for Prometheus is applied in the namespace")
+		cmd = exec.CommandContext(ctx, "kubectl", "get", "ServiceMonitor", "-n", namespace)
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "ServiceMonitor should exist")
+
+		By("getting the service account token")
+		token, err := serviceAccountToken(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(token).NotTo(BeEmpty())
+
+		By("waiting for the metrics endpoint to be ready")
+		verifyMetricsEndpointReady := func(g Gomega) {
+			kcmd := exec.CommandContext(ctx, "kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
+			output, kErr := testutil.Run(kcmd, GinkgoWriter)
+			g.Expect(kErr).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
+		}
+		Eventually(verifyMetricsEndpointReady).Should(Succeed())
+
+		By("verifying that the controller manager has started")
+		verifyManagerStarted := func(g Gomega) {
+			kcmd := exec.CommandContext(ctx, "kubectl", "logs", controllerPodName, "-n", namespace)
+			output, kErr := testutil.Run(kcmd, GinkgoWriter)
+			g.Expect(kErr).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("starting manager"), "Manager not yet started")
+		}
+		Eventually(verifyManagerStarted).Should(Succeed())
+
+		By("creating the curl-metrics pod to access the metrics endpoint")
+		// #nosec G204
+		cmd = exec.CommandContext(ctx, "kubectl", "run", "curl-metrics", "--restart=Never",
+			"--namespace", namespace,
+			"--image=curlimages/curl:latest",
+			"--overrides",
+			fmt.Sprintf(`{
+				"spec": {
+					"containers": [{
+						"name": "curl",
+						"image": "curlimages/curl:latest",
+						"command": ["/bin/sh", "-c"],
+						"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
+						"securityContext": {
+							"allowPrivilegeEscalation": false,
+							"capabilities": {
+								"drop": ["ALL"]
+							},
+							"runAsNonRoot": true,
+							"runAsUser": 1000,
+							"seccompProfile": {
+								"type": "RuntimeDefault"
+							}
+						}
+					}],
+					"serviceAccount": "%s"
+				}
+			}`, token, metricsServiceName, namespace, serviceAccountName))
+		_, err = testutil.Run(cmd, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
+
+		By("waiting for the curl-metrics pod to complete.")
+		verifyCurlUp := func(g Gomega) {
+			cmd := exec.CommandContext(ctx, "kubectl", "get", "pods", "curl-metrics", "-o", "jsonpath={.status.phase}", "-n", namespace)
+			output, err := testutil.Run(cmd, GinkgoWriter)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
+		}
+		Eventually(verifyCurlUp, testutil.VeryLongTimeout).Should(Succeed())
+
+		By("getting the metrics by checking curl-metrics logs")
+		metricsOutput := getMetricsOutput(ctx)
+		Expect(metricsOutput).To(ContainSubstring("controller_runtime_webhook_panics_total"))
+	})
+
+	It("should provisioned cert-manager", func(ctx SpecContext) {
+		By("validating that cert-manager has the certificate Secret")
+		verifyCertManager := func(g Gomega) {
+			cmd := exec.CommandContext(ctx, "kubectl", "get", "secrets", "webhook-server-cert", "-n", namespace)
+			_, err := testutil.Run(cmd, GinkgoWriter)
+			g.Expect(err).NotTo(HaveOccurred())
+		}
+		Eventually(verifyCertManager).Should(Succeed())
+	})
+
+	It("should have CA injection for validating webhooks", func(ctx SpecContext) {
+		By("checking CA injection for validating webhooks")
+		verifyCAInjection := func(g Gomega) {
+			cmd := exec.CommandContext(ctx, "kubectl", "get",
+				"validatingwebhookconfigurations.admissionregistration.k8s.io",
+				"network-operator-validating-webhook-configuration",
+				"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
+			vwhOutput, err := testutil.Run(cmd, GinkgoWriter)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(vwhOutput)).To(BeNumerically(">", 10))
+		}
+		Eventually(verifyCAInjection).Should(Succeed())
+	})
+
+	// +kubebuilder:scaffold:e2e-webhooks-checks
+})
+
+// Reconciliation tests run in parallel across multiple Ginkgo processes.
+// Each test creates its own namespace and gnmi-test-server instance for isolation.
+var _ = Describe("Reconciliation", func() {
+	projectDir, err := testutil.GetProjectDir()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get project directory: %v", err))
+	}
+
+	// Get provider filter from environment (set by Makefile)
+	providerFilter := os.Getenv("E2E_PROVIDER")
+
+	testdataRoot := filepath.Join(projectDir, "test", "e2e", "testdata")
+	providerDirs, err := os.ReadDir(testdataRoot)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to read testdata directory: %v", err))
+	}
+
+	var testFiles []string
+	var providerName string
+	for _, providerDir := range providerDirs {
+		if !providerDir.IsDir() {
+			continue
+		}
+		providerName = providerDir.Name()
+
+		if providerFilter != "" && providerName != providerFilter {
+			continue
+		}
+
+		providerTestdataDir := filepath.Join(testdataRoot, providerName)
+
+		testFiles, err = filepath.Glob(filepath.Join(providerTestdataDir, "*.txt"))
+		if err != nil {
+			Fail(fmt.Sprintf("Failed to glob testdata: %v", err))
+		}
+		break
+	}
+
+	for _, testFile := range testFiles {
+		testName := filepath.Base(testFile)
+		testName = testName[:len(testName)-4] // remove .txt
+
+		It(fmt.Sprintf("should reconcile %s/%s", providerName, testName), func(ctx SpecContext) {
+			By("parsing testdata file")
+			a, err := txtar.ParseFile(testFile)
+			Expect(err).NotTo(HaveOccurred(), "Failed to parse test file: %s", testFile)
+
+			var state, preload []byte
+			var resources []txtar.File
+			for _, f := range a.Files {
+				switch f.Name {
+				case "state/expect":
+					state = f.Data
+				case "state/preload":
+					preload = f.Data
+				default:
+					resources = append(resources, f)
+				}
+			}
+			Expect(state).NotTo(BeEmpty(), "Expected '-- state/expect --' section in testdata")
+			Expect(resources).NotTo(BeEmpty(), "Expected at least one resource in testdata")
+
+			By("creating test namespace")
+			testNamespace := fmt.Sprintf("test-%s-%s-%s", providerName, strings.ReplaceAll(testName, "_", "-"), time.Now().Format("20060102150405"))
+			// Truncate to 63 chars max (K8s namespace limit)
+			if len(testNamespace) > 63 {
+				testNamespace = testNamespace[:63]
+			}
+			Expect(testEnv.CreateNamespace(ctx, testNamespace)).NotTo(HaveOccurred(), "Failed to create test namespace")
+
+			DeferCleanup(func(_ SpecContext) {
+				// Use a fresh context with generous timeout for cleanup
+				// The SpecContext may be nearly exhausted after test timeout
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+				defer cancel()
+
+				// Clean up test resources before deleting the gnmi-test-server pod to avoid issues with finalizers that require API access.
+				By("deleting test resources")
+				_ = testEnv.DeleteCustomResources(cleanupCtx, testNamespace) //nolint:errcheck // best-effort cleanup
+				By("deleting test namespace")
+				_ = testEnv.DeleteNamespace(cleanupCtx, testNamespace) //nolint:errcheck // best-effort cleanup
+			})
+
+			deviceName := fmt.Sprintf("test-device-%d", time.Now().UnixNano())
+
+			By("deploying a gnmi-test-server instance for this test")
+			gnmiAddr, err := testEnv.DeployGNMIServer(ctx, testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Failed to deploy gnmi-test-server")
+			Expect(gnmiAddr).ToNot(BeNil())
+
+			By("preloading gNMI state if specified")
+			if len(preload) > 0 {
+				err = testEnv.PreloadGNMIState(ctx, testNamespace, preload)
+				Expect(err).NotTo(HaveOccurred(), "Failed to preload gNMI state")
+			}
+
+			By("creating a test device")
+			device := fmt.Sprintf(`
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: Device
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    %s: ""
+spec:
+  endpoint:
+    address: "%s"`, deviceName, testNamespace, testutil.E2ETestLabel, gnmiAddr.String())
+			err = testutil.Apply(ctx, device, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply Device")
+
+			By("applying resources from testdata")
+			_, _ = fmt.Fprintf(GinkgoWriter, "DEBUG: Found %d resources to apply\n", len(resources))
+			for _, res := range resources {
+				_, _ = fmt.Fprintf(GinkgoWriter, "DEBUG: Applying resource: %s\n", res.Name)
+				err = testutil.ApplyWithPatch(ctx, string(res.Data), testNamespace, deviceName, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred(), "Failed to apply resource: %s", res.Name)
+			}
+
+			By("waiting for resources to be configured")
+			for _, res := range resources {
+				// Extract actual kind/name from YAML since section name may differ from metadata.name
+				resourceID, err := testutil.ExtractResourceIdentifier(string(res.Data))
+				Expect(err).NotTo(HaveOccurred(), "Failed to extract resource identifier from: %s", res.Name)
+				err = testutil.WaitForCondition(ctx, resourceID, testNamespace, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred(), "Resource not configured: %s", resourceID)
+			}
+
+			By("verifying gNMI state matches expected JSON")
+			gnmiState, err := testEnv.GetGNMIState(ctx, testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Failed to get gNMI state")
+
+			err = testutil.CompareJSON(string(gnmiState), string(state))
+			Expect(err).NotTo(HaveOccurred(), "gNMI state does not match expected JSON")
+		})
+	}
+})
+
+// serviceAccountToken returns a token for the specified service account in the given namespace.
+// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
+// and parsing the resulting token from the API response.
+func serviceAccountToken(ctx context.Context) (string, error) {
+	// #nosec G101
+	const tokenRequestRawString = `{
+		"apiVersion": "authentication.k8s.io/v1",
+		"kind": "TokenRequest"
+	}`
+
+	// Temporary file to store the token request
+	secretName := serviceAccountName + "-token-request"
+	tokenRequestFile := filepath.Join(os.TempDir(), secretName)
+	if err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644)); err != nil {
+		return "", err
+	}
+
+	var out string
+	verifyTokenCreation := func(g Gomega) {
+		// Execute kubectl command to create the token
+		// #nosec G204
+		cmd := exec.CommandContext(ctx, "kubectl", "create", "--raw", fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token", namespace, serviceAccountName), "-f", tokenRequestFile)
+		output, err := cmd.CombinedOutput()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Parse the JSON output to extract the token
+		var token tokenRequest
+		err = json.Unmarshal(output, &token)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		out = token.Status.Token
+	}
+	Eventually(verifyTokenCreation).Should(Succeed())
+
+	return out, nil
+}
+
+// getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
+func getMetricsOutput(ctx context.Context) string {
+	By("getting the curl-metrics logs")
+	cmd := exec.CommandContext(ctx, "kubectl", "logs", "curl-metrics", "-n", namespace)
+	metricsOutput, err := testutil.Run(cmd, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
+	Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
+	return metricsOutput
+}
+
+// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
+// containing only the token field that we need to extract.
+type tokenRequest struct {
+	Status struct {
+		Token string `json:"token"`
+	} `json:"status"`
+}
+
+// performCleanup ensures testEnv.Teardown is called exactly once
+func performCleanup() {
+	cleanupOnce.Do(func() {
+		if testEnv != nil {
+			fmt.Fprintf(os.Stderr, "Tearing down test environment...\n")
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.DefaultTimeout)
+			defer cancel()
+			if err := testEnv.Teardown(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to teardown test environment: %v\n", err)
+			}
+		}
+	})
+}
+
+// setupClusterDependencies installs Prometheus and CertManager if needed.
+// Called by cluster_suite_test.go.
+func setupClusterDependencies(ctx SpecContext) {
+	if !skipPrometheusInstall {
+		By("checking if prometheus is installed already")
+		isPrometheusOperatorAlreadyInstalled = testutil.IsPrometheusCRDsInstalled(ctx, GinkgoWriter)
+		if !isPrometheusOperatorAlreadyInstalled {
+			_, _ = fmt.Fprintf(GinkgoWriter, "Installing Prometheus Operator...\n")
+			Expect(testutil.InstallPrometheusOperator(ctx, GinkgoWriter)).To(Succeed(), "Failed to install Prometheus Operator")
+		} else {
+			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Prometheus Operator is already installed. Skipping installation...\n")
+		}
+	}
+	if !skipCertManagerInstall {
+		By("checking if cert manager is installed already")
+		isCertManagerAlreadyInstalled = testutil.IsCertManagerCRDsInstalled(ctx, GinkgoWriter)
+		if !isCertManagerAlreadyInstalled {
+			_, _ = fmt.Fprintf(GinkgoWriter, "Installing CertManager...\n")
+			Expect(testutil.InstallCertManager(ctx, GinkgoWriter)).To(Succeed(), "Failed to install CertManager")
+			// Fresh install - need to wait for webhook to be ready (can take up to 90s)
+			By("waiting for cert-manager webhook to be ready (fresh install)")
+			Expect(testutil.WaitForCertManagerWebhook(ctx, GinkgoWriter)).To(Succeed(), "Cert-manager webhook not ready")
+		} else {
+			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: CertManager is already installed. Skipping installation...\n")
+			// Already installed - webhook should be ready, but verify quickly
+		}
+	}
+}
+
+// cleanupClusterDependencies uninstalls Prometheus and CertManager if we installed them.
+// Called by cluster_suite_test.go.
+func cleanupClusterDependencies(ctx SpecContext) {
+	if !skipPrometheusInstall && !isPrometheusOperatorAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling Prometheus Operator...\n")
+		testutil.UninstallPrometheusOperator(ctx, GinkgoWriter)
+	}
+	if !skipCertManagerInstall && !isCertManagerAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling CertManager...\n")
+		testutil.UninstallCertManager(ctx, GinkgoWriter)
+	}
+}
+
+// buildAndLoadImages builds and loads Docker images to Kind.
+// Called by cluster_suite_test.go.
+func buildAndLoadImages(ctx SpecContext) {
+	By("building the manager(Operator) image")
+	cmd := exec.CommandContext(ctx, "make", "docker-build", "IMG="+image)
+	_, err := testutil.Run(cmd, GinkgoWriter)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
+
+	By("loading the manager(Operator) image on Kind")
+	err = testutil.LoadImageToKindClusterWithName(ctx, image, GinkgoWriter)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+
+	By("building the gnmi-test-server image")
+	cmd = exec.CommandContext(ctx, "make", "docker-build-test-gnmi-server", "TEST_SERVER_IMG="+serverImage)
+	_, err = testutil.Run(cmd, GinkgoWriter)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the gnmi-test-server image")
+
+	By("loading the gnmi-test-server image on Kind")
+	err = testutil.LoadImageToKindClusterWithName(ctx, serverImage, GinkgoWriter)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the gnmi-test-server image into Kind")
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build !cluster && !envtest
+
 // SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build !cluster && !envtest
+
 // SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/e2e/testdata/cisco-nxos-gnmi/interfaces.txt
+++ b/test/e2e/testdata/cisco-nxos-gnmi/interfaces.txt
@@ -1,0 +1,358 @@
+# Integration test for Interface resources
+#
+# Tests interface types and NX-OS specific InterfaceConfig:
+#   loopback-vtep  -> Loopback with IPv4 address
+#   uplink-spine1  -> Physical L3 with unnumbered IPv4 + BFD
+#   edge-port      -> Physical L2 with InterfaceConfig (STP edge, BufferBoost disabled)
+#   host-pc        -> Aggregate L2 with vPC, LACP, InterfaceConfig (STP network, LACP options)
+
+-- state/preload --
+{
+  "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    }
+  }
+}
+
+-- interfaceconfig/edge-port-config --
+apiVersion: nx.cisco.networking.metal.ironcore.dev/v1alpha1
+kind: InterfaceConfig
+metadata:
+  name: interface-nxconfig-edge
+  namespace: default
+spec:
+  bufferBoost:
+    enabled: false
+  spanningTree:
+    portType: Edge
+    bpduGuard: true
+
+-- interfaceconfig/host-pc-config --
+apiVersion: nx.cisco.networking.metal.ironcore.dev/v1alpha1
+kind: InterfaceConfig
+metadata:
+  name: interface-nxconfig-po
+  namespace: default
+spec:
+  lacp:
+    vpcConvergence: true
+    suspendIndividual: false
+  spanningTree:
+    portType: Network
+    bpduFilter: true
+
+-- interface/loopback-vtep --
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: Interface
+metadata:
+  labels:
+    networking.metal.ironcore.dev/device-name: device
+  name: loopback-vtep
+  namespace: default
+spec:
+  deviceRef:
+    name: device
+  name: lo0
+  description: NVE/VTEP Leaf1
+  adminState: Up
+  type: Loopback
+  ipv4:
+    addresses:
+      - 10.0.0.10/32
+
+-- interface/uplink-spine1 --
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: Interface
+metadata:
+  labels:
+    networking.metal.ironcore.dev/device-name: device
+  name: uplink-spine1
+  namespace: default
+spec:
+  deviceRef:
+    name: device
+  name: eth1/1
+  description: Leaf1 to Spine1
+  adminState: Up
+  type: Physical
+  mtu: 9216
+  ipv4:
+    unnumbered:
+      interfaceRef:
+        name: loopback-vtep
+  bfd:
+    enabled: true
+    desiredMinimumTxInterval: 300ms
+    requiredMinimumReceive: 300ms
+    detectionMultiplier: 3
+
+-- interface/edge-port --
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: Interface
+metadata:
+  name: edge-port
+  namespace: default
+  labels:
+    networking.metal.ironcore.dev/device: device
+spec:
+  deviceRef:
+    name: device
+  name: eth1/2
+  type: Physical
+  adminState: Up
+  mtu: 1500
+  description: "Edge port with STP and BufferBoost config"
+  providerConfigRef:
+    apiVersion: nx.cisco.networking.metal.ironcore.dev/v1alpha1
+    kind: InterfaceConfig
+    name: interface-nxconfig-edge
+  switchport:
+    mode: Trunk
+    nativeVlan: 1
+    allowedVlans:
+      - 10
+
+-- interface/host-pc --
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: Interface
+metadata:
+  name: host-pc
+  namespace: default
+  labels:
+    networking.metal.ironcore.dev/device: device
+spec:
+  deviceRef:
+    name: device
+  name: po10
+  type: Aggregate
+  adminState: Up
+  mtu: 1500
+  description: "vPC to Host with STP and LACP config"
+  providerConfigRef:
+    apiVersion: nx.cisco.networking.metal.ironcore.dev/v1alpha1
+    kind: InterfaceConfig
+    name: interface-nxconfig-po
+  switchport:
+    mode: Trunk
+    nativeVlan: 1
+    allowedVlans:
+      - 10
+  aggregation:
+    controlProtocol:
+      mode: Active
+    memberInterfaceRefs:
+      - name: edge-port
+    multichassis:
+      enabled: true
+      id: 2
+
+-- state/expect --
+{
+  "System": {
+    "bfd-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": [
+            {
+              "adminSt": "enabled",
+              "id": "eth1/1",
+              "ifka-items": {
+                "detectMult": 3,
+                "minRxIntvl": 300,
+                "minTxIntvl": 300
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "bfd-items": {
+        "adminSt": "enabled"
+      },
+      "lacp-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "ctrl": "port-unreachable,redirect",
+                    "id": "lo0"
+                  },
+                  {
+                    "ctrl": "port-unreachable",
+                    "id": "eth1/1"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "intf-items": {
+      "aggr-items": {
+        "AggrIf-list": [
+          {
+            "accessVlan": "vlan-1",
+            "adminSt": "up",
+            "aggrExtd-items": {
+              "bufferBoost": "enable"
+            },
+            "descr": "vPC to Host with STP and LACP config",
+            "id": "po10",
+            "lacpVpcConvergence": "enable",
+            "layer": "Layer2",
+            "medium": "broadcast",
+            "mode": "trunk",
+            "mtu": 1500,
+            "nativeVlan": "vlan-1",
+            "pcMode": "active",
+            "rsmbrIfs-items": {
+              "RsMbrIfs-list": [
+                {
+                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/2']"
+                }
+              ]
+            },
+            "suspIndividual": "disable",
+            "trunkVlans": "10",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
+          }
+        ]
+      },
+      "lb-items": {
+        "LbRtdIf-list": [
+          {
+            "adminSt": "up",
+            "descr": "NVE/VTEP Leaf1",
+            "id": "lo0",
+            "rtvrfMbr-items": {
+              "tDn": "/System/inst-items/Inst-list[name='default']"
+            }
+          }
+        ]
+      },
+      "phys-items": {
+        "PhysIf-list": [
+          {
+            "FECMode": "auto",
+            "accessVlan": "unknown",
+            "adminSt": "up",
+            "descr": "Leaf1 to Spine1",
+            "id": "eth1/1",
+            "layer": "Layer3",
+            "medium": "p2p",
+            "mode": "access",
+            "mtu": 9216,
+            "nativeVlan": "unknown",
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            },
+            "rtvrfMbr-items": {
+              "tDn": "/System/inst-items/Inst-list[name='default']"
+            },
+            "trunkVlans": "1-4094",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
+          },
+          {
+            "accessVlan": "vlan-1",
+            "adminSt": "up",
+            "descr": "Edge port with STP and BufferBoost config",
+            "FECMode": "auto",
+            "id": "eth1/2",
+            "layer": "Layer2",
+            "medium": "broadcast",
+            "mode": "trunk",
+            "mtu": 1500,
+            "nativeVlan": "vlan-1",
+            "trunkVlans": "10",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
+            "physExtd-items": {
+              "bufferBoost": "disable"
+            }
+          }
+        ]
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "addr-items": {
+                      "Addr-list": [
+                        {
+                          "addr": "10.0.0.10/32",
+                          "pref": 0,
+                          "tag": 0,
+                          "type": "primary"
+                        }
+                      ]
+                    },
+                    "id": "lo0"
+                  },
+                  {
+                    "id": "eth1/1",
+                    "unnumbered": "lo0"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "stp-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": [
+            {
+              "id": "eth1/2",
+              "mode": "edge",
+              "bpdufilter": "default",
+              "bpduguard": "enable"
+            },
+            {
+              "id": "po10",
+              "mode": "network",
+              "bpdufilter": "enable",
+              "bpduguard": "default"
+            }
+          ]
+        }
+      }
+    },
+    "vpc-items": {
+      "inst-items": {
+        "dom-items": {
+          "if-items": {
+            "If-list": [
+              {
+                "id": 2,
+                "rsvpcConf-items": {
+                  "tDn": "/System/intf-items/aggr-items/AggrIf-list[id='po10']"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "procsys-items": {
+      "bootTime": "1700000000"
+    }
+  }
+}

--- a/test/e2e/testutil/cluster.go
+++ b/test/e2e/testutil/cluster.go
@@ -1,0 +1,339 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+)
+
+var (
+	// gnmiPort is the port on which the gnmi-test-server listens for gNMI requests.
+	gnmiPort uint16 = 9339
+	// serverImage is the container image for the gnmi-test-server.
+	// This must match the image built by the Makefile.
+	serverImage = "ghcr.io/ironcore-dev/gnmi-test-server:latest"
+)
+
+// ClusterEnvironment enables end-to-end tests to run against a real Kubernetes cluster (e.g., Kind).
+// TODO: use native library instead of kubectl (follow up)
+type ClusterEnvironment struct {
+	restConfig *rest.Config
+	k8sClient  client.Client
+}
+
+// NewClusterEnvironment creates a new cluster-based test environment.
+func NewClusterEnvironment() *ClusterEnvironment {
+	return &ClusterEnvironment{}
+}
+
+// Setup connects to the existing cluster (CRDs should already be installed).
+func (c *ClusterEnvironment) Setup(ctx context.Context) error {
+	// Register schemes
+	if err := corev1.AddToScheme(scheme.Scheme); err != nil {
+		return err
+	}
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return err
+	}
+	if err := nxv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return err
+	}
+
+	// Get REST config from kubeconfig
+	var err error
+	c.restConfig = ctrl.GetConfigOrDie()
+
+	c.k8sClient, err = client.New(c.restConfig, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstallCRDs installs CRDs into the cluster. Should only be called once (from process 1).
+// Uses server-side apply to handle existing CRDs gracefully.
+func (c *ClusterEnvironment) InstallCRDs(ctx context.Context) error {
+	if err := c.runKubectl(ctx, "apply", "-k", "config/crd", "--server-side", "--force-conflicts"); err != nil {
+		return fmt.Errorf("failed to install CRDs: %w", err)
+	}
+	return nil
+}
+
+// DeployManager deploys the controller-manager and waits for it to be ready.
+// Should only be called once (from process 1).
+// Respects E2E_PROVIDER env var for provider selection.
+func (c *ClusterEnvironment) DeployManager(ctx context.Context) error {
+	dir, _ := GetProjectDir() //nolint:errcheck // uses current dir as fallback
+	env := os.Environ()
+	if provider := os.Getenv("E2E_PROVIDER"); provider != "" {
+		env = append(env, "PROVIDER="+provider)
+	}
+
+	// First deploy CRDs explicitly (make deploy also does this, but let's be sure)
+	cmd := exec.CommandContext(ctx, "make", "deploy-crds")
+	cmd.Dir = dir
+	cmd.Env = env
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to deploy CRDs: %s: %w", string(output), err)
+	}
+
+	// Then deploy the manager
+	cmd = exec.CommandContext(ctx, "make", "deploy")
+	cmd.Dir = dir
+	cmd.Env = env
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to deploy manager: %s: %w", string(output), err)
+	}
+
+	if err := c.runKubectl(ctx, "wait", "deployment/network-operator-controller-manager",
+		"-n", "network-operator-system",
+		"--for", "condition=Available",
+		"--timeout", "2m"); err != nil {
+		return fmt.Errorf("manager not ready: %w", err)
+	}
+	return nil
+}
+
+// UndeployManager undeploys the controller-manager.
+func (c *ClusterEnvironment) UndeployManager(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "make", "undeploy")
+	dir, _ := GetProjectDir() //nolint:errcheck // uses current dir as fallback
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to undeploy manager: %s: %w", string(output), err)
+	}
+	return nil
+}
+
+// Teardown cleans up CRDs.
+func (c *ClusterEnvironment) Teardown(ctx context.Context) error {
+	_ = c.runKubectl(ctx, "delete", "-k", "config/crd", "--ignore-not-found") //nolint:errcheck // best-effort cleanup
+	return nil
+}
+
+// Client returns the Kubernetes client.
+func (c *ClusterEnvironment) Client() client.Client {
+	return c.k8sClient
+}
+
+// RESTConfig returns the REST config.
+func (c *ClusterEnvironment) RESTConfig() *rest.Config {
+	return c.restConfig
+}
+
+// DeployGNMIServer deploys the gnmi-test-server pod and returns its gNMI address.
+func (c *ClusterEnvironment) DeployGNMIServer(ctx context.Context, namespace string) (netip.AddrPort, error) {
+	if err := c.runKubectl(
+		ctx,
+		"run", "gnmi-test-server",
+		"--image", serverImage,
+		"--image-pull-policy", "Never",
+		"--namespace", namespace,
+		"--restart", "Never",
+		"--port", "8000",
+		"--port", strconv.FormatUint(uint64(gnmiPort), 10),
+	); err != nil {
+		return netip.AddrPort{}, fmt.Errorf("failed to deploy gnmi-test-server: %w", err)
+	}
+
+	if err := c.runKubectl(
+		ctx,
+		"wait", "pods/gnmi-test-server",
+		"--for", "condition=Ready",
+		"--namespace", namespace,
+		"--timeout", "1m",
+	); err != nil {
+		return netip.AddrPort{}, fmt.Errorf("gnmi-test-server pod not ready: %w", err)
+	}
+
+	out, err := c.runKubectlOutput(
+		ctx,
+		"get", "pod", "gnmi-test-server",
+		"--output", "jsonpath={.status.podIP}",
+		"--namespace", namespace,
+	)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("failed to get gnmi-test-server IP: %w", err)
+	}
+	var s netip.Addr
+	if s, err = netip.ParseAddr(strings.TrimSpace(out)); err != nil {
+		return netip.AddrPort{}, fmt.Errorf("invalid IP address from gnmi-test-server pod: %w", err)
+	}
+
+	return netip.AddrPortFrom(s, gnmiPort), nil
+}
+
+// GetGNMIState fetches state via kubectl exec.
+func (c *ClusterEnvironment) GetGNMIState(ctx context.Context, namespace string) ([]byte, error) {
+	out, err := c.runKubectlOutput(
+		ctx,
+		"exec", "gnmi-test-server",
+		"--namespace", namespace,
+		"--",
+		"wget", "-qO-", "http://localhost:8000/v1/state",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gNMI state: %w", err)
+	}
+	return []byte(out), nil
+}
+
+// ClearGNMIState clears state.
+func (c *ClusterEnvironment) ClearGNMIState(ctx context.Context, namespace string) error {
+	_, err := c.runKubectlOutput(
+		ctx,
+		"exec", "gnmi-test-server",
+		"--namespace", namespace,
+		"--",
+		"wget", "-qO-", "--post-data=", "http://localhost:8000/v1/clear",
+	)
+	return err
+}
+
+// PreloadGNMIState preloads nested JSON into the gnmi-test-server state.
+// This allows tests to set up paths like System/procsys-items/bootTime
+// before the Device controller reconciles.
+func (c *ClusterEnvironment) PreloadGNMIState(ctx context.Context, namespace string, jsonData []byte) error {
+	_, err := c.runKubectlOutput(
+		ctx,
+		"exec", "gnmi-test-server",
+		"--namespace", namespace,
+		"--",
+		"wget", "-qO-", "--post-data="+string(jsonData), "http://localhost:8000/v1/state",
+	)
+	return err
+}
+
+// runKubectl runs a kubectl command and returns an error if it fails.
+func (c *ClusterEnvironment) runKubectl(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	dir, _ := GetProjectDir() //nolint:errcheck // uses current dir as fallback
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", string(output), err)
+	}
+	return nil
+}
+
+// runKubectlOutput runs a kubectl command and returns its output.
+func (c *ClusterEnvironment) runKubectlOutput(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	dir, _ := GetProjectDir() //nolint:errcheck // uses current dir as fallback
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s: %w", stderr.String(), err)
+	}
+	return stdout.String(), nil
+}
+
+// DeleteNamespace deletes the given namespace.
+func (c *ClusterEnvironment) DeleteNamespace(ctx context.Context, namespace string) error {
+	if err := c.runKubectl(ctx, "delete", "namespace", namespace, "--ignore-not-found"); err != nil {
+		return fmt.Errorf("failed to delete namespace %s: %w", namespace, err)
+	}
+	return nil
+}
+
+// CreateNamespace creates a new namespace with the given name and labels it for cleanup tracking.
+func (c *ClusterEnvironment) CreateNamespace(ctx context.Context, namespace string) error {
+	if err := c.runKubectl(ctx, "create", "namespace", namespace); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", namespace, err)
+	}
+	// Label the namespace for cleanup tracking across parallel test processes
+	if err := c.runKubectl(ctx, "label", "namespace", namespace, E2ETestLabel+"="); err != nil {
+		return fmt.Errorf("failed to label namespace %s: %w", namespace, err)
+	}
+	return nil
+}
+
+// WaitForTestNamespacesGone waits for all labeled test namespaces to be fully deleted.
+// This ensures DeferCleanup hooks have completed before the manager is undeployed.
+// Without this, the manager (and CRDs) may be deleted while resources with finalizers still exist,
+// leaving them stuck forever because the controller can no longer process the finalizers.
+func (c *ClusterEnvironment) WaitForTestNamespacesGone(ctx context.Context) error {
+	// Get all namespaces with our e2e test label
+	out, err := c.runKubectlOutput(
+		ctx,
+		"get", "namespaces",
+		"-l", E2ETestLabel,
+		"-o", "jsonpath={.items[*].metadata.name}",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to list test namespaces: %w", err)
+	}
+
+	namespaces := strings.Fields(out)
+	if len(namespaces) == 0 {
+		return nil
+	}
+
+	// Wait for each test namespace to be deleted (with timeout)
+	for _, ns := range namespaces {
+		_ = c.runKubectl(ctx, "wait", "namespace", ns, //nolint:errcheck // best-effort cleanup
+			"--for=delete",
+			"--timeout=120s")
+	}
+
+	return nil
+}
+
+// DeleteCustomResources deletes all custom resources in the given namespace.
+// Deletion order: CoreResources first (have finalizers), then ConfigResources, then Device.
+// This allows finalizers to complete while their dependencies still exist.
+func (c *ClusterEnvironment) DeleteCustomResources(ctx context.Context, namespace string) error {
+	deleteResources := func(gvks []schema.GroupVersionKind) {
+		for _, gvk := range gvks {
+			_ = c.runKubectl(ctx, "delete", //nolint:errcheck // best-effort cleanup
+				ResourcePluralName(gvk), "--all",
+				"--namespace", namespace,
+				"--ignore-not-found")
+		}
+		// Wait for resources to be fully gone (finalizers completed)
+		for _, gvk := range gvks {
+			_ = c.runKubectl(ctx, "wait", //nolint:errcheck // best-effort cleanup
+				ResourcePluralName(gvk),
+				"--for=delete", "--all",
+				"--namespace", namespace,
+				"--timeout=60s")
+		}
+	}
+
+	// Delete core resources first (have finalizers that need Device + configs)
+	deleteResources(CoreResources)
+	// Then delete config resources
+	deleteResources(ConfigResources)
+
+	// Delete Device LAST - after all other resources and their finalizers are done
+	_ = c.runKubectl(ctx, "delete", "devices", "--all", //nolint:errcheck // best-effort cleanup
+		"--namespace", namespace,
+		"--ignore-not-found")
+	_ = c.runKubectl(ctx, "wait", "devices", //nolint:errcheck // best-effort cleanup
+		"--for=delete", "--all",
+		"--namespace", namespace,
+		"--timeout=60s")
+
+	return nil
+}

--- a/test/e2e/testutil/doc.go
+++ b/test/e2e/testutil/doc.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testutil provides test infrastructure for e2e tests.
+//
+// It supports two test modes selected by build tags:
+//
+//   - Envtest (build tag: envtest): Uses controller-runtime's envtest.Environment
+//     with an in-process gNMI test server. Fast (~10s) but doesn't test deployment.
+//
+//   - Cluster (default): Uses a real Kubernetes cluster (typically Kind) with a
+//     deployed operator and gnmi-test-server pod. Slower (~2-5min) but tests full stack.
+//
+// The concrete types ClusterEnvironment and EnvtestEnvironment provide the same
+// methods, allowing test logic to work with either mode via build tag selection.
+package testutil

--- a/test/e2e/testutil/helpers.go
+++ b/test/e2e/testutil/helpers.go
@@ -1,0 +1,547 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	prometheusURL  = "https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.82.2/bundle.yaml"
+	certmanagerURL = "https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml"
+)
+
+// warnError writes a warning to the provided writer.
+func warnError(w io.Writer, err error) {
+	_, _ = fmt.Fprintf(w, "warning: %v\n", err)
+}
+
+// Run executes the provided command within this context.
+// It writes the command to the provided writer for logging.
+func Run(cmd *exec.Cmd, w io.Writer) (string, error) {
+	dir, err := GetProjectDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project directory: %w", err)
+	}
+
+	cmd.Dir = dir
+	if err = os.Chdir(cmd.Dir); err != nil {
+		_, _ = fmt.Fprintf(w, "chdir dir: %s\n", err)
+	}
+
+	command := strings.Join(cmd.Args, " ")
+	// #nosec G705
+	_, _ = fmt.Fprintf(w, "running: %s\n", command)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("%s failed with error: (%w) %s", command, err, string(output))
+	}
+
+	return string(output), nil
+}
+
+// Apply takes a raw YAML resource and applies it to the cluster by
+// creating a temporary file and running 'kubectl apply -f'.
+func Apply(ctx context.Context, resource string, w io.Writer) error {
+	file, err := os.CreateTemp("", "resource-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	// #nosec G703
+	defer func() { _ = os.Remove(file.Name()) }()
+	if _, err = file.WriteString(resource); err != nil {
+		return fmt.Errorf("failed to write to temp file: %w", err)
+	}
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	// #nosec G204 G702
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", file.Name())
+	if _, err = Run(cmd, w); err != nil {
+		return fmt.Errorf("failed to apply resource: %w", err)
+	}
+	return nil
+}
+
+// ExtractResourceIdentifier parses YAML and returns "kind/name" for use with kubectl wait.
+// The kind is lowercased to match kubectl's resource type format.
+func ExtractResourceIdentifier(resourceYAML string) (string, error) {
+	var obj unstructured.Unstructured
+	if err := yaml.Unmarshal([]byte(resourceYAML), &obj); err != nil {
+		return "", fmt.Errorf("failed to unmarshal YAML: %w", err)
+	}
+
+	kind := strings.ToLower(obj.GetKind())
+	name := obj.GetName()
+	if kind == "" || name == "" {
+		return "", errors.New("YAML missing kind or metadata.name")
+	}
+
+	return kind + "/" + name, nil
+}
+
+// CompareJSON compares two JSON strings and returns an error if they are not equal.
+// For comparison, it unmarshals both into interface{} and uses reflect.DeepEqual
+// after sorting any arrays and removing empty arrays/objects to ignore ordering
+// and cleanup artifacts.
+func CompareJSON(got, want string) error {
+	var gotObj, wantObj any
+	if err := json.Unmarshal([]byte(got), &gotObj); err != nil {
+		return fmt.Errorf("failed to unmarshal got JSON: %w", err)
+	}
+	if err := json.Unmarshal([]byte(want), &wantObj); err != nil {
+		return fmt.Errorf("failed to unmarshal want JSON: %w", err)
+	}
+
+	// Normalize both objects (sort arrays, remove empty containers)
+	gotObj = normalizeJSON(gotObj)
+	wantObj = normalizeJSON(wantObj)
+
+	if !reflect.DeepEqual(gotObj, wantObj) {
+		// For error message, show original compacted JSON (not normalized)
+		// so empty objects show as {} not null
+		var gotBuf, wantBuf bytes.Buffer
+		_ = json.Compact(&gotBuf, []byte(got))   //nolint:errcheck // already parsed successfully above
+		_ = json.Compact(&wantBuf, []byte(want)) //nolint:errcheck // already parsed successfully above
+		return fmt.Errorf("JSON mismatch:\ngot:  %s\nwant: %s", gotBuf.String(), wantBuf.String())
+	}
+	return nil
+}
+
+// normalizeJSON recursively sorts arrays and removes empty arrays/objects
+// to make comparison order-independent and ignore cleanup artifacts.
+func normalizeJSON(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any)
+		for k, v := range val {
+			normalized := normalizeJSON(v)
+			// Skip empty maps and empty arrays
+			if !isEmpty(normalized) {
+				result[k] = normalized
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	case []any:
+		var result []any
+		for _, elem := range val {
+			normalized := normalizeJSON(elem)
+			if !isEmpty(normalized) {
+				result = append(result, normalized)
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		// Sort the array by JSON representation
+		sort.Slice(result, func(i, j int) bool {
+			bi, _ := json.Marshal(result[i]) //nolint:errcheck // sorting comparison, errors treated as equal
+			bj, _ := json.Marshal(result[j]) //nolint:errcheck // sorting comparison, errors treated as equal
+			return string(bi) < string(bj)
+		})
+		return result
+	default:
+		return v
+	}
+}
+
+// isEmpty checks if a value is an empty map, empty array, or nil.
+func isEmpty(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch val := v.(type) {
+	case map[string]any:
+		return len(val) == 0
+	case []any:
+		return len(val) == 0
+	}
+	return false
+}
+
+// InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
+func InstallPrometheusOperator(ctx context.Context, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "create", "-f", prometheusURL)
+	_, err := Run(cmd, w)
+	return err
+}
+
+// UninstallPrometheusOperator uninstalls the prometheus
+func UninstallPrometheusOperator(ctx context.Context, w io.Writer) {
+	cmd := exec.CommandContext(ctx, "kubectl", "delete", "-f", prometheusURL)
+	if _, err := Run(cmd, w); err != nil {
+		warnError(w, err)
+	}
+}
+
+// IsPrometheusCRDsInstalled checks if any Prometheus CRDs are installed
+// by verifying the existence of key CRDs related to Prometheus.
+func IsPrometheusCRDsInstalled(ctx context.Context, w io.Writer) bool {
+	// List of common Prometheus CRDs
+	prometheusCRDs := []string{
+		"prometheuses.monitoring.coreos.com",
+		"prometheusrules.monitoring.coreos.com",
+		"prometheusagents.monitoring.coreos.com",
+	}
+
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "crds", "-o", "custom-columns=NAME:.metadata.name")
+	output, err := Run(cmd, w)
+	if err != nil {
+		return false
+	}
+	crdList := GetNonEmptyLines(output)
+	for _, crd := range prometheusCRDs {
+		for _, line := range crdList {
+			if strings.Contains(line, crd) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// InstallCertManager installs the cert manager bundle.
+func InstallCertManager(ctx context.Context, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", certmanagerURL)
+	if _, err := Run(cmd, w); err != nil {
+		return err
+	}
+	// Wait for cert-manager-webhook to be ready, which can take time if cert-manager
+	// was re-installed after uninstalling on a cluster.
+	cmd = exec.CommandContext(
+		ctx, "kubectl", "wait", "deployment.apps/cert-manager-webhook",
+		"--for", "condition=Available",
+		"--namespace", "cert-manager",
+		"--timeout", "5m",
+	)
+	if _, err := Run(cmd, w); err != nil {
+		return err
+	}
+
+	// Wait for webhook to be fully operational (TLS cert ready)
+	// The deployment being Available doesn't mean the webhook TLS is ready
+	cmd = exec.CommandContext(
+		ctx, "kubectl", "wait", "certificate/cert-manager-webhook-ca",
+		"--for", "condition=Ready",
+		"--namespace", "cert-manager",
+		"--timeout", "2m",
+	)
+	_, _ = Run(cmd, w) //nolint:errcheck // cert may not exist in older versions
+
+	// Give the webhook a moment to pick up the cert
+	time.Sleep(5 * time.Second)
+	return nil
+}
+
+// UninstallCertManager uninstalls the cert manager
+func UninstallCertManager(ctx context.Context, w io.Writer) {
+	cmd := exec.CommandContext(ctx, "kubectl", "delete", "-f", certmanagerURL)
+	if _, err := Run(cmd, w); err != nil {
+		warnError(w, err)
+	}
+}
+
+// WaitForCertManagerWebhook waits for the cert-manager webhook to be fully operational.
+// This should be called before deploying resources that use cert-manager certificates.
+func WaitForCertManagerWebhook(ctx context.Context, w io.Writer) error {
+	// Wait for deployment to be available
+	cmd := exec.CommandContext(
+		ctx, "kubectl", "wait", "deployment.apps/cert-manager-webhook",
+		"--for", "condition=Available",
+		"--namespace", "cert-manager",
+		"--timeout", "2m",
+	)
+	if _, err := Run(cmd, w); err != nil {
+		return err
+	}
+
+	// Wait for the CA injector to inject the CA bundle into the webhook
+	cmd = exec.CommandContext(
+		ctx, "kubectl", "wait", "deployment.apps/cert-manager-cainjector",
+		"--for", "condition=Available",
+		"--namespace", "cert-manager",
+		"--timeout", "2m",
+	)
+	if _, err := Run(cmd, w); err != nil {
+		return err
+	}
+
+	// Wait for the cainjector to inject the CA bundle into the webhook configuration
+	// This is what actually makes the webhook work - the API server needs the CA to verify the webhook's TLS cert
+	cmd = exec.CommandContext(
+		ctx, "kubectl", "wait", "validatingwebhookconfiguration/cert-manager-webhook",
+		"--for", "jsonpath={.webhooks[0].clientConfig.caBundle}",
+		"--timeout", "2m",
+	)
+	if _, err := Run(cmd, w); err != nil {
+		return fmt.Errorf("cert-manager webhook CA bundle not injected: %w", err)
+	}
+
+	return nil
+}
+
+// IsCertManagerCRDsInstalled checks if any Cert Manager CRDs are installed
+// by verifying the existence of key CRDs related to Cert Manager.
+func IsCertManagerCRDsInstalled(ctx context.Context, w io.Writer) bool {
+	// List of common Cert Manager CRDs
+	certManagerCRDs := []string{
+		"certificates.cert-manager.io",
+		"issuers.cert-manager.io",
+		"clusterissuers.cert-manager.io",
+		"certificaterequests.cert-manager.io",
+		"orders.acme.cert-manager.io",
+		"challenges.acme.cert-manager.io",
+	}
+
+	// Execute the kubectl command to get all CRDs
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "crds")
+	output, err := Run(cmd, w)
+	if err != nil {
+		return false
+	}
+
+	// Check if any of the Cert Manager CRDs are present
+	crdList := GetNonEmptyLines(output)
+	for _, crd := range certManagerCRDs {
+		for _, line := range crdList {
+			if strings.Contains(line, crd) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// LoadImageToKindClusterWithName loads a local docker image to the kind cluster
+func LoadImageToKindClusterWithName(ctx context.Context, name string, w io.Writer) error {
+	cluster := "kind"
+	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
+		cluster = v
+	}
+	// See: https://kind.sigs.k8s.io/docs/user/rootless/#creating-a-kind-cluster-with-rootless-nerdctl
+	prov, ok := os.LookupEnv("KIND_EXPERIMENTAL_PROVIDER")
+	if ok && prov != "docker" {
+		// If kind is configured to not use the docker runtime (e.g. when using podman or nerctl),
+		// we need to create a temp file to store the image archive and load it as a tarball.
+		// See: https://github.com/kubernetes-sigs/kind/issues/2760
+		file, err := os.CreateTemp("", "operator-image-")
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %w", err)
+		}
+		_ = file.Close()
+		// #nosec G703
+		defer func() { _ = os.Remove(file.Name()) }()
+
+		// https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md#whale-nerdctl-save
+		// https://docs.podman.io/en/v5.3.0/markdown/podman-save.1.html
+		// #nosec G702
+		cmd := exec.CommandContext(ctx, prov, "save", name, "--output", file.Name())
+		if _, err = Run(cmd, w); err != nil {
+			return fmt.Errorf("failed to save image: %w", err)
+		}
+
+		cmd = exec.CommandContext(ctx, "kind", "load", "image-archive", file.Name(), "--name", cluster) //nolint:gosec
+		_, err = Run(cmd, w)
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", name, "--name", cluster)
+	_, err := Run(cmd, w)
+	return err
+}
+
+// GetNonEmptyLines converts given command output string into individual objects
+// according to line breakers, and ignores the empty elements in it.
+func GetNonEmptyLines(output string) []string {
+	var res []string
+	for element := range strings.SplitSeq(output, "\n") {
+		if element != "" {
+			res = append(res, element)
+		}
+	}
+	return res
+}
+
+// GetProjectDir will return the directory where the project is
+func GetProjectDir() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return wd, err
+	}
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
+	return wd, nil
+}
+
+// PatchResourceYAML takes a raw YAML resource and patches its namespace and deviceRef.
+// This allows txtar test files to have placeholder values that get replaced at runtime.
+// It returns the patched YAML string ready for kubectl apply.
+func PatchResourceYAML(resourceYAML, namespace, deviceName string) (string, error) {
+	// Parse YAML into unstructured map
+	var obj map[string]any
+	if err := yaml.Unmarshal([]byte(resourceYAML), &obj); err != nil {
+		return "", fmt.Errorf("failed to unmarshal YAML: %w", err)
+	}
+
+	// Patch metadata.namespace
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		metadata = make(map[string]any)
+		obj["metadata"] = metadata
+	}
+	metadata["namespace"] = namespace
+
+	// Ensure labels map exists and add e2e test label
+	labels, ok := metadata["labels"].(map[string]any)
+	if !ok {
+		labels = make(map[string]any)
+		metadata["labels"] = labels
+	}
+	labels[E2ETestLabel] = ""
+
+	// Patch spec.deviceRef.name if it exists
+	if spec, ok := obj["spec"].(map[string]any); ok {
+		if deviceRef, ok := spec["deviceRef"].(map[string]any); ok {
+			deviceRef["name"] = deviceName
+		}
+	}
+
+	// Patch the device label if it exists
+	if _, hasDeviceLabel := labels["networking.metal.ironcore.dev/device"]; hasDeviceLabel {
+		labels["networking.metal.ironcore.dev/device"] = deviceName
+	}
+
+	// Marshal back to YAML
+	out, err := yaml.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal patched YAML: %w", err)
+	}
+	return string(out), nil
+}
+
+// ApplyWithPatch applies a YAML resource after patching its namespace and deviceRef.
+// This is the cluster-mode equivalent of envtest's createResourceFromTxtar.
+func ApplyWithPatch(ctx context.Context, resourceYAML, namespace, deviceName string, w io.Writer) error {
+	patched, err := PatchResourceYAML(resourceYAML, namespace, deviceName)
+	if err != nil {
+		return err
+	}
+	return Apply(ctx, patched, w)
+}
+
+// WaitForCondition waits for a resource to have a condition set to True.
+// It tries "Configured" first, falls back to "Ready" if Configured doesn't exist.
+// Skips config-only resources that don't have status conditions.
+func WaitForCondition(ctx context.Context, resourceName, namespace string, w io.Writer) error {
+	// Config-only resources don't have status conditions - skip them
+	// resourceName format is "kind/name" e.g. "bgpconfig/evpn-settings"
+	kind := strings.Split(resourceName, "/")[0]
+	switch strings.ToLower(kind) {
+	case "interfaceconfig", "lldpconfig", "bgpconfig", "nveconfig", "managementaccessconfig":
+		return nil // No conditions to wait for
+	}
+
+	// Try Configured first using jsonpath (more reliable than --for condition=X with multiple conditions)
+	cmd := exec.CommandContext(
+		ctx, "kubectl", "wait", resourceName,
+		"--for", `jsonpath={.status.conditions[?(@.type=="Configured")].status}=True`,
+		"--namespace", namespace,
+		"--timeout", "10s",
+	)
+	if _, err := Run(cmd, w); err == nil {
+		return nil
+	}
+
+	// Fallback to Ready using jsonpath (condition=Ready doesn't work reliably with custom resources)
+	cmd = exec.CommandContext(
+		ctx, "kubectl", "wait", resourceName,
+		"--for", `jsonpath={.status.conditions[?(@.type=="Ready")].status}=True`,
+		"--namespace", namespace,
+		"--timeout", "2m",
+	)
+	_, err := Run(cmd, w)
+	return err
+}
+
+// UncommentCode searches for target in the file and remove the comment prefix
+// of the target content. The target content may span multiple lines.
+func UncommentCode(filename, target, prefix string) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	before, after, ok := bytes.Cut(content, []byte(target))
+	if !ok {
+		if bytes.Contains(content, []byte(target)[len(prefix):]) {
+			return nil // already uncommented
+		}
+
+		return fmt.Errorf("unable to find the code %s to be uncomment", target)
+	}
+
+	out := new(bytes.Buffer)
+	if _, err = out.Write(before); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewBufferString(target))
+	if !scanner.Scan() {
+		return nil
+	}
+	for {
+		_, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
+		if err != nil {
+			return err
+		}
+		// Avoid writing a newline in case the previous line was the last in target.
+		if !scanner.Scan() {
+			break
+		}
+		if _, err = out.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+
+	if _, err = out.Write(after); err != nil {
+		return err
+	}
+
+	return os.WriteFile(filename, out.Bytes(), 0o644)
+}
+
+// ExtractConditions extracts status conditions from an unstructured object
+// into a typed []metav1.Condition slice for use with apimeta helpers.
+func ExtractConditions(obj *unstructured.Unstructured) ([]metav1.Condition, error) {
+	raw, _, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var conditions []metav1.Condition
+	return conditions, json.Unmarshal(data, &conditions)
+}

--- a/test/e2e/testutil/provider.go
+++ b/test/e2e/testutil/provider.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+	"github.com/ironcore-dev/network-operator/internal/provider"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/iosxr"
+	"github.com/ironcore-dev/network-operator/internal/provider/cisco/nxos"
+)
+
+// E2ETestLabel is the label key applied to resources created by e2e tests for cleanup tracking.
+const E2ETestLabel = "networking.metal.ironcore.dev/e2e-test"
+
+// ProviderType represents the network device provider to test against.
+type ProviderType string
+
+// ProviderFactory creates a new provider instance.
+type ProviderFactory = func() provider.Provider
+
+// Provider names must match the registered provider names in internal/provider/*/provider.go
+const (
+	ProviderNXOS  ProviderType = "cisco-nxos-gnmi"
+	ProviderIOSXR ProviderType = "cisco-iosxr-gnmi"
+)
+
+// ProviderConfig holds the configuration for a provider test.
+type ProviderConfig struct {
+	Name        ProviderType
+	NewProvider ProviderFactory
+}
+
+// SupportedProviders lists all providers to test.
+var SupportedProviders = []ProviderConfig{
+	{Name: ProviderNXOS, NewProvider: func() provider.Provider { return nxos.NewProvider() }},
+	{Name: ProviderIOSXR, NewProvider: func() provider.Provider { return iosxr.NewProvider() }},
+}
+
+// CoreResources are the main API resources with finalizers.
+// During cleanup, these are deleted FIRST so their finalizers can
+// complete while Device and config resources still exist.
+var CoreResources = []schema.GroupVersionKind{
+	v1alpha1.GroupVersion.WithKind("Interface"),
+	v1alpha1.GroupVersion.WithKind("VLAN"),
+	v1alpha1.GroupVersion.WithKind("VRF"),
+	v1alpha1.GroupVersion.WithKind("NTP"),
+	v1alpha1.GroupVersion.WithKind("DNS"),
+	v1alpha1.GroupVersion.WithKind("LLDP"),
+	v1alpha1.GroupVersion.WithKind("Banner"),
+	v1alpha1.GroupVersion.WithKind("OSPF"),
+	v1alpha1.GroupVersion.WithKind("PIM"),
+	v1alpha1.GroupVersion.WithKind("NetworkVirtualizationEdge"),
+	v1alpha1.GroupVersion.WithKind("EVPNInstance"),
+	v1alpha1.GroupVersion.WithKind("RoutingPolicy"),
+	v1alpha1.GroupVersion.WithKind("PrefixSet"),
+	v1alpha1.GroupVersion.WithKind("BGP"),
+	v1alpha1.GroupVersion.WithKind("BGPPeer"),
+	v1alpha1.GroupVersion.WithKind("Syslog"),
+	v1alpha1.GroupVersion.WithKind("SNMP"),
+	v1alpha1.GroupVersion.WithKind("ManagementAccess"),
+	v1alpha1.GroupVersion.WithKind("AccessControlList"),
+	v1alpha1.GroupVersion.WithKind("DHCPRelay"),
+	v1alpha1.GroupVersion.WithKind("ISIS"),
+}
+
+// ConfigResources are provider-specific config resources (e.g., NX-OS configs).
+// During cleanup, these are deleted AFTER core resources.
+var ConfigResources = []schema.GroupVersionKind{
+	nxv1alpha1.GroupVersion.WithKind("InterfaceConfig"),
+	nxv1alpha1.GroupVersion.WithKind("LLDPConfig"),
+	nxv1alpha1.GroupVersion.WithKind("BGPConfig"),
+	nxv1alpha1.GroupVersion.WithKind("VPCDomain"),
+}
+
+// ResourcePluralName returns the plural resource name for a GVK.
+// These must match the CRD spec.names.plural values (from `kubectl api-resources`).
+// We can't use meta.UnsafeGuessKindToResource because CRDs define their own plurals
+// which don't always follow standard Kubernetes pluralization rules.
+func ResourcePluralName(gvk schema.GroupVersionKind) string {
+	plurals := map[string]string{
+		"Interface":                 "interfaces",
+		"VLAN":                      "vlans",
+		"VRF":                       "vrfs",
+		"NTP":                       "ntp",
+		"DNS":                       "dns",
+		"LLDP":                      "lldps",
+		"Banner":                    "banners",
+		"OSPF":                      "ospf",
+		"PIM":                       "pim",
+		"NetworkVirtualizationEdge": "networkvirtualizationedges",
+		"EVPNInstance":              "evpninstances",
+		"InterfaceConfig":           "interfaceconfigs",
+		"LLDPConfig":                "lldpconfigs",
+		"VPCDomain":                 "vpcdomains",
+		"BGPConfig":                 "bgpconfigs",
+		"RoutingPolicy":             "routingpolicies",
+		"PrefixSet":                 "prefixsets",
+		"BGP":                       "bgp",
+		"BGPPeer":                   "bgppeers",
+		"Syslog":                    "syslogs",
+		"SNMP":                      "snmp",
+		"ManagementAccess":          "managementaccesses",
+		"AccessControlList":         "accesscontrollists",
+		"DHCPRelay":                 "dhcprelays",
+		"ISIS":                      "isis",
+		"Device":                    "devices",
+	}
+	if plural, ok := plurals[gvk.Kind]; ok {
+		return plural
+	}
+	// Fallback to standard pluralization
+	plural, _ := meta.UnsafeGuessKindToResource(gvk)
+	return plural.Resource
+}
+
+// CreateTestDevice creates a Device pointing to the gNMI server with a generated name.
+func CreateTestDevice(ctx context.Context, c client.Client, gnmiAddr, namespace string) (*v1alpha1.Device, error) {
+	device := &v1alpha1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-device-",
+			Namespace:    namespace,
+		},
+		Spec: v1alpha1.DeviceSpec{
+			Endpoint: v1alpha1.Endpoint{
+				Address: gnmiAddr,
+			},
+		},
+	}
+	if err := c.Create(ctx, device); err != nil {
+		return nil, err
+	}
+
+	// Set the device status to Running so that dependent resources can reconcile
+	device.Status.Phase = v1alpha1.DevicePhaseRunning
+	if err := c.Status().Update(ctx, device); err != nil {
+		return nil, err
+	}
+
+	return device, nil
+}
+
+// CleanupTimeout is the timeout for cleanup operations.
+const CleanupTimeout = 30 * time.Second
+
+// CleanupInterval is the polling interval for cleanup operations.
+const CleanupInterval = 100 * time.Millisecond

--- a/test/e2e/testutil/timeouts.go
+++ b/test/e2e/testutil/timeouts.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import "time"
+
+const (
+	// DefaultTimeout is used for standard resource reconciliation
+	DefaultTimeout = 30 * time.Second
+
+	// LongTimeout is used for operations that may take longer (deployments, pod starts)
+	LongTimeout = 2 * time.Minute
+
+	// VeryLongTimeout is used for end-to-end scenarios with multiple dependencies
+	VeryLongTimeout = 5 * time.Minute
+)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -1,3 +1,5 @@
+//go:build !cluster && !envtest
+
 // SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/test/gnmi/Dockerfile
+++ b/test/gnmi/Dockerfile
@@ -12,17 +12,14 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 
-# Install dependencies
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=bind,source=go.mod,target=go.mod \
-    --mount=type=bind,source=go.sum,target=go.sum \
-    go mod download -x
+# Copy source files
+COPY go.mod go.sum ./
+RUN go mod download -x
+
+COPY . .
 
 # Build the application into a static executable while removing the symbol table and debugging information
-RUN --mount=type=bind,target=. \
-    --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /usr/bin/server ./main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /usr/bin/server ./main.go
 
 FROM alpine:${ALPINE_VERSION}
 
@@ -39,5 +36,5 @@ USER 65532:65532
 # Switch into workspace
 WORKDIR /
 
-# Start the server application
-CMD ["/server", "--port=9339", "--http-port=8000"]
+# Start the server application with NX-OS behavior enabled
+CMD ["/server", "--port=9339", "--http-port=8000", "--nxos"]

--- a/test/gnmi/main.go
+++ b/test/gnmi/main.go
@@ -4,362 +4,57 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/tls"
-	"encoding/json"
 	"flag"
-	"fmt"
-	"io"
 	"log"
-	"net"
-	"net/http"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
+	"os"
+	"os/signal"
+	"syscall"
 
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
-	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/reflection"
-	"google.golang.org/grpc/status"
-
-	gtls "github.com/openconfig/gnmi/testing/fake/testing/tls"
+	"github.com/ironcore-dev/gnmi-test-server/testserver"
 )
-
-var _ gpb.GNMIServer = (*Server)(nil)
-
-// Server implements the GNMI gRPC server
-type Server struct {
-	gpb.UnimplementedGNMIServer
-
-	State *State
-}
-
-func (s *Server) Capabilities(_ context.Context, _ *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
-	return &gpb.CapabilityResponse{SupportedEncodings: []gpb.Encoding{gpb.Encoding_JSON}}, nil
-}
-
-func (s *Server) Get(_ context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
-	notifications := make([]*gpb.Notification, 0, len(req.GetPath()))
-	for _, path := range req.GetPath() {
-		if len(path.GetElem()) == 0 {
-			return nil, status.Error(codes.InvalidArgument, "root path is not allowed")
-		}
-		log.Printf("Getting path: %v", path)
-		notifications = append(notifications, &gpb.Notification{
-			Timestamp: time.Now().UnixNano(),
-			Update: []*gpb.Update{
-				{
-					Path: path,
-					Val: &gpb.TypedValue{
-						Value: &gpb.TypedValue_JsonVal{
-							JsonVal: s.State.Get(path),
-						},
-					},
-				},
-			},
-		})
-	}
-	return &gpb.GetResponse{
-		Notification: notifications,
-	}, nil
-}
-
-func (s *Server) Set(_ context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
-	log.Printf("Received Set request: %v", req)
-	res := make([]*gpb.UpdateResult, 0, len(req.GetDelete())+len(req.GetUpdate()))
-	for _, del := range req.GetDelete() {
-		log.Printf("Deleting path: %v", del)
-		res = append(res, &gpb.UpdateResult{
-			Timestamp: time.Now().UnixNano(),
-			Path:      del,
-			Op:        gpb.UpdateResult_DELETE,
-		})
-		s.State.Del(del)
-	}
-	for _, replace := range req.GetReplace() {
-		log.Printf("Replacing path: %v with value: %q", replace.GetPath(), replace.GetVal().GetJsonVal())
-		res = append(res, &gpb.UpdateResult{
-			Timestamp: time.Now().UnixNano(),
-			Path:      replace.Path,
-			Op:        gpb.UpdateResult_REPLACE,
-		})
-		// Delete the existing value at the path and set the new value.
-		s.State.Del(replace.GetPath())
-		s.State.Set(replace.GetPath(), replace.GetVal().GetJsonVal())
-	}
-	for _, update := range req.GetUpdate() {
-		log.Printf("Updating path: %v with value: %q", update.GetPath(), update.GetVal().GetJsonVal())
-		res = append(res, &gpb.UpdateResult{
-			Timestamp: time.Now().UnixNano(),
-			Path:      update.Path,
-			Op:        gpb.UpdateResult_UPDATE,
-		})
-		// The value will automatically be merged into the existing state.
-		s.State.Set(update.GetPath(), update.GetVal().GetJsonVal())
-	}
-	// TODO: Handle UnionReplace
-	return &gpb.SetResponse{
-		Response:  res,
-		Timestamp: time.Now().UnixNano(),
-	}, nil
-}
-
-func (s *Server) Subscribe(stream grpc.BidiStreamingServer[gpb.SubscribeRequest, gpb.SubscribeResponse]) error {
-	req, err := stream.Recv()
-	switch {
-	case err == io.EOF:
-		return nil
-	case err != nil:
-		return err
-	case req.GetSubscribe() == nil:
-		return status.Errorf(codes.InvalidArgument, "the subscribe request must contain a subscription definition")
-	}
-
-	switch req.GetRequest().(type) {
-	case *gpb.SubscribeRequest_Poll:
-		return status.Errorf(codes.InvalidArgument, "invalid request type: %T", req.GetRequest())
-	case *gpb.SubscribeRequest_Subscribe:
-	}
-
-	switch mode := req.GetSubscribe().GetMode(); mode {
-	case gpb.SubscriptionList_ONCE:
-		log.Printf("Received Subscribe request with ONCE mode")
-
-		paths := make([]*gpb.Path, 0, len(req.GetSubscribe().GetSubscription()))
-		for _, r := range req.GetSubscribe().GetSubscription() {
-			paths = append(paths, r.GetPath())
-		}
-
-		res, err := s.Get(stream.Context(), &gpb.GetRequest{
-			Prefix:    req.GetSubscribe().GetPrefix(),
-			Path:      paths,
-			Encoding:  req.GetSubscribe().GetEncoding(),
-			UseModels: req.GetSubscribe().GetUseModels(),
-			Extension: req.GetExtension(),
-		})
-		if err != nil {
-			return err
-		}
-
-		for _, notification := range res.GetNotification() {
-			if err := stream.Send(&gpb.SubscribeResponse{
-				Response: &gpb.SubscribeResponse_Update{
-					Update: notification,
-				},
-			}); err != nil {
-				return status.Errorf(codes.Internal, "failed to send response: %v", err)
-			}
-		}
-
-	case gpb.SubscriptionList_STREAM:
-		return status.Errorf(codes.Unimplemented, "subscribe method Stream not implemented")
-	case gpb.SubscriptionList_POLL:
-		return status.Errorf(codes.Unimplemented, "subscribe method Poll not implemented")
-	default:
-		return status.Errorf(codes.InvalidArgument, "unknown subscribe request mode: %v", mode)
-	}
-
-	return nil
-}
-
-// handleState handles HTTP requests to the /v1/state endpoint
-func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		s.State.RLock()
-		defer s.State.RUnlock()
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if len(s.State.Buf) == 0 {
-			w.Write([]byte("{}"))
-			return
-		}
-		var buf bytes.Buffer
-		if err := json.Compact(&buf, s.State.Buf); err != nil {
-			log.Printf("Failed to compact JSON: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("Internal Server Error"))
-			return
-		}
-		w.Write(buf.Bytes())
-	case http.MethodDelete:
-		s.State.Lock()
-		defer s.State.Unlock()
-		s.State.Buf = nil
-		w.WriteHeader(http.StatusNoContent)
-	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
-	}
-}
-
-// State represents a JSON body that can be manipulated using [sjson] syntax.
-type State struct {
-	sync.RWMutex
-
-	Buf []byte
-}
-
-func (s State) Get(path *gpb.Path) []byte {
-	s.RLock()
-	defer s.RUnlock()
-	var sb strings.Builder
-	for _, elem := range path.GetElem() {
-		if elem.GetName() == "" {
-			continue
-		}
-		if sb.Len() > 0 {
-			sb.WriteByte('|')
-		}
-		sb.WriteString(elem.GetName())
-		if len(elem.GetKey()) == 0 {
-			continue
-		}
-		for k, v := range elem.GetKey() {
-			sb.WriteByte('|')
-			sb.WriteString(`#(`)
-			sb.WriteString(k)
-			sb.WriteString(`=="`)
-			sb.WriteString(v)
-			sb.WriteString(`")#`)
-		}
-	}
-	res := gjson.GetBytes(s.Buf, sb.String())
-	if !res.Exists() || (res.IsArray() && len(res.Array()) == 0) {
-		return []byte("null")
-	}
-	return []byte(res.Raw)
-}
-
-func (s *State) Set(path *gpb.Path, raw []byte) {
-	s.Lock()
-	defer s.Unlock()
-	var sb strings.Builder
-	for _, elem := range path.GetElem() {
-		if elem.GetName() == "" {
-			continue
-		}
-		if sb.Len() > 0 {
-			sb.WriteByte('.')
-		}
-		sb.WriteString(elem.GetName())
-		if len(elem.GetKey()) == 0 {
-			continue
-		}
-		var idx int
-		gjson.GetBytes(s.Buf, sb.String()).ForEach(func(_, r gjson.Result) bool {
-			for k, v := range elem.GetKey() {
-				if r.Get(k).String() != v {
-					idx++
-					return true
-				}
-			}
-			return false
-		})
-		sb.WriteByte('.')
-		sb.WriteString(strconv.Itoa(idx))
-	}
-	s.Buf, _ = sjson.SetRawBytes(s.Buf, sb.String(), raw) //nolint:errcheck
-}
-
-func (s *State) Del(path *gpb.Path) {
-	s.Lock()
-	defer s.Unlock()
-	var sb strings.Builder
-	for _, elem := range path.GetElem() {
-		if elem.GetName() == "" {
-			continue
-		}
-		if sb.Len() > 0 {
-			sb.WriteByte('.')
-		}
-		sb.WriteString(elem.GetName())
-		if len(elem.GetKey()) == 0 {
-			continue
-		}
-		var (
-			idx   int
-			found bool
-		)
-		gjson.GetBytes(s.Buf, sb.String()).ForEach(func(_, r gjson.Result) bool {
-			for k, v := range elem.GetKey() {
-				if r.Get(k).String() != v {
-					idx++
-					return true
-				}
-			}
-			found = true
-			return false
-		})
-		if !found {
-			return
-		}
-		sb.WriteByte('.')
-		sb.WriteString(strconv.Itoa(idx))
-	}
-
-	s.Buf, _ = sjson.DeleteBytes(s.Buf, sb.String()) //nolint:errcheck
-}
 
 func main() {
 	// Parse command line flags
 	port := flag.Int("port", 9339, "The gRPC server port")
 	httpPort := flag.Int("http-port", 8000, "The HTTP server port")
+	nxos := flag.Bool("nxos", false, "Enable NX-OS behavior (strip DME markers)")
 	flag.Parse()
 
-	// Create a listener on the specified port
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
-	if err != nil {
-		log.Fatalf("Failed to listen on port %d: %v", *port, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Build server options
+	opts := []testserver.ServerOption{
+		testserver.WithGRPCPort(*port),
+		testserver.WithHTTPPort(*httpPort),
+		testserver.WithBindAddress("0.0.0.0"),
+	}
+	if *nxos {
+		opts = append(opts, testserver.WithNXOSBehavior())
 	}
 
-	// Create a TLS certificate for gRPC server
-	// This is a self-signed certificate for testing purposes.
-	cert, err := gtls.NewCert()
+	// Start the server using the reusable NewTestServer function
+	// Bind to 0.0.0.0 to accept connections from other pods in the cluster
+	server, grpcAddr, httpAddr, err := testserver.NewTestServer(ctx, opts...)
 	if err != nil {
-		log.Fatalf("Failed to create TLS certificate: %v", err)
+		log.Fatalf("Failed to start server: %v", err)
 	}
 
-	// Create a new gRPC server with TLS
-	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
-		Certificates: []tls.Certificate{cert},
-	})))
-
-	// Create our server implementation
-	server := &Server{State: &State{}}
-
-	// Register the GNMIService with our server implementation
-	gpb.RegisterGNMIServer(grpcServer, server)
-
-	// Enable reflection for easier testing with tools like grpcurl
-	reflection.Register(grpcServer)
-
-	// Setup HTTP server
-	http.HandleFunc("/v1/state", server.handleState)
-	httpServer := &http.Server{Addr: fmt.Sprintf(":%d", *httpPort)}
-
-	// Start HTTP server in a goroutine
-	go func() {
-		log.Printf("Starting HTTP server on port %d", *httpPort)
-		log.Printf("HTTP endpoint available at: /v1/state")
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Failed to serve HTTP server: %v", err)
-		}
-	}()
-
-	log.Printf("Starting gRPC server on port %d", *port)
-	log.Printf("Server is ready to accept connections...")
+	log.Printf("gRPC server listening on %s", grpcAddr)
+	log.Printf("HTTP server listening on %s", httpAddr)
+	log.Printf("HTTP endpoint available at: /v1/state")
 	log.Printf("Use --port flag to specify a different gRPC port (default: 9339)")
 	log.Printf("Use --http-port flag to specify a different HTTP port (default: 8000)")
 	log.Printf("Available services: GNMI")
 
-	// Start serving
-	if err := grpcServer.Serve(lis); err != nil {
-		log.Fatalf("Failed to serve gRPC server: %v", err)
+	// Wait for interrupt signal
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	log.Println("Shutting down...")
+	if err := server.Close(); err != nil {
+		log.Printf("Error during shutdown: %v", err)
 	}
 }

--- a/test/gnmi/testserver/server.go
+++ b/test/gnmi/testserver/server.go
@@ -1,0 +1,636 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
+
+	gtls "github.com/openconfig/gnmi/testing/fake/testing/tls"
+)
+
+var _ gpb.GNMIServer = (*Server)(nil)
+
+// Server implements the GNMI gRPC server
+type Server struct {
+	gpb.UnimplementedGNMIServer
+
+	State *State
+
+	grpcServer *grpc.Server
+	httpServer *http.Server
+	grpcAddr   string
+	httpAddr   string
+}
+
+// ServerOption configures the test server
+type ServerOption func(*serverConfig)
+
+type serverConfig struct {
+	grpcPort        int
+	httpPort        int
+	bindAddress     string
+	stripDMEMarkers bool
+	dmeMarkerValue  string
+}
+
+// WithGRPCPort sets a specific gRPC port (default: 0 for random)
+func WithGRPCPort(port int) ServerOption {
+	return func(c *serverConfig) {
+		c.grpcPort = port
+	}
+}
+
+// WithHTTPPort sets a specific HTTP port (default: 0 for random)
+func WithHTTPPort(port int) ServerOption {
+	return func(c *serverConfig) {
+		c.httpPort = port
+	}
+}
+
+// WithBindAddress sets the address to bind to (default: 127.0.0.1).
+// Use "0.0.0.0" to listen on all interfaces (required for container/pod deployments).
+func WithBindAddress(addr string) ServerOption {
+	return func(c *serverConfig) {
+		c.bindAddress = addr
+	}
+}
+
+// WithNXOSBehavior configures the server to emulate NX-OS device behavior:
+//   - Strips fields with DME_UNSET_PROPERTY_MARKER value when storing (the marker
+//     means "unset this field", not "store this literal string")
+//   - Returns empty TypedValue for non-existent paths (instead of NOT_FOUND error)
+func WithNXOSBehavior() ServerOption {
+	return func(c *serverConfig) {
+		c.stripDMEMarkers = true
+		c.dmeMarkerValue = "DME_UNSET_PROPERTY_MARKER"
+	}
+}
+
+// NewTestServer starts an in-process gNMI + HTTP server.
+// By default, it uses random available ports. Use WithGRPCPort/WithHTTPPort to specify ports.
+// Returns the server, gRPC address, HTTP address, and any error.
+func NewTestServer(ctx context.Context, opts ...ServerOption) (*Server, string, string, error) {
+	cfg := &serverConfig{
+		grpcPort:    0,           // Random port by default
+		httpPort:    0,           // Random port by default
+		bindAddress: "127.0.0.1", // Localhost by default (safe for in-process tests)
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Create a listener on the specified port
+	grpcLis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.bindAddress, cfg.grpcPort))
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to listen for gRPC: %w", err)
+	}
+
+	httpLis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.bindAddress, cfg.httpPort))
+	if err != nil {
+		grpcLis.Close()
+		return nil, "", "", fmt.Errorf("failed to listen for HTTP: %w", err)
+	}
+
+	// Create a TLS certificate for gRPC server
+	cert, err := gtls.NewCert()
+	if err != nil {
+		grpcLis.Close()
+		httpLis.Close()
+		return nil, "", "", fmt.Errorf("failed to create TLS certificate: %w", err)
+	}
+
+	// Create a new gRPC server with TLS
+	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+	})))
+
+	// Create our server implementation
+	server := &Server{
+		State: &State{
+			stripDMEMarkers: cfg.stripDMEMarkers,
+			dmeMarkerValue:  cfg.dmeMarkerValue,
+		},
+		grpcServer: grpcServer,
+		grpcAddr:   grpcLis.Addr().String(),
+		httpAddr:   httpLis.Addr().String(),
+	}
+
+	// Register the GNMIService with our server implementation
+	gpb.RegisterGNMIServer(grpcServer, server)
+
+	// Enable reflection for easier testing
+	reflection.Register(grpcServer)
+
+	// Setup HTTP server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/state", server.handleState)
+	mux.HandleFunc("/v1/clear", server.handleClear)
+	server.httpServer = &http.Server{Handler: mux}
+
+	// Start HTTP server in a goroutine
+	go func() {
+		log.Printf("Starting HTTP server on %s", server.httpAddr)
+		if err := server.httpServer.Serve(httpLis); err != nil && err != http.ErrServerClosed {
+			log.Printf("HTTP server error: %v", err)
+		}
+	}()
+
+	// Start gRPC server in a goroutine
+	go func() {
+		log.Printf("Starting gRPC server on %s", server.grpcAddr)
+		if err := grpcServer.Serve(grpcLis); err != nil {
+			log.Printf("gRPC server error: %v", err)
+		}
+	}()
+
+	return server, server.grpcAddr, server.httpAddr, nil
+}
+
+// GRPCAddr returns the gRPC server address
+func (s *Server) GRPCAddr() string {
+	return s.grpcAddr
+}
+
+// HTTPAddr returns the HTTP server address
+func (s *Server) HTTPAddr() string {
+	return s.httpAddr
+}
+
+// GetState returns the current JSON state
+func (s *Server) GetState() ([]byte, error) {
+	s.State.RLock()
+	defer s.State.RUnlock()
+	if len(s.State.Buf) == 0 {
+		return []byte("{}"), nil
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, s.State.Buf); err != nil {
+		return nil, fmt.Errorf("failed to compact JSON: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ClearState clears all accumulated state
+func (s *Server) ClearState() {
+	s.State.Lock()
+	defer s.State.Unlock()
+	s.State.Buf = nil
+}
+
+// Close gracefully shuts down the server
+func (s *Server) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var errs []error
+	if s.httpServer != nil {
+		if err := s.httpServer.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("HTTP shutdown: %w", err))
+		}
+	}
+	if s.grpcServer != nil {
+		s.grpcServer.GracefulStop()
+	}
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	return nil
+}
+
+func (s *Server) Capabilities(_ context.Context, _ *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error) {
+	return &gpb.CapabilityResponse{SupportedEncodings: []gpb.Encoding{gpb.Encoding_JSON}}, nil
+}
+
+func (s *Server) Get(_ context.Context, req *gpb.GetRequest) (*gpb.GetResponse, error) {
+	notifications := make([]*gpb.Notification, 0, len(req.GetPath()))
+	for _, path := range req.GetPath() {
+		if len(path.GetElem()) == 0 {
+			return nil, status.Error(codes.InvalidArgument, "root path is not allowed")
+		}
+		log.Printf("Getting path: %v", path)
+		notifications = append(notifications, &gpb.Notification{
+			Timestamp: time.Now().UnixNano(),
+			Update: []*gpb.Update{
+				{
+					Path: path,
+					Val: &gpb.TypedValue{
+						Value: &gpb.TypedValue_JsonVal{
+							JsonVal: s.State.Get(path),
+						},
+					},
+				},
+			},
+		})
+	}
+	return &gpb.GetResponse{
+		Notification: notifications,
+	}, nil
+}
+
+func (s *Server) Set(_ context.Context, req *gpb.SetRequest) (*gpb.SetResponse, error) {
+	log.Printf("Received Set request: %v", req)
+	res := make([]*gpb.UpdateResult, 0, len(req.GetDelete())+len(req.GetUpdate()))
+	for _, del := range req.GetDelete() {
+		log.Printf("Deleting path: %v", del)
+		res = append(res, &gpb.UpdateResult{
+			Timestamp: time.Now().UnixNano(),
+			Path:      del,
+			Op:        gpb.UpdateResult_DELETE,
+		})
+		s.State.Del(del)
+	}
+	for _, replace := range req.GetReplace() {
+		log.Printf("Replacing path: %v with value: %q", replace.GetPath(), replace.GetVal().GetJsonVal())
+		res = append(res, &gpb.UpdateResult{
+			Timestamp: time.Now().UnixNano(),
+			Path:      replace.Path,
+			Op:        gpb.UpdateResult_REPLACE,
+		})
+		// Delete the existing value at the path and set the new value.
+		s.State.Del(replace.GetPath())
+		s.State.Set(replace.GetPath(), replace.GetVal().GetJsonVal())
+	}
+	for _, update := range req.GetUpdate() {
+		log.Printf("Updating path: %v with value: %q", update.GetPath(), update.GetVal().GetJsonVal())
+		res = append(res, &gpb.UpdateResult{
+			Timestamp: time.Now().UnixNano(),
+			Path:      update.Path,
+			Op:        gpb.UpdateResult_UPDATE,
+		})
+		// The value will automatically be merged into the existing state.
+		s.State.Set(update.GetPath(), update.GetVal().GetJsonVal())
+	}
+	// TODO: Handle UnionReplace
+	return &gpb.SetResponse{
+		Response:  res,
+		Timestamp: time.Now().UnixNano(),
+	}, nil
+}
+
+func (s *Server) Subscribe(stream grpc.BidiStreamingServer[gpb.SubscribeRequest, gpb.SubscribeResponse]) error {
+	req, err := stream.Recv()
+	switch {
+	case err == io.EOF:
+		return nil
+	case err != nil:
+		return err
+	case req.GetSubscribe() == nil:
+		return status.Errorf(codes.InvalidArgument, "the subscribe request must contain a subscription definition")
+	}
+
+	switch req.GetRequest().(type) {
+	case *gpb.SubscribeRequest_Poll:
+		return status.Errorf(codes.InvalidArgument, "invalid request type: %T", req.GetRequest())
+	case *gpb.SubscribeRequest_Subscribe:
+	}
+
+	switch mode := req.GetSubscribe().GetMode(); mode {
+	case gpb.SubscriptionList_ONCE:
+		log.Printf("Received Subscribe request with ONCE mode")
+
+		paths := make([]*gpb.Path, 0, len(req.GetSubscribe().GetSubscription()))
+		for _, r := range req.GetSubscribe().GetSubscription() {
+			paths = append(paths, r.GetPath())
+		}
+
+		res, err := s.Get(stream.Context(), &gpb.GetRequest{
+			Prefix:    req.GetSubscribe().GetPrefix(),
+			Path:      paths,
+			Encoding:  req.GetSubscribe().GetEncoding(),
+			UseModels: req.GetSubscribe().GetUseModels(),
+			Extension: req.GetExtension(),
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, notification := range res.GetNotification() {
+			if err := stream.Send(&gpb.SubscribeResponse{
+				Response: &gpb.SubscribeResponse_Update{
+					Update: notification,
+				},
+			}); err != nil {
+				return status.Errorf(codes.Internal, "failed to send response: %v", err)
+			}
+		}
+
+	case gpb.SubscriptionList_STREAM:
+		return status.Errorf(codes.Unimplemented, "subscribe method Stream not implemented")
+	case gpb.SubscriptionList_POLL:
+		return status.Errorf(codes.Unimplemented, "subscribe method Poll not implemented")
+	default:
+		return status.Errorf(codes.InvalidArgument, "unknown subscribe request mode: %v", mode)
+	}
+
+	return nil
+}
+
+// handleState handles HTTP requests to the /v1/state endpoint
+// GET: returns current state as JSON
+// POST: preloads nested JSON into state
+// DELETE: clears all state
+// Supports X-HTTP-Method-Override header for clients that can't send DELETE.
+func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
+	method := r.Method
+	if override := r.Header.Get("X-HTTP-Method-Override"); override != "" {
+		method = override
+	}
+	switch method {
+	case http.MethodGet:
+		state, err := s.GetState()
+		if err != nil {
+			log.Printf("Failed to get state: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Internal Server Error"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(state)
+	case http.MethodPost:
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("Failed to read body: %v", err)
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+		if len(body) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if !gjson.ValidBytes(body) {
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+		// Use Set with empty path to merge JSON into root of state
+		s.State.Set(&gpb.Path{}, body)
+		log.Printf("Merged state from JSON")
+		w.WriteHeader(http.StatusNoContent)
+	case http.MethodDelete:
+		s.ClearState()
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// handleClear handles POST /v1/clear to clear all state.
+func (s *Server) handleClear(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	s.ClearState()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// mergeJSON merges src JSON into dst JSON at the root level.
+// Keys in src overwrite keys in dst.
+func mergeJSON(dst, src []byte) []byte {
+	srcParsed := gjson.ParseBytes(src)
+	if !srcParsed.IsObject() {
+		return src
+	}
+	result := dst
+	srcParsed.ForEach(func(key, value gjson.Result) bool {
+		result, _ = sjson.SetRawBytes(result, key.String(), []byte(value.Raw))
+		return true
+	})
+	return result
+}
+
+// State represents a JSON body that can be manipulated using [sjson] syntax.
+type State struct {
+	sync.RWMutex
+
+	Buf []byte
+
+	// NX-OS behavior options
+	stripDMEMarkers bool
+	dmeMarkerValue  string
+}
+
+// stripMarkerFields removes fields with the DME marker value from JSON recursively.
+// This emulates NX-OS behavior where these markers mean "unset this field"
+// rather than "store this literal string".
+func (s *State) stripMarkerFields(data []byte) []byte {
+	if !s.stripDMEMarkers || s.dmeMarkerValue == "" {
+		return data
+	}
+	return s.stripMarkersRecursive(data)
+}
+
+// stripMarkersRecursive walks the JSON structure and removes marker fields at all levels.
+func (s *State) stripMarkersRecursive(data []byte) []byte {
+	parsed := gjson.ParseBytes(data)
+	if !parsed.IsObject() && !parsed.IsArray() {
+		return data
+	}
+
+	if parsed.IsArray() {
+		// Process each array element
+		var results []string
+		parsed.ForEach(func(_, value gjson.Result) bool {
+			processed := s.stripMarkersRecursive([]byte(value.Raw))
+			results = append(results, string(processed))
+			return true
+		})
+		return []byte("[" + strings.Join(results, ",") + "]")
+	}
+
+	// It's an object - process fields
+	var toDelete []string
+	parsed.ForEach(func(key, value gjson.Result) bool {
+		keyStr := key.String()
+		if value.Type == gjson.String && value.String() == s.dmeMarkerValue {
+			toDelete = append(toDelete, keyStr)
+		} else if value.IsObject() || value.IsArray() {
+			// Recurse into nested structures
+			processed := s.stripMarkersRecursive([]byte(value.Raw))
+			data, _ = sjson.SetRawBytes(data, keyStr, processed)
+		}
+		return true
+	})
+	for _, key := range toDelete {
+		data, _ = sjson.DeleteBytes(data, key)
+	}
+	return data
+}
+
+func (s *State) Get(path *gpb.Path) []byte {
+	s.RLock()
+	defer s.RUnlock()
+	var sb strings.Builder
+	for _, elem := range path.GetElem() {
+		if elem.GetName() == "" {
+			continue
+		}
+		if sb.Len() > 0 {
+			sb.WriteByte('|')
+		}
+		sb.WriteString(elem.GetName())
+		if len(elem.GetKey()) == 0 {
+			continue
+		}
+		for k, v := range elem.GetKey() {
+			sb.WriteByte('|')
+			sb.WriteString(`#(`)
+			sb.WriteString(k)
+			sb.WriteString(`=="`)
+			sb.WriteString(v)
+			sb.WriteString(`")#`)
+		}
+	}
+	res := gjson.GetBytes(s.Buf, sb.String())
+	if !res.Exists() || (res.IsArray() && len(res.Array()) == 0) {
+		// Return empty bytes for non-existent paths. This triggers gnmiext's
+		// ErrNil handling (len(b) == 0), matching real NX-OS behavior which
+		// returns empty TypedValue for paths that don't exist yet.
+		return []byte{}
+	}
+	return []byte(res.Raw)
+}
+
+func (s *State) Set(path *gpb.Path, raw []byte) {
+	s.Lock()
+	defer s.Unlock()
+
+	// Strip DME marker fields if NX-OS behavior is enabled
+	raw = s.stripMarkerFields(raw)
+
+	elems := path.GetElem()
+
+	// Handle empty path - merge raw into state at root level
+	if len(elems) == 0 {
+		if len(s.Buf) == 0 {
+			s.Buf = raw
+		} else {
+			s.Buf = mergeJSON(s.Buf, raw)
+		}
+		return
+	}
+
+	var sb strings.Builder
+
+	for i, elem := range elems {
+		if elem.GetName() == "" {
+			continue
+		}
+		if sb.Len() > 0 {
+			sb.WriteByte('.')
+		}
+		sb.WriteString(elem.GetName())
+
+		if len(elem.GetKey()) == 0 {
+			continue
+		}
+
+		// Find existing array index or append
+		var idx int
+		gjson.GetBytes(s.Buf, sb.String()).ForEach(func(_, r gjson.Result) bool {
+			for k, v := range elem.GetKey() {
+				if r.Get(k).String() != v {
+					idx++
+					return true
+				}
+			}
+			return false
+		})
+		sb.WriteByte('.')
+		sb.WriteString(strconv.Itoa(idx))
+
+		// Inject keys into this list element if it's not the final element
+		// (for the final element, keys go into raw below)
+		if i < len(elems)-1 {
+			currentPath := sb.String()
+			current := gjson.GetBytes(s.Buf, currentPath)
+			if !current.Exists() || current.Raw == "null" {
+				// Create the element with its keys
+				keyObj := make(map[string]string)
+				for k, v := range elem.GetKey() {
+					keyObj[k] = v
+				}
+				keyJSON, _ := json.Marshal(keyObj)
+				s.Buf, _ = sjson.SetRawBytes(s.Buf, currentPath, keyJSON)
+			} else {
+				// Element exists, ensure keys are set
+				for k, v := range elem.GetKey() {
+					if !gjson.GetBytes(s.Buf, currentPath+"."+k).Exists() {
+						s.Buf, _ = sjson.SetBytes(s.Buf, currentPath+"."+k, v)
+					}
+				}
+			}
+		}
+	}
+
+	// For the final element, inject its keys (from the last keyed element) into raw
+	lastElem := elems[len(elems)-1]
+	for k, v := range lastElem.GetKey() {
+		if !gjson.GetBytes(raw, k).Exists() {
+			raw, _ = sjson.SetBytes(raw, k, v)
+		}
+	}
+
+	s.Buf, _ = sjson.SetRawBytes(s.Buf, sb.String(), raw) //nolint:errcheck
+}
+
+func (s *State) Del(path *gpb.Path) {
+	s.Lock()
+	defer s.Unlock()
+	var sb strings.Builder
+	for _, elem := range path.GetElem() {
+		if elem.GetName() == "" {
+			continue
+		}
+		if sb.Len() > 0 {
+			sb.WriteByte('.')
+		}
+		sb.WriteString(elem.GetName())
+		if len(elem.GetKey()) == 0 {
+			continue
+		}
+		var (
+			idx   int
+			found bool
+		)
+		gjson.GetBytes(s.Buf, sb.String()).ForEach(func(_, r gjson.Result) bool {
+			for k, v := range elem.GetKey() {
+				if r.Get(k).String() != v {
+					idx++
+					return true
+				}
+			}
+			found = true
+			return false
+		})
+		if !found {
+			return
+		}
+		sb.WriteByte('.')
+		sb.WriteString(strconv.Itoa(idx))
+	}
+
+	s.Buf, _ = sjson.DeleteBytes(s.Buf, sb.String()) //nolint:errcheck
+}


### PR DESCRIPTION
Enable running tests again a  Kind cluster. The test suite uses Ginkgo's parallel execution capabilities and includes Manager deployment validation. Each test gets its dedicated namespace with a gnmi-test-server pod.

 ```bash
 # Run cluster mode tests
 make test-e2e-kind PROVIDER=cisco-nxos-gnmi

 # Run with parallelism
 make test-e2e-kind PROVIDER=cisco-nxos-gnmi GINKGO_PROCS=4
 ```