### PR TITLE
fix(iosxr): correct interface mode handling and nil pointer checks

### DIFF
--- a/internal/provider/cisco/iosxr/intf.go
+++ b/internal/provider/cisco/iosxr/intf.go
@@ -84,13 +84,15 @@ type Iface struct {
 	IPv6Neighbor IPv6Neighbor  `json:"Cisco-IOS-XR-ipv6-nd-cfg:ipv6-neighbor,omitzero"`
 	Shutdown     gnmiext.Empty `json:"shutdown,omitzero"`
 
+	// Required for subinterfaces
 	// Existence of this object causes the creation of the software subinterface
 	ModeNoPhysical string `json:"interface-mode-non-physical,omitzero"`
 
 	// BundleMember configuration for Physical interface as member of a Bundle-Ether
 	BundleMember BundleMember `json:"Cisco-IOS-XR-bundlemgr-cfg:bundle-member,omitzero"`
 
-	// Mode in which an interface is running (e.g., virtual for subinterfaces)
+	// Required for bundle-interfaces
+	// Existence of this object causes the creation of the interface within the bundlemgr database
 	Mode         gnmiext.Empty    `json:"interface-virtual,omitzero"`
 	Bundle       Bundle           `json:"Cisco-IOS-XR-bundlemgr-cfg:bundle,omitzero"`
 	SubInterface VlanSubInterface `json:"Cisco-IOS-XR-l2-eth-infra-cfg:vlan-sub-configuration,omitzero"`

--- a/internal/provider/cisco/iosxr/provider.go
+++ b/internal/provider/cisco/iosxr/provider.go
@@ -220,11 +220,16 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		}
 
 		iface := Iface{
-			Name:           name,
-			Description:    req.Interface.Spec.Description,
-			Active:         "act",
-			ModeNoPhysical: "default",
-			Mode:           gnmiext.Empty(false),
+			Name:        name,
+			Description: req.Interface.Spec.Description,
+			Active:      "act",
+			// Without this, bundlemgr cannot find the Bundle-Ether interface in its database
+			Mode: gnmiext.Empty(true),
+		}
+
+		iface.Shutdown = gnmiext.Empty(false)
+		if req.Interface.Spec.AdminState == v1alpha1.AdminStateDown {
+			iface.Shutdown = gnmiext.Empty(true)
 		}
 
 		bundleID, subinterfaceID, err := ExtractBundleAndSubinterfaceID(name)
@@ -256,13 +261,16 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		return updateInterface(ctx, p.client, conf...)
 	case v1alpha1.InterfaceTypeSubinterface:
 
-		// Set Interface mode to virtual is required for bundle interfaces
 		iface := Iface{
 			Name:           name,
 			Description:    req.Interface.Spec.Description,
 			Active:         "act",
-			Mode:           gnmiext.Empty(false),
 			ModeNoPhysical: "default",
+		}
+
+		iface.Shutdown = gnmiext.Empty(false)
+		if req.Interface.Spec.AdminState == v1alpha1.AdminStateDown {
+			iface.Shutdown = gnmiext.Empty(true)
 		}
 
 		_, subinterfaceID, err := ExtractBundleAndSubinterfaceID(name)
@@ -294,7 +302,7 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		}
 		iface.IPv4Network = ipv4
 
-		if req.VRF.Spec.Name != "" {
+		if req.VRF != nil && req.VRF.Spec.Name != "" {
 			iface.Vrf = req.VRF.Spec.Name
 		}
 
@@ -469,7 +477,7 @@ func (p *Provider) EnsureBGPPeer(ctx context.Context, req *provider.EnsureBGPPee
 		RD:       rd,
 	}
 
-	if req.BGPPeer.Spec.AddressFamilies.Ipv6Unicast != nil || req.BGPPeer.Spec.AddressFamilies.L2vpnEvpn != nil {
+	if req.BGPPeer.Spec.AddressFamilies != nil && (req.BGPPeer.Spec.AddressFamilies.Ipv6Unicast != nil || req.BGPPeer.Spec.AddressFamilies.L2vpnEvpn != nil) {
 		return errors.New("bgp peer: ipv6 unicast or l2vpnEvpn address family is currently not supported")
 	}
 

--- a/internal/provider/cisco/iosxr/provider_test.go
+++ b/internal/provider/cisco/iosxr/provider_test.go
@@ -34,11 +34,11 @@ func Register(name string, val gnmiext.DataElement) {
 }
 
 func removeRootElement(xpath string) string {
-	parts := strings.Split(xpath, "/")
+	parts := strings.Split(xpath, ":")
 	if len(parts) == 1 {
 		return xpath
 	}
-	return strings.Join(parts[1:], "/")
+	return parts[1]
 }
 
 func Test_Payload(t *testing.T) {

--- a/internal/provider/cisco/iosxr/system.go
+++ b/internal/provider/cisco/iosxr/system.go
@@ -27,7 +27,7 @@ type BasicDeviceInfo struct {
 
 func (*BasicDeviceInfo) XPath() string {
 	// Rack name defines the physical chassis, which is 0 for single-chassis devices.
-	return "Cisco-IOS-XR-platform-inventory-oper:/platform-inventory/racks/rack[name=0]/attributes/basic-info"
+	return "Cisco-IOS-XR-platform-inventory-oper:platform-inventory/racks/rack[name=0]/attributes/basic-info"
 }
 
 type SystemTime struct {
@@ -52,7 +52,7 @@ type Clock struct {
 }
 
 func (*SystemTime) XPath() string {
-	return "Cisco-IOS-XR-shellutil-oper:/system-time"
+	return "Cisco-IOS-XR-shellutil-oper:system-time"
 }
 
 func (c *Clock) ConvertToTime() time.Time {

--- a/internal/provider/cisco/iosxr/testdata/bgppeer.json
+++ b/internal/provider/cisco/iosxr/testdata/bgppeer.json
@@ -1,71 +1,73 @@
 {
-  "bgp": {
-    "instances": {
-      "instance": {
-        "as": {
-          "vrfs": {
-            "vrf": {
-              "address-families": {
-                "address-family": [
-                  {
-                    "af-name": "ipv4-unicast",
-                    "redistribute": {
-                      "static": {}
+  "router": {
+    "bgp": {
+      "instances": {
+        "instance": {
+          "as": {
+            "vrfs": {
+              "vrf": {
+                "address-families": {
+                  "address-family": [
+                    {
+                      "af-name": "ipv4-unicast",
+                      "redistribute": {
+                        "static": {}
+                      }
                     }
+                  ]
+                },
+                "vrf-name": "testvrf",
+                "rd": {
+                  "two-byte-as": {
+                    "two-byte-as-number": 1000,
+                    "asn2-index": 100
                   }
-                ]
-              },
-              "vrf-name": "testvrf",
-              "rd": {
-                "two-byte-as": {
-                  "two-byte-as-number": 1000,
-                  "asn2-index": 100
-                }
-              },
-              "neighbors": {
-                "neighbor": [
-                  {
-                    "address": "127.0.0.1",
-                    "address-families": {
-                      "address-family": [
-                        {
-                          "af-name": "ipv4-unicast",
-                          "maximum-prefix": {
-                            "maximum-prefix-number": 100,
-                            "restart": 15,
-                            "threshold-value": 80
-                          },
-                          "route-policy": {
-                            "in": "RPL_testvrf",
-                            "out": "RPL_testvrf"
-                          },
-                          "send-community-ebgp": {},
-                          "send-community-gshut-ebgp": {},
-                          "send-extended-community-ebgp": {},
-                          "soft-reconfiguration": {
-                            "inbound": {
-                              "always": [
-                                null
-                              ]
+                },
+                "neighbors": {
+                  "neighbor": [
+                    {
+                      "address": "127.0.0.1",
+                      "address-families": {
+                        "address-family": [
+                          {
+                            "af-name": "ipv4-unicast",
+                            "maximum-prefix": {
+                              "maximum-prefix-number": 100,
+                              "restart": 15,
+                              "threshold-value": 80
+                            },
+                            "route-policy": {
+                              "in": "RPL_testvrf",
+                              "out": "RPL_testvrf"
+                            },
+                            "send-community-ebgp": {},
+                            "send-community-gshut-ebgp": {},
+                            "send-extended-community-ebgp": {},
+                            "soft-reconfiguration": {
+                              "inbound": {
+                                "always": [
+                                  null
+                                ]
+                              }
                             }
                           }
+                        ]
+                      },
+                      "local-as": {
+                        "as": {
+                          "as-number": 65000,
+                          "no-prepend": {
+                            "replace-as": {}
+                          }
                         }
-                      ]
-                    },
-                    "local-as": {
-                      "as": {
-                        "as-number": 65000,
-                        "no-prepend": {
-                          "replace-as": {}
-                        }
+                      },
+                      "remote-as": 65001,
+                      "use": {
+                        "session-group": "EBGP-CUSTOMER-DEFAULTS"
                       }
-                    },
-                    "remote-as": 65001,
-                    "use": {
-                      "session-group": "EBGP-CUSTOMER-DEFAULTS"
                     }
-                  }
-                ]
+                  ]
+                }
               }
             }
           }

--- a/internal/provider/cisco/iosxr/testdata/intf.json
+++ b/internal/provider/cisco/iosxr/testdata/intf.json
@@ -1,47 +1,50 @@
 {
-  "interface-configuration": {
-    "interface-name": "TwentyFiveGigE0/0/0/14",
-    "description": "random interface test",
-    "Cisco-IOS-XR-infra-statsd-cfg:statistics": {
-      "load-interval": 30
-    },
-    "mtus": {
-      "mtu": [
-        {
-          "mtu": 9026,
-          "owner": "TwentyFiveGigE"
-        }
-      ]
-    },
-    "active": "act",
-    "Cisco-IOS-XR-infra-rsi-cfg:vrf": "default",
-    "Cisco-IOS-XR-ipv4-io-cfg:ipv4-network": {
-      "addresses": {
-        "primary": {
-          "address": "192.168.1.2",
-          "netmask": "255.255.255.0"
+  "interface-configurations": {
+    "interface-configuration": {
+      "interface-name": "TwentyFiveGigE0/0/0/14",
+      "description": "random interface test",
+      "Cisco-IOS-XR-infra-statsd-cfg:statistics": {
+        "load-interval": 30
+      },
+      "mtus": {
+        "mtu": [
+          {
+            "mtu": 9026,
+            "owner": "TwentyFiveGigE"
+          }
+        ]
+      },
+      "active": "act",
+      "Cisco-IOS-XR-infra-rsi-cfg:vrf": "default",
+      "Cisco-IOS-XR-ipv4-io-cfg:ipv4-network": {
+        "addresses": {
+          "primary": {
+            "address": "192.168.1.2",
+            "netmask": "255.255.255.0"
+          }
+        },
+        "mtu": 1000
+      },
+      "Cisco-IOS-XR-ipv6-ma-cfg:ipv6-network": {
+        "mtu": 2100,
+        "addresses": {
+          "regular-addresses": {
+            "regular-address": [
+              {
+                "address": "2001:db8::1",
+                "prefix-length": 64,
+                "zone": ""
+              }
+            ]
+          }
         }
       },
-      "mtu": 1000
-    },
-    "Cisco-IOS-XR-ipv6-ma-cfg:ipv6-network": {
-      "mtu": 2100,
-      "addresses": {
-        "regular-addresses": {
-          "regular-address": [
-            {
-              "address": "2001:db8::1",
-              "prefix-length": 64,
-              "zone": ""
-            }
-          ]
-        }
-      }
-    },
-    "Cisco-IOS-XR-ipv6-nd-cfg:ipv6-neighbor": {
-      "ra-suppress": true
-    },
-    
-    "shutdown": [null]
+      "Cisco-IOS-XR-ipv6-nd-cfg:ipv6-neighbor": {
+        "ra-suppress": true
+      },
+      "shutdown": [
+        null
+      ]
+    }
   }
 }

--- a/internal/provider/cisco/iosxr/testdata/vrf.json
+++ b/internal/provider/cisco/iosxr/testdata/vrf.json
@@ -1,63 +1,65 @@
 {
-  "vrf": {
-    "vrf-name": "vrf-name",
-    "description": "vrf-description",
-    "address-family": {
-      "ipv4": {
-        "unicast": {
-          "Cisco-IOS-XR-um-router-bgp-cfg:export": {
-            "route-target": {
-              "four-byte-as-route-targets": {
-                "four-byte-as-route-target": [
-                  {
-                    "four-byte-as-number": 4268359684,
-                    "asn4-index": 1101,
-                    "stitching": "disable"
-                  }
-                ]
+  "vrfs": {
+    "vrf": {
+      "vrf-name": "vrf-name",
+      "description": "vrf-description",
+      "address-family": {
+        "ipv4": {
+          "unicast": {
+            "Cisco-IOS-XR-um-router-bgp-cfg:export": {
+              "route-target": {
+                "four-byte-as-route-targets": {
+                  "four-byte-as-route-target": [
+                    {
+                      "four-byte-as-number": 4268359684,
+                      "asn4-index": 1101,
+                      "stitching": "disable"
+                    }
+                  ]
+                }
               }
-            }
-          },
-          "Cisco-IOS-XR-um-router-bgp-cfg:import": {
-            "route-target": {
-              "four-byte-as-route-targets": {
-                "four-byte-as-route-target": [
-                  {
-                    "four-byte-as-number": 4268359684,
-                    "asn4-index": 1101,
-                    "stitching": "disable"
-                  }
-                ]
+            },
+            "Cisco-IOS-XR-um-router-bgp-cfg:import": {
+              "route-target": {
+                "four-byte-as-route-targets": {
+                  "four-byte-as-route-target": [
+                    {
+                      "four-byte-as-number": 4268359684,
+                      "asn4-index": 1101,
+                      "stitching": "disable"
+                    }
+                  ]
+                }
               }
             }
           }
-        }
-      },
-      "ipv6": {
-        "unicast": {
-          "Cisco-IOS-XR-um-router-bgp-cfg:export": {
-            "route-target": {
-              "four-byte-as-route-targets": {
-                "four-byte-as-route-target": [
-                  {
-                    "four-byte-as-number": 4268359684,
-                    "asn4-index": 1101,
-                    "stitching": "disable"
-                  }
-                ]
+        },
+        "ipv6": {
+          "unicast": {
+            "Cisco-IOS-XR-um-router-bgp-cfg:export": {
+              "route-target": {
+                "four-byte-as-route-targets": {
+                  "four-byte-as-route-target": [
+                    {
+                      "four-byte-as-number": 4268359684,
+                      "asn4-index": 1101,
+                      "stitching": "disable"
+                    }
+                  ]
+                }
               }
-            }
-          },
-          "Cisco-IOS-XR-um-router-bgp-cfg:import": {
-            "route-target": {
-              "four-byte-as-route-targets": {
-                "four-byte-as-route-target": [
-                  {
-                    "four-byte-as-number": 4268359684,
-                    "asn4-index": 1101,
-                    "stitching": "disable"
-                  }
-                ]
+            },
+            "Cisco-IOS-XR-um-router-bgp-cfg:import": {
+              "route-target": {
+                "four-byte-as-route-targets": {
+                  "four-byte-as-route-target": [
+                    {
+                      "four-byte-as-number": 4268359684,
+                      "asn4-index": 1101,
+                      "stitching": "disable"
+                    }
+                  ]
+                }
               }
             }
           }


### PR DESCRIPTION
- Set interface mode to virtual for Bundle-Ether interfaces to ensure bundlemgr can find them
- Fix mode configuration for subinterfaces (use ModeNoPhysical instead of Mode)
- Add nil pointer checks for VRF and address families to prevent panics
- Correct XPath queries by removing leading slash for proper YANG path resolution
- Handle admin state (shutdown) configuration for all interface types