### PR TITLE
Remove redundant WrapTerminalError in BGPPeer reconcile

### DIFF
--- a/internal/controller/core/bgp_peer_controller.go
+++ b/internal/controller/core/bgp_peer_controller.go
@@ -477,7 +477,7 @@ func (r *BGPPeerReconciler) reconcile(ctx context.Context, s *bgpPeerScope) (ret
 	conditions.Set(s.BGPPeer, cond)
 
 	if err != nil {
-		return apistatus.WrapTerminalError(err)
+		return err
 	}
 
 	status, err := s.Provider.GetPeerStatus(ctx, &provider.BGPPeerStatusRequest{


### PR DESCRIPTION
The Reconcile function ([line 216](https://github.com/ironcore-dev/network-operator/blob/main/internal/controller/core/bgp_peer_controller.go#L216)) already wraps returned errors with apistatus, so wrapping here is unnecessary double-wrapping. Returning the plain error is sufficient.