### PR TITLE
Improve test reliability by waiting for resources to be fully deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Dockerfile.cross
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+cover.html
 
 # Go workspace file
 go.work

--- a/internal/controller/core/acl_controller_test.go
+++ b/internal/controller/core/acl_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -78,6 +79,12 @@ var _ = Describe("AccessControlList Controller", func() {
 
 			By("Cleanup the specific resource instance AccessControlList")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for AccessControlList to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.AccessControlList{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/banner_controller_test.go
+++ b/internal/controller/core/banner_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -45,6 +46,12 @@ var _ = Describe("Banner Controller", func() {
 
 			By("Cleanup the specific resource instance Banner")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for Banner to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.Banner{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -267,6 +267,7 @@ var _ = Describe("BGPPeer Controller", func() {
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).NotTo(BeEmpty())
 				g.Expect(conditions.IsConfigured(resource)).To(BeFalse()) // checks ObservedGeneration too
 			}).Should(Succeed())
 
@@ -525,6 +526,7 @@ var _ = Describe("BGPPeer Controller", func() {
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
+				g.Expect(resource.Status.Conditions).NotTo(BeEmpty())
 				g.Expect(conditions.IsConfigured(resource)).To(BeFalse()) // checks ObservedGeneration too
 			}).Should(Succeed())
 

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -263,6 +263,13 @@ var _ = Describe("BGPPeer Controller", func() {
 				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
 			})
 
+			By("Waiting for BGPPeer's condition to be fully consistent")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGPPeer{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
+				g.Expect(conditions.IsConfigured(resource)).To(BeFalse()) // checks ObservedGeneration too
+			}).Should(Succeed())
+
 			By("Verifying the controller sets Interface not found status")
 			Eventually(func(g Gomega) {
 				resource := &v1alpha1.BGPPeer{}
@@ -513,6 +520,13 @@ var _ = Describe("BGPPeer Controller", func() {
 					g.Expect(testProvider.BGPPeers.Has(host)).To(BeFalse(), "Provider should not have BGP peer configured")
 				}).Should(Succeed())
 			})
+
+			By("Waiting for BGPPeer's condition to be fully consistent")
+			Eventually(func(g Gomega) {
+				resource := &v1alpha1.BGPPeer{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgppeer), resource)).To(Succeed())
+				g.Expect(conditions.IsConfigured(resource)).To(BeFalse()) // checks ObservedGeneration too
+			}).Should(Succeed())
 
 			By("Verifying the controller sets Configured=False with appropriate reason")
 			Eventually(func(g Gomega) {

--- a/internal/controller/core/certificate_controller_test.go
+++ b/internal/controller/core/certificate_controller_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -87,6 +88,12 @@ var _ = Describe("Certificate Controller", func() {
 
 			By("Cleanup the specific resource instance Certificate")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for Certificate to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.Certificate{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/dhcprelay_controller_test.go
+++ b/internal/controller/core/dhcprelay_controller_test.go
@@ -1075,12 +1075,20 @@ var _ = Describe("DHCPRelay Controller", func() {
 			err = k8sClient.Get(ctx, interfaceKey, intf)
 			if err == nil {
 				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, interfaceKey, &v1alpha1.Interface{})
+					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}).Should(Succeed())
 			}
 
 			By("Cleaning up the VLAN resource")
 			err = k8sClient.Get(ctx, vlanKey, vlan)
 			if err == nil {
 				Expect(k8sClient.Delete(ctx, vlan)).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, vlanKey, &v1alpha1.VLAN{})
+					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}).Should(Succeed())
 			}
 
 			By("Cleaning up the Device resource")

--- a/internal/controller/core/dns_controller_test.go
+++ b/internal/controller/core/dns_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -64,6 +65,12 @@ var _ = Describe("DNS Controller", func() {
 
 			By("Cleanup the specific resource instance DNS")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for DNS to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.DNS{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/isis_controller_test.go
+++ b/internal/controller/core/isis_controller_test.go
@@ -5,6 +5,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,6 +66,12 @@ var _ = Describe("ISIS Controller", func() {
 
 			By("Cleanup the specific resource instance ISIS")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for ISIS to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.ISIS{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/lldp_controller_test.go
+++ b/internal/controller/core/lldp_controller_test.go
@@ -406,6 +406,15 @@ var _ = Describe("LLDP Controller", func() {
 				g.Expect(k8sClient.Update(ctx, device)).To(Succeed())
 			}).Should(Succeed())
 
+			By("Waiting for LLDP to acknowledge the pause")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, lldp)
+				g.Expect(err).NotTo(HaveOccurred())
+				cond := meta.FindStatusCondition(lldp.Status.Conditions, v1alpha1.PausedCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed())
+
 			By("Updating LLDP AdminState to Down")
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, resourceKey, lldp)

--- a/internal/controller/core/managementaccess_controller_test.go
+++ b/internal/controller/core/managementaccess_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -62,6 +63,12 @@ var _ = Describe("ManagementAccess Controller", func() {
 
 			By("Cleanup the specific resource instance ManagementAccess")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for ManagementAccess to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.ManagementAccess{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/ntp_controller_test.go
+++ b/internal/controller/core/ntp_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -65,6 +66,12 @@ var _ = Describe("NTP Controller", func() {
 
 			By("Cleanup the specific resource instance NTP")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for NTP to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.NTP{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/ospf_controller_test.go
+++ b/internal/controller/core/ospf_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +61,12 @@ var _ = Describe("OSPF Controller", func() {
 
 			By("Cleanup the specific resource instance OSPF")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for OSPF to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.OSPF{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/pim_controller_test.go
+++ b/internal/controller/core/pim_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,6 +59,12 @@ var _ = Describe("PIM Controller", func() {
 
 			By("Cleanup the specific resource instance PIM")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for PIM to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.PIM{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/prefixset_controller_test.go
+++ b/internal/controller/core/prefixset_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -69,6 +70,12 @@ var _ = Describe("PrefixSet Controller", func() {
 
 			By("Cleanup the specific resource instance PrefixSet")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for PrefixSet to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.PrefixSet{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/snmp_controller_test.go
+++ b/internal/controller/core/snmp_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -76,6 +77,12 @@ var _ = Describe("SNMP Controller", func() {
 
 			By("Cleanup the specific resource instance SNMP")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for SNMP to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.SNMP{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -342,11 +342,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&EthernetSegmentReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Recorder: recorder,
-		Provider: prov,
-		Locker:   testLocker,
+		Client:          k8sManager.GetClient(),
+		Scheme:          k8sManager.GetScheme(),
+		Recorder:        recorder,
+		Provider:        prov,
+		Locker:          testLocker,
+		RequeueInterval: time.Second,
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/core/syslog_controller_test.go
+++ b/internal/controller/core/syslog_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -71,6 +72,12 @@ var _ = Describe("Syslog Controller", func() {
 
 			By("Cleanup the specific resource instance Syslog")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for Syslog to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.Syslog{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/user_controller_test.go
+++ b/internal/controller/core/user_controller_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -81,6 +82,12 @@ var _ = Describe("User Controller", func() {
 
 			By("Cleanup the specific resource instance User")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for User to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, key, &v1alpha1.User{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)

--- a/internal/controller/core/vlan_controller_test.go
+++ b/internal/controller/core/vlan_controller_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -61,6 +62,12 @@ var _ = Describe("VLAN Controller", func() {
 
 			By("Cleanup the specific resource instance VLAN")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Waiting for the VLAN to be fully deleted")
+			Eventually(func(g Gomega) {
+				vlan := &v1alpha1.VLAN{}
+				g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, key, vlan))).To(BeTrue())
+			}).Should(Succeed())
 
 			resource = &v1alpha1.Device{}
 			err = k8sClient.Get(ctx, key, resource)


### PR DESCRIPTION
While working on https://github.com/ironcore-dev/network-operator/pull/426 I noticed that the tests are unreliable. Typical rate was 1-2 fails out of 10 runs of the test suite. Different tests would fail each time and it was hard to reproduce the failures reliably.

The root cause seems to be this. Envtest [doesn't run any controllers](https://book.kubebuilder.io/reference/envtest.html#testing-considerations), therefore the tests need to delete the created resources manually. This is already handled in the existing `AfterEach` blocks. However the deletion could happen too quickly, before the controller could finalize the resource(s). This would then trigger a cascade failure, where resources that should have been deleted are still present (or vice versa) and other related conditions.

For example in the Device tests, the added `Eventually(IsNotFound)` waits after deleting the primary resource and before deleting the Device in `AfterEach`. Without the wait, the Device could be deleted before the controller had a chance to finalize the resource — causing `GetDeviceByName` to fail, the finalizer to never be removed, and the provider state to never be cleaned up.

Also the `EthernetSegmentController` was registered in `suite_test.go` without `RequeueInterval`, meaning it would always run only 1 round of reconciliation and never get polled again.

This PR consists of the extracted test fixes from https://github.com/ironcore-dev/network-operator/pull/426 + several small additional fixes that were required to make this PR pass the tests on its own. 

Also adding the generated `cover.html` file to gitignore