### PR TITLE
Implement EVPN Fabric multicast PIM reconciliation

### DIFF
--- a/internal/controller/evpn/fabric_controller.go
+++ b/internal/controller/evpn/fabric_controller.go
@@ -59,6 +59,7 @@ type FabricReconciler struct {
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=isis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgp,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=bgppeers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=pim,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=pool.networking.metal.ironcore.dev,resources=claims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=pool.networking.metal.ironcore.dev,resources=ipaddresspools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=pool.networking.metal.ironcore.dev,resources=ipprefixpools,verbs=get;list;watch
@@ -173,6 +174,7 @@ func (r *FabricReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v1alpha1.ISIS{}).
 		Owns(&v1alpha1.BGP{}).
 		Owns(&v1alpha1.BGPPeer{}).
+		Owns(&v1alpha1.PIM{}).
 		// Re-reconcile when a Device's labels change so that devices newly
 		// matching a deviceSelector are enrolled into the fabric.
 		Watches(
@@ -208,6 +210,22 @@ func (r *FabricReconciler) reconcile(ctx context.Context, fabric *evpnv1alpha1.F
 		loopbacks: make(map[string][]*v1alpha1.Interface),
 		uplinks:   make(map[string][]*v1alpha1.Interface),
 	}
+
+	// The ordering of phases is critical. Each phase may depend on resources
+	// provisioned by earlier phases:
+	//
+	//  1. reconcileSystemLoopbacks — provisions lo0 (Router-ID) Claims and Interfaces.
+	//  2. reconcileVTEPLoopbacks   — provisions lo1/lo2 (VTEP) Claims and Interfaces.
+	//  3. reconcileAnycastRPLoopbacks — provisions lo100 (PIM anycast RP) Claims and Interfaces.
+	//  4. reconcileUnderlayLinks   — patches underlay p2p Interfaces with addressing;
+	//                                 populates state.uplinks used by later phases.
+	//  5. reconcileUnderlayIGP     — requires lo0 (router-ID) and uplinks from phases 1+4.
+	//  6. reconcileOverlayBGP      — requires lo0 (router-ID, peer address) from phase 1.
+	//  7. reconcileMulticastPIM    — requires lo0, lo1, lo100, and uplinks from phases 1–4.
+	//
+	// Phases that find their prerequisites missing (e.g. Claims not yet allocated)
+	// skip the affected device and return without error. The Owns() watches on
+	// Claim and Interface will re-enqueue the Fabric once the dependency appears.
 	phases := []ReconcileFunc{
 		r.reconcileSystemLoopbacks,
 		r.reconcileVTEPLoopbacks,
@@ -215,6 +233,7 @@ func (r *FabricReconciler) reconcile(ctx context.Context, fabric *evpnv1alpha1.F
 		r.reconcileUnderlayLinks,
 		r.reconcileUnderlayIGP,
 		r.reconcileOverlayBGP,
+		r.reconcileMulticastPIM,
 	}
 	for _, phase := range phases {
 		res, err := phase(ctx, fabric, state)
@@ -943,6 +962,199 @@ func (r *FabricReconciler) reconcileBGPPeer(ctx context.Context, local, remote *
 	}
 	if res == controllerutil.OperationResultCreated {
 		r.Recorder.Eventf(fabric, nil, "Normal", "BGPPeerCreated", "Reconcile", "Created overlay BGPPeer %s", name)
+	}
+	return nil
+}
+
+// reconcileMulticastPIM creates one PIM resource per device participating in any anycast
+// rendezvous point group. RP devices get anycastAddresses (peer lo0 IPs); client devices
+// get a static RP address only.
+func (r *FabricReconciler) reconcileMulticastPIM(ctx context.Context, fabric *evpnv1alpha1.Fabric, state *ReconcileState) (ctrl.Result, error) {
+	if fabric.Spec.BUM.PIM == nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Collect per-device PIM config across all RP groups.
+	rendezvousPoints := make(map[string][]v1alpha1.RendezvousPoint)
+	interfaceRefs := make(map[string][]v1alpha1.PIMInterface)
+
+	for _, rpGroup := range fabric.Spec.BUM.PIM.AnycastRendezvousPoints {
+		rpSelector, err := metav1.LabelSelectorAsSelector(&rpGroup.DeviceSelector)
+		if err != nil {
+			return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("invalid deviceSelector in RP group %q: %w", rpGroup.Name, err))
+		}
+		clientSelector, err := metav1.LabelSelectorAsSelector(&rpGroup.ClientDeviceSelector)
+		if err != nil {
+			return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("invalid clientDeviceSelector in RP group %q: %w", rpGroup.Name, err))
+		}
+
+		rpDevices := &v1alpha1.DeviceList{}
+		if err := r.List(ctx, rpDevices, client.InNamespace(fabric.Namespace), client.MatchingLabelsSelector{Selector: rpSelector}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("listing RP devices for group %q: %w", rpGroup.Name, err)
+		}
+		clientDevices := &v1alpha1.DeviceList{}
+		if err := r.List(ctx, clientDevices, client.InNamespace(fabric.Namespace), client.MatchingLabelsSelector{Selector: clientSelector}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("listing client devices for group %q: %w", rpGroup.Name, err)
+		}
+
+		// Resolve the anycast RP IP from the first RP device's lo100.
+		if len(rpDevices.Items) == 0 {
+			r.Recorder.Eventf(fabric, nil, "Warning", "NoRPDevices", "Reconcile", "No devices matched deviceSelector for RP group %q", rpGroup.Name)
+			continue
+		}
+
+		lo100Name := fmt.Sprintf("%s-%s-lo%d", fabric.Name, rpDevices.Items[0].Name, LoopbackAnycastRP)
+		loopbacks := state.loopbacks[rpDevices.Items[0].Name]
+
+		lo100Idx := slices.IndexFunc(loopbacks, func(intf *v1alpha1.Interface) bool { return intf.Name == lo100Name })
+		if lo100Idx < 0 {
+			ctrl.LoggerFrom(ctx).V(1).Info("Skipping PIM reconciliation: lo100 not yet allocated", "group", rpGroup.Name)
+			continue
+		}
+
+		lo100 := loopbacks[lo100Idx]
+		if lo100.Spec.IPv4 == nil || len(lo100.Spec.IPv4.Addresses) == 0 {
+			return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("lo100 interface %s has no IPv4 address", lo100Name))
+		}
+
+		anycastIP := lo100.Spec.IPv4.Addresses[0].Addr().String()
+
+		// Collect lo0 IPs of all RP devices for anycastAddresses.
+		rpLo0Addrs := make([]string, 0, len(rpDevices.Items))
+		for i := range rpDevices.Items {
+			lo0Name := fmt.Sprintf("%s-%s-lo%d", fabric.Name, rpDevices.Items[i].Name, LoopbackRouterID)
+			loopbacks := state.loopbacks[rpDevices.Items[i].Name]
+
+			lo0Idx := slices.IndexFunc(loopbacks, func(intf *v1alpha1.Interface) bool { return intf.Name == lo0Name })
+			if lo0Idx < 0 {
+				continue
+			}
+
+			lo0 := loopbacks[lo0Idx]
+			if lo0.Spec.IPv4 == nil || len(lo0.Spec.IPv4.Addresses) == 0 {
+				r.Recorder.Eventf(fabric, nil, "Warning", "MissingIPv4", "Reconcile", "lo0 interface %s has no IPv4 address", lo0Name)
+				continue
+			}
+
+			rpLo0Addrs = append(rpLo0Addrs, lo0.Spec.IPv4.Addresses[0].Addr().String())
+		}
+
+		// Configure RP devices.
+		for i := range rpDevices.Items {
+			device := &rpDevices.Items[i]
+
+			lo0Name := fmt.Sprintf("%s-%s-lo%d", fabric.Name, device.Name, LoopbackRouterID)
+			lo100Name := fmt.Sprintf("%s-%s-lo%d", fabric.Name, device.Name, LoopbackAnycastRP)
+			interfaces := state.loopbacks[device.Name]
+
+			idx := slices.IndexFunc(interfaces, func(intf *v1alpha1.Interface) bool { return intf.Name == lo0Name })
+			var selfAddr string
+			if idx >= 0 && interfaces[idx].Spec.IPv4 != nil && len(interfaces[idx].Spec.IPv4.Addresses) > 0 {
+				selfAddr = interfaces[idx].Spec.IPv4.Addresses[0].Addr().String()
+			}
+
+			// Exclude self from anycastAddresses.
+			var peerAddrs []string
+			for _, addr := range rpLo0Addrs {
+				if addr != selfAddr {
+					peerAddrs = append(peerAddrs, addr)
+				}
+			}
+			slices.Sort(peerAddrs)
+
+			rendezvousPoints[device.Name] = append(rendezvousPoints[device.Name], v1alpha1.RendezvousPoint{
+				Address:          anycastIP,
+				MulticastGroups:  rpGroup.MulticastGroups,
+				AnycastAddresses: peerAddrs,
+			})
+
+			// Interface refs for RP: lo0, lo100, uplinks.
+			interfaceRefs[device.Name] = append(
+				interfaceRefs[device.Name],
+				v1alpha1.PIMInterface{LocalObjectReference: v1alpha1.LocalObjectReference{Name: lo0Name}, Mode: v1alpha1.PIMModeSparse},
+				v1alpha1.PIMInterface{LocalObjectReference: v1alpha1.LocalObjectReference{Name: lo100Name}, Mode: v1alpha1.PIMModeSparse},
+			)
+			for _, up := range state.uplinks[device.Name] {
+				interfaceRefs[device.Name] = append(interfaceRefs[device.Name], v1alpha1.PIMInterface{
+					LocalObjectReference: v1alpha1.LocalObjectReference{Name: up.Name},
+					Mode:                 v1alpha1.PIMModeSparse,
+				})
+			}
+		}
+
+		// Configure client devices.
+		for i := range clientDevices.Items {
+			device := &clientDevices.Items[i]
+
+			rendezvousPoints[device.Name] = append(rendezvousPoints[device.Name], v1alpha1.RendezvousPoint{
+				Address:         anycastIP,
+				MulticastGroups: rpGroup.MulticastGroups,
+			})
+
+			// Interface refs for client: lo0, lo1 (VTEP), uplinks.
+			lo0Name := fmt.Sprintf("%s-%s-lo%d", fabric.Name, device.Name, LoopbackRouterID)
+			lo1Name := fmt.Sprintf("%s-%s-lo%d", fabric.Name, device.Name, LoopbackVTEP)
+			interfaceRefs[device.Name] = append(
+				interfaceRefs[device.Name],
+				v1alpha1.PIMInterface{LocalObjectReference: v1alpha1.LocalObjectReference{Name: lo0Name}, Mode: v1alpha1.PIMModeSparse},
+				v1alpha1.PIMInterface{LocalObjectReference: v1alpha1.LocalObjectReference{Name: lo1Name}, Mode: v1alpha1.PIMModeSparse},
+			)
+			for _, up := range state.uplinks[device.Name] {
+				interfaceRefs[device.Name] = append(interfaceRefs[device.Name], v1alpha1.PIMInterface{
+					LocalObjectReference: v1alpha1.LocalObjectReference{Name: up.Name},
+					Mode:                 v1alpha1.PIMModeSparse,
+				})
+			}
+		}
+	}
+
+	// Create or update one PIM resource per device.
+	for deviceName := range rendezvousPoints {
+		if err := r.reconcilePIM(ctx, deviceName, fabric, rendezvousPoints[deviceName], interfaceRefs[deviceName]); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// reconcilePIM creates or updates the PIM resource for a fabric device.
+func (r *FabricReconciler) reconcilePIM(ctx context.Context, deviceName string, fabric *evpnv1alpha1.Fabric, rps []v1alpha1.RendezvousPoint, refs []v1alpha1.PIMInterface) error {
+	name := fmt.Sprintf("%s-%s-multicast", fabric.Name, deviceName)
+
+	// Deduplicate interface refs (a device in multiple RP groups gets duplicates) and sort.
+	seen := sets.New[string]()
+	intfRefs := make([]v1alpha1.PIMInterface, 0, len(refs))
+	for _, ref := range refs {
+		if !seen.Has(ref.Name) {
+			seen.Insert(ref.Name)
+			intfRefs = append(intfRefs, ref)
+		}
+	}
+	slices.SortFunc(intfRefs, func(a, b v1alpha1.PIMInterface) int { return cmp.Compare(a.Name, b.Name) })
+
+	pim := &v1alpha1.PIM{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: fabric.Namespace,
+		},
+	}
+	res, err := controllerutil.CreateOrPatch(ctx, r.Client, pim, func() error {
+		if pim.Labels == nil {
+			pim.Labels = make(map[string]string)
+		}
+		pim.Labels[evpnv1alpha1.FabricLabel] = fabric.Name
+		pim.Spec.DeviceRef = v1alpha1.LocalObjectReference{Name: deviceName}
+		pim.Spec.AdminState = v1alpha1.AdminStateUp
+		pim.Spec.RendezvousPoints = rps
+		pim.Spec.InterfaceRefs = intfRefs
+		return controllerutil.SetControllerReference(fabric, pim, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("reconciling PIM %s: %w", name, err)
+	}
+	if res == controllerutil.OperationResultCreated {
+		r.Recorder.Eventf(fabric, nil, "Normal", "PIMCreated", "Reconcile", "Created multicast PIM %s", name)
 	}
 	return nil
 }

--- a/internal/controller/evpn/fabric_controller_test.go
+++ b/internal/controller/evpn/fabric_controller_test.go
@@ -438,6 +438,65 @@ var _ = Describe("Fabric Controller", func() {
 				}
 			}
 
+			By("Verifying PIM resources are created for RP devices (spines) with anycast addresses")
+			for _, spine := range []*corev1alpha1.Device{spine1, spine2} {
+				Eventually(func(g Gomega) {
+					pim := &corev1alpha1.PIM{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: fabric.Name + "-" + spine.Name + "-multicast", Namespace: metav1.NamespaceDefault}, pim)).To(Succeed())
+					g.Expect(pim.Spec.DeviceRef.Name).To(Equal(spine.Name))
+					g.Expect(pim.Spec.AdminState).To(Equal(corev1alpha1.AdminStateUp))
+
+					// RP must have a rendezvous point entry with anycast addresses (other spine lo0 IPs).
+					g.Expect(pim.Spec.RendezvousPoints).To(HaveLen(1))
+					rp := pim.Spec.RendezvousPoints[0]
+
+					// Anycast IP is the lo100 address.
+					lo100 := &corev1alpha1.Interface{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: fabric.Name + "-" + spine.Name + "-lo100", Namespace: metav1.NamespaceDefault}, lo100)).To(Succeed())
+					g.Expect(lo100.Spec.IPv4).NotTo(BeNil())
+					g.Expect(rp.Address).To(Equal(lo100.Spec.IPv4.Addresses[0].Addr().String()))
+
+					g.Expect(rp.MulticastGroups).To(HaveLen(1))
+					g.Expect(rp.MulticastGroups[0].String()).To(Equal("224.0.0.0/4"))
+
+					// AnycastAddresses should contain the other spine's lo0 IP (not self).
+					g.Expect(rp.AnycastAddresses).To(HaveLen(1))
+
+					// Interface refs should include lo0, lo100, and the uplink.
+					g.Expect(pim.Spec.InterfaceRefs).To(ContainElement(HaveField("Name", fabric.Name+"-"+spine.Name+"-lo0")))
+					g.Expect(pim.Spec.InterfaceRefs).To(ContainElement(HaveField("Name", fabric.Name+"-"+spine.Name+"-lo100")))
+
+					g.Expect(pim.OwnerReferences).To(ContainElement(SatisfyAll(
+						HaveField("Kind", "Fabric"),
+						HaveField("Name", fabric.Name),
+						HaveField("Controller", HaveValue(BeTrue())),
+					)))
+				}).Should(Succeed())
+			}
+
+			By("Verifying PIM resources are created for client devices (leaves) without anycast addresses")
+			for _, leaf := range []*corev1alpha1.Device{leaf1, leaf2} {
+				Eventually(func(g Gomega) {
+					pim := &corev1alpha1.PIM{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: fabric.Name + "-" + leaf.Name + "-multicast", Namespace: metav1.NamespaceDefault}, pim)).To(Succeed())
+					g.Expect(pim.Spec.DeviceRef.Name).To(Equal(leaf.Name))
+
+					g.Expect(pim.Spec.RendezvousPoints).To(HaveLen(1))
+					rp := pim.Spec.RendezvousPoints[0]
+
+					// Same anycast IP as spines.
+					g.Expect(rp.Address).NotTo(BeEmpty())
+					g.Expect(rp.MulticastGroups).To(HaveLen(1))
+
+					// Clients have no anycast addresses.
+					g.Expect(rp.AnycastAddresses).To(BeEmpty())
+
+					// Interface refs should include lo0, lo1 (VTEP).
+					g.Expect(pim.Spec.InterfaceRefs).To(ContainElement(HaveField("Name", fabric.Name+"-"+leaf.Name+"-lo0")))
+					g.Expect(pim.Spec.InterfaceRefs).To(ContainElement(HaveField("Name", fabric.Name+"-"+leaf.Name+"-lo1")))
+				}).Should(Succeed())
+			}
+
 			By("Verifying the Fabric Ready condition is True once all phases are complete")
 			Eventually(func(g Gomega) {
 				f := &evpnv1alpha1.Fabric{}


### PR DESCRIPTION
Add a reconcileMulticastPIM phase that creates one PIM resource per device participating in any anycast rendezvous point group.

RP devices get anycastAddresses populated with peer RP lo0 IPs for redundancy. Client devices get a static RP address pointing to the shared anycast IP (lo100). PIM sparse mode is enabled on lo0, lo100 or lo1, and all fabric uplinks.