### PR TITLE
fix(provider/nxos): don't fail VRF deletion when BGP feature is missing

### DIFF
--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -469,8 +469,14 @@ func (p *Provider) DeleteBGP(ctx context.Context, req *provider.DeleteBGPRequest
 // The function is a no-op when the BGP feature is disabled.
 func (p *Provider) deleteBGP(ctx context.Context, vrfName string) error {
 	f := &Feature{Name: "bgp"}
-	if err := p.client.GetConfig(ctx, f); err != nil || f.AdminSt != AdminStEnabled {
+	if err := p.client.GetConfig(ctx, f); err != nil {
+		if errors.Is(err, gnmiext.ErrNil) {
+			return nil // ErrNil: path does not exist: feature is not enabled.
+		}
 		return err
+	}
+	if f.AdminSt != AdminStEnabled {
+		return nil
 	}
 
 	// Remove this domain's ownership marker from the default VRF.


### PR DESCRIPTION
deleteBGP checks if BGP is enabled before cleaning up. When the BGP feature doesn't exist on the device, GetConfig returns ErrNil. The current code returns this error instead of treating it as "nothing to clean up".

Handle ErrNil explicitly and return nil, same as when BGP is disabled.