### PR TITLE
Bump cert-manager to v1.21.0 and detect kind cluster in Tiltfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ setup-test-e2e: kind ## Set up a Kind cluster for e2e tests if it does not exist
 
 # E2E test dependency versions
 E2E_PROMETHEUS_OPERATOR_VERSION ?= v0.82.2
-E2E_CERTMANAGER_VERSION ?= v1.17.2
+E2E_CERTMANAGER_VERSION ?= v1.21.0
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,8 +11,11 @@ watch_settings(ignore=['**/*/zz_generated.deepcopy.go', 'config/crd/bases/*'])
 
 allow_k8s_contexts(['minikube', 'kind-network-operator'])
 
+cluster_name = str(local('kubectl config current-context', quiet=True)).strip()
+is_kind = cluster_name.startswith('kind-')
+
 load('ext://cert_manager', 'deploy_cert_manager')
-deploy_cert_manager(version='v1.18.2')
+deploy_cert_manager(version='v1.21.0', load_to_kind=is_kind, kind_cluster_name=cluster_name.removeprefix('kind-'))
 
 docker_build('controller:latest', '.', only=[
     'api/', 'cmd/', 'internal/', 'go.mod', 'go.sum'


### PR DESCRIPTION
Detect the active kube context at Tilt startup and set
load_to_kind/kind_cluster_name dynamically so cert-manager images
are side-loaded only when running against a kind cluster.

Align the E2E test cert-manager version in the Makefile.