### PR TITLE
Replace PropagationPolicy and DeleteAllOf in controller tests

### DIFF
--- a/internal/controller/cisco/nx/bordergateway_controller_test.go
+++ b/internal/controller/cisco/nx/bordergateway_controller_test.go
@@ -76,24 +76,22 @@ var _ = Describe("BorderGateway Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &nxv1alpha1.BorderGateway{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance BorderGateway")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("Cleaning up the BorderGateway resource")
+			bg := &nxv1alpha1.BorderGateway{}
+			bg.Name = name
+			bg.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bg))).To(Succeed())
 
 			By("Ensuring the resource is deleted from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.BorderGateway).To(BeNil(), "Provider BorderGateway settings should be reset after deletion")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/cisco/nx/system_controller_test.go
+++ b/internal/controller/cisco/nx/system_controller_test.go
@@ -55,24 +55,22 @@ var _ = Describe("System Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &nxv1alpha1.System{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance System")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("Cleaning up the System resource")
+			system := &nxv1alpha1.System{}
+			system.Name = name
+			system.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, system))).To(Succeed())
 
 			By("Ensuring the resource is deleted from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.Settings).To(BeNil(), "Provider System settings should be reset after deletion")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/cisco/nx/vpcdomain_controller_test.go
+++ b/internal/controller/cisco/nx/vpcdomain_controller_test.go
@@ -116,16 +116,16 @@ var _ = Describe("VPCDomain Controller", func() {
 			By("Cleanup the specific resource instance VPCDomain")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
+			By("Ensuring the resource is deleted from the provider")
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.VPCDomain).To(BeNil(), "Provider VPCDomain should be nil")
+			}).Should(Succeed())
+
 			resource = &corev1.Device{}
 			Expect(k8sClient.Get(ctx, key, resource)).To(Succeed())
 
 			By("Cleanup the specific resource instance Device")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
-			Eventually(func(g Gomega) {
-				g.Expect(testProvider.VPCDomain).To(BeNil(), "Provider VPCDomain should be nil")
-			}).Should(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -296,18 +296,28 @@ var _ = Describe("VPCDomain Controller", func() {
 			By("Cleanup the VPCDomain")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
-			By("Cleanup all Interface and VRF resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &corev1.Interface{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-			Expect(k8sClient.DeleteAllOf(ctx, &corev1.VRF{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-
-			By("Cleanup Device A and B")
-			Expect(k8sClient.Delete(ctx, &corev1.Device{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault}})).To(Succeed())
-			Expect(k8sClient.Delete(ctx, &corev1.Device{ObjectMeta: metav1.ObjectMeta{Name: name + "-b", Namespace: metav1.NamespaceDefault}})).To(Succeed())
+			By("Cleanup Interface and VRF resources")
+			for _, ifName := range []string{name + "-phys", name + "-po", name + "-phys-b", name + "-po-b", name + "-lo0"} {
+				intf := &corev1.Interface{}
+				intf.Name = ifName
+				intf.Namespace = metav1.NamespaceDefault
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
+			}
+			for _, vrfName := range []string{name + "-vrf-a", name + "-vrf-b"} {
+				vrf := &corev1.VRF{}
+				vrf.Name = vrfName
+				vrf.Namespace = metav1.NamespaceDefault
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vrf))).To(Succeed())
+			}
 
 			By("Ensuring the resource is deleted from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.VPCDomain).To(BeNil(), "Provider VPCDomain should be nil")
 			}).Should(Succeed())
+
+			By("Cleanup Device A and B")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &corev1.Device{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault}}))).To(Succeed())
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &corev1.Device{ObjectMeta: metav1.ObjectMeta{Name: name + "-b", Namespace: metav1.NamespaceDefault}}))).To(Succeed())
 		})
 
 		It("reports WaitingForDependencies when peer-link interface is missing", func() {

--- a/internal/controller/core/acl_controller_test.go
+++ b/internal/controller/core/acl_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -73,30 +72,22 @@ var _ = Describe("AccessControlList Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.AccessControlList{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the AccessControlList resource")
+			acl := &v1alpha1.AccessControlList{}
+			acl.Name = name
+			acl.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, acl))).To(Succeed())
 
-			By("Cleanup the specific resource instance AccessControlList")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for AccessControlList to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.AccessControlList{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.ACLs.Has(name)).To(BeFalse(), "Provider shouldn't have AccessControlList configured anymore")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/banner_controller_test.go
+++ b/internal/controller/core/banner_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -40,31 +39,23 @@ var _ = Describe("Banner Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.Banner{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the Banner resource")
+			banner := &v1alpha1.Banner{}
+			banner.Name = name
+			banner.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, banner))).To(Succeed())
 
-			By("Cleanup the specific resource instance Banner")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for Banner to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.Banner{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.PreLoginBanner).To(BeNil(), "Provider PreLogin Banner should be nil")
 				g.Expect(testProvider.PostLoginBanner).To(BeNil(), "Provider PostLogin Banner should be nil")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile a PreLogin Banner", func() {

--- a/internal/controller/core/bgp_controller_test.go
+++ b/internal/controller/core/bgp_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,8 +36,41 @@ var _ = Describe("BGP Controller", func() {
 		})
 
 		AfterEach(func() {
+			By("Cleaning up BGP resources for this device")
+			bgpList := &v1alpha1.BGPList{}
+			Expect(k8sClient.List(ctx, bgpList, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+			for i := range bgpList.Items {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &bgpList.Items[i]))).To(Succeed())
+			}
+
+			By("Cleaning up VRF resources for this device")
+			vrfList := &v1alpha1.VRFList{}
+			Expect(k8sClient.List(ctx, vrfList, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+			for i := range vrfList.Items {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &vrfList.Items[i]))).To(Succeed())
+			}
+
+			By("Cleaning up RoutingPolicy resources for this device")
+			rpList := &v1alpha1.RoutingPolicyList{}
+			Expect(k8sClient.List(ctx, rpList, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+			for i := range rpList.Items {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &rpList.Items[i]))).To(Succeed())
+			}
+
+			By("Waiting for BGP resources to be fully deleted")
+			Eventually(func(g Gomega) {
+				list := &v1alpha1.BGPList{}
+				g.Expect(k8sClient.List(ctx, list, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+				g.Expect(list.Items).To(BeEmpty())
+			}).Should(Succeed())
+
+			By("Verifying BGP is removed from the provider")
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.BGP).To(BeNil(), "Provider should not have BGP instance configured")
+			}).Should(Succeed())
+
 			By("Deleting the Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -55,17 +87,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-				Eventually(func(g Gomega) {
-					b := &v1alpha1.BGP{}
-					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
-				}).Should(Succeed())
-				By("Ensuring the resource is deleted from the provider")
-				Eventually(func(g Gomega) {
-					g.Expect(testProvider.BGP).To(BeNil(), "Provider should not have BGP instance configured")
-				}).Should(Succeed())
-			})
 
 			By("Adding a finalizer to the resource")
 			Eventually(func(g Gomega) {
@@ -122,13 +143,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-				Eventually(func(g Gomega) {
-					b := &v1alpha1.BGP{}
-					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
-				}).Should(Succeed())
-			})
 
 			By("Expecting ReadyCondition to be False with VRFNotFoundReason reason")
 			Eventually(func(g Gomega) {
@@ -154,9 +168,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, vrf)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, vrf)).To(Succeed())
-			})
 
 			By("Creating a BGP with the vrfRef set")
 			bgp := &v1alpha1.BGP{
@@ -172,13 +183,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-				Eventually(func(g Gomega) {
-					b := &v1alpha1.BGP{}
-					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
-				}).Should(Succeed())
-			})
 
 			By("Ensuring the provider receives the VRF")
 			Eventually(func(g Gomega) {
@@ -218,13 +222,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-				Eventually(func(g Gomega) {
-					b := &v1alpha1.BGP{}
-					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
-				}).Should(Succeed())
-			})
 
 			By("Expecting ReadyCondition to be False with WaitingForDependencies reason")
 			Eventually(func(g Gomega) {
@@ -256,13 +253,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, rp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, rp)).To(Succeed())
-				Eventually(func(g Gomega) {
-					r := &v1alpha1.RoutingPolicy{}
-					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rp), r))).To(BeTrue())
-				}).Should(Succeed())
-			})
 
 			By("Expecting ReadyCondition to become True after the RoutingPolicy is created")
 			Eventually(func(g Gomega) {
@@ -288,13 +278,6 @@ var _ = Describe("BGP Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-				Eventually(func(g Gomega) {
-					b := &v1alpha1.BGP{}
-					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(bgp), b))).To(BeTrue())
-				}).Should(Succeed())
-			})
 
 			By("Waiting for the BGP to be reconciled so we know it exists")
 			Eventually(func(g Gomega) {

--- a/internal/controller/core/bgp_peer_controller_test.go
+++ b/internal/controller/core/bgp_peer_controller_test.go
@@ -37,8 +37,41 @@ var _ = Describe("BGPPeer Controller", func() {
 		})
 
 		AfterEach(func() {
+			By("Cleaning up BGPPeer resources for this device")
+			peerList := &v1alpha1.BGPPeerList{}
+			Expect(k8sClient.List(ctx, peerList, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+			for i := range peerList.Items {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &peerList.Items[i]))).To(Succeed())
+			}
+
+			By("Cleaning up BGP resources for this device")
+			bgpList := &v1alpha1.BGPList{}
+			Expect(k8sClient.List(ctx, bgpList, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+			for i := range bgpList.Items {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &bgpList.Items[i]))).To(Succeed())
+			}
+
+			By("Cleaning up Interface resources for this device")
+			intfList := &v1alpha1.InterfaceList{}
+			Expect(k8sClient.List(ctx, intfList, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+			for i := range intfList.Items {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &intfList.Items[i]))).To(Succeed())
+			}
+
+			By("Waiting for BGPPeer resources to be fully deleted")
+			Eventually(func(g Gomega) {
+				list := &v1alpha1.BGPPeerList{}
+				g.Expect(k8sClient.List(ctx, list, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: device.Name})).To(Succeed())
+				g.Expect(list.Items).To(BeEmpty())
+			}).Should(Succeed())
+
+			By("Verifying BGP peer is removed from the provider")
+			Eventually(func(g Gomega) {
+				g.Expect(testProvider.BGPPeers.Len()).To(Equal(0), "Provider should not have any BGP peers configured")
+			}).Should(Succeed())
+
 			By("Deleting the Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile a BGP peer", func() {
@@ -55,9 +88,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-			})
 
 			By("Waiting for the BGP resource to be fully configured")
 			Eventually(func(g Gomega) {
@@ -80,13 +110,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-				By("Verifying the BGP peer is removed from the provider")
-				Eventually(func(g Gomega) {
-					g.Expect(testProvider.BGPPeers.Has(host)).To(BeFalse(), "Provider should not have BGP peer configured")
-				}).Should(Succeed())
-			})
 
 			By("Verifying the controller adds a finalizer")
 			Eventually(func(g Gomega) {
@@ -146,9 +169,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-			})
 
 			By("Waiting for the BGP resource to be fully configured")
 			Eventually(func(g Gomega) {
@@ -171,9 +191,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, intf)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-			})
 
 			By("Creating a BGPPeer resource with LocalAddress pointing to the Interface")
 			bgppeer := &v1alpha1.BGPPeer{
@@ -192,9 +209,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			})
 
 			By("Verifying the controller updates the status conditions successfully")
 			Eventually(func(g Gomega) {
@@ -231,9 +245,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-			})
 
 			By("Waiting for the BGP resource to be fully configured")
 			Eventually(func(g Gomega) {
@@ -259,9 +270,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			})
 
 			By("Waiting for BGPPeer's condition to be fully consistent")
 			Eventually(func(g Gomega) {
@@ -302,9 +310,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-			})
 
 			By("Waiting for the BGP resource to be fully configured")
 			Eventually(func(g Gomega) {
@@ -327,9 +332,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, intf)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-			})
 
 			By("Creating a BGPPeer resource with LocalAddress pointing to the cross-device Interface")
 			bgppeer := &v1alpha1.BGPPeer{
@@ -348,9 +350,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			})
 
 			By("Verifying the BGP peer rejects the cross-device interface reference")
 			Eventually(func(g Gomega) {
@@ -384,9 +383,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			})
 
 			By("Verifying the controller sets ConfiguredCondition to False with BGPNotFoundReason")
 			Eventually(func(g Gomega) {
@@ -427,9 +423,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, pausedBGP)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, pausedBGP)).To(Succeed())
-			})
 
 			By("Creating a BGPPeer referencing the paused BGP")
 			bgppeer := &v1alpha1.BGPPeer{
@@ -445,9 +438,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-			})
 
 			By("Verifying the controller sets ConfiguredCondition to False with WaitingForDependenciesReason")
 			Eventually(func(g Gomega) {
@@ -486,9 +476,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgp)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgp)).To(Succeed())
-			})
 
 			By("Waiting for the BGP resource to be fully configured")
 			Eventually(func(g Gomega) {
@@ -514,13 +501,6 @@ var _ = Describe("BGPPeer Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bgppeer)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, bgppeer)).To(Succeed())
-				By("Verifying the BGP peer is removed from the provider")
-				Eventually(func(g Gomega) {
-					g.Expect(testProvider.BGPPeers.Has(host)).To(BeFalse(), "Provider should not have BGP peer configured")
-				}).Should(Succeed())
-			})
 
 			By("Waiting for BGPPeer's condition to be fully consistent")
 			Eventually(func(g Gomega) {

--- a/internal/controller/core/certificate_controller_test.go
+++ b/internal/controller/core/certificate_controller_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -82,30 +81,28 @@ var _ = Describe("Certificate Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.Certificate{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the Certificate resource")
+			certificate := &v1alpha1.Certificate{}
+			certificate.Name = name
+			certificate.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, certificate))).To(Succeed())
 
-			By("Cleanup the specific resource instance Certificate")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("Cleaning up the Secret resource")
+			secret := &corev1.Secret{}
+			secret.Name = name
+			secret.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, secret))).To(Succeed())
 
-			By("Waiting for Certificate to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.Certificate{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.Certs.Has("cert1")).To(BeFalse(), "Certificate should be deleted from the provider")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/device_controller_test.go
+++ b/internal/controller/core/device_controller_test.go
@@ -43,19 +43,17 @@ var _ = Describe("Device Controller", func() {
 		})
 
 		AfterEach(func() {
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
-
 			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, device)).To(Succeed())
-
-			secret := &corev1.Secret{}
-			err = k8sClient.Get(ctx, key, secret)
-			Expect(err).NotTo(HaveOccurred())
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 
 			By("Cleanup the specific resource instance Secret")
-			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			secret := &corev1.Secret{}
+			secret.Name = name
+			secret.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, secret))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/dhcprelay_controller_test.go
+++ b/internal/controller/core/dhcprelay_controller_test.go
@@ -102,48 +102,46 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay = &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
 
-				By("Waiting for DHCPRelay resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			By("Waiting for DHCPRelay resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the Interface resource")
 			intf = &v1alpha1.Interface{}
-			err = k8sClient.Get(ctx, interfaceKey, intf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, interfaceKey, &v1alpha1.Interface{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			intf.Name = interfaceKey.Name
+			intf.Namespace = interfaceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, interfaceKey, &v1alpha1.Interface{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the VLAN resource")
 			vlan = &v1alpha1.VLAN{}
-			err = k8sClient.Get(ctx, vlanKey, vlan)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, vlan)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, vlanKey, &v1alpha1.VLAN{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			vlan.Name = vlanKey.Name
+			vlan.Namespace = vlanKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vlan))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, vlanKey, &v1alpha1.VLAN{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the resource has been deleted")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.DHCPRelay).To(BeNil(), "Provider should have no DHCPRelay configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -332,15 +330,9 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay := &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				// Remove finalizer if present to allow deletion
-				if controllerutil.ContainsFinalizer(dhcprelay, v1alpha1.FinalizerName) {
-					controllerutil.RemoveFinalizer(dhcprelay, v1alpha1.FinalizerName)
-					Expect(k8sClient.Update(ctx, dhcprelay)).To(Succeed())
-				}
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
-			}
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
 		})
 
 		It("Should not add finalizer when Device does not exist", func() {
@@ -401,20 +393,19 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay := &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			device := &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should set ConfiguredCondition to False when Interface does not exist", func() {
@@ -541,36 +532,35 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay := &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the Interface resource")
-			err = k8sClient.Get(ctx, otherIntfKey, otherIntf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, otherIntf)).To(Succeed())
-			}
+			otherIntf := &v1alpha1.Interface{}
+			otherIntf.Name = otherIntfKey.Name
+			otherIntf.Namespace = otherIntfKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, otherIntf))).To(Succeed())
 
 			By("Cleaning up the VLAN resource")
-			err = k8sClient.Get(ctx, otherVlanKey, otherVlan)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, otherVlan)).To(Succeed())
-			}
+			otherVlan := &v1alpha1.VLAN{}
+			otherVlan.Name = otherVlanKey.Name
+			otherVlan.Namespace = otherVlanKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, otherVlan))).To(Succeed())
 
 			By("Cleaning up the Device resources")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
-			err = k8sClient.Get(ctx, otherDeviceKey, otherDevice)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, otherDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			device := &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
+			otherDevice := &v1alpha1.Device{}
+			otherDevice.Name = otherDeviceKey.Name
+			otherDevice.Namespace = otherDeviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, otherDevice))).To(Succeed())
 		})
 
 		It("Should set ConfiguredCondition to False with CrossDeviceReferenceReason", func() {
@@ -724,42 +714,41 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay := &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the VRF resource")
-			err = k8sClient.Get(ctx, otherVrfKey, otherVrf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, otherVrf)).To(Succeed())
-			}
+			otherVrf := &v1alpha1.VRF{}
+			otherVrf.Name = otherVrfKey.Name
+			otherVrf.Namespace = otherVrfKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, otherVrf))).To(Succeed())
 
 			By("Cleaning up the Interface resource")
-			err = k8sClient.Get(ctx, interfaceKey, intf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-			}
+			intf := &v1alpha1.Interface{}
+			intf.Name = interfaceKey.Name
+			intf.Namespace = interfaceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 
 			By("Cleaning up the VLAN resource")
-			err = k8sClient.Get(ctx, vlanKey, vlan)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, vlan)).To(Succeed())
-			}
+			vlan := &v1alpha1.VLAN{}
+			vlan.Name = vlanKey.Name
+			vlan.Namespace = vlanKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vlan))).To(Succeed())
 
 			By("Cleaning up the Device resources")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
-			err = k8sClient.Get(ctx, otherDeviceKey, otherDevice)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, otherDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			device := &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
+			otherDevice := &v1alpha1.Device{}
+			otherDevice.Name = otherDeviceKey.Name
+			otherDevice.Namespace = otherDeviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, otherDevice))).To(Succeed())
 		})
 
 		It("Should set ConfiguredCondition to False with CrossDeviceReferenceReason", func() {
@@ -892,45 +881,38 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay := &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the unnumbered Interface resource")
-			err = k8sClient.Get(ctx, unnumberedIntfKey, unnumberedIntf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, unnumberedIntf)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, unnumberedIntfKey, &v1alpha1.Interface{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, unnumberedIntf))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, unnumberedIntfKey, &v1alpha1.Interface{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the loopback Interface resource")
-			err = k8sClient.Get(ctx, loopbackIntfKey, loopbackIntf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, loopbackIntf)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, loopbackIntfKey, &v1alpha1.Interface{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, loopbackIntf))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, loopbackIntfKey, &v1alpha1.Interface{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the provider has been cleaned up")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.DHCPRelay).To(BeNil(), "Provider should have no DHCPRelay configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile with an unnumbered Interface", func() {
@@ -1062,41 +1044,31 @@ var _ = Describe("DHCPRelay Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the DHCPRelay resource")
 			dhcprelay := &v1alpha1.DHCPRelay{}
-			err := k8sClient.Get(ctx, resourceKey, dhcprelay)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, dhcprelay)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			dhcprelay.Name = resourceKey.Name
+			dhcprelay.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dhcprelay))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.DHCPRelay{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the Interface resource")
-			err = k8sClient.Get(ctx, interfaceKey, intf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, interfaceKey, &v1alpha1.Interface{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			i := &v1alpha1.Interface{}
+			i.Name = interfaceKey.Name
+			i.Namespace = interfaceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, i))).To(Succeed())
 
 			By("Cleaning up the VLAN resource")
-			err = k8sClient.Get(ctx, vlanKey, vlan)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, vlan)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, vlanKey, &v1alpha1.VLAN{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			vlan := &v1alpha1.VLAN{}
+			vlan.Name = vlanKey.Name
+			vlan.Namespace = vlanKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vlan))).To(Succeed())
 
 			By("Cleaning up the Device resource")
-			device = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			device := &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should set ConfiguredCondition to False with WaitingForDependenciesReason when Interface is not configured", func() {

--- a/internal/controller/core/dns_controller_test.go
+++ b/internal/controller/core/dns_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -59,30 +58,22 @@ var _ = Describe("DNS Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.DNS{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the DNS resource")
+			dns := &v1alpha1.DNS{}
+			dns.Name = name
+			dns.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dns))).To(Succeed())
 
-			By("Cleanup the specific resource instance DNS")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for DNS to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.DNS{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.DNS).To(BeNil(), "Provider DNS should be nil")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/ethernetsegment_controller_test.go
+++ b/internal/controller/core/ethernetsegment_controller_test.go
@@ -47,8 +47,11 @@ var _ = Describe("EthernetSegment Controller", func() {
 		})
 
 		AfterEach(func() {
-			By("Cleaning up all EthernetSegment resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.EthernetSegment{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			By("Cleaning up the EthernetSegment resource")
+			es := &v1alpha1.EthernetSegment{}
+			es.Name = name
+			es.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, es))).To(Succeed())
 
 			By("Verifying the EthernetSegment is removed from the provider")
 			Eventually(func(g Gomega) {
@@ -58,16 +61,15 @@ var _ = Describe("EthernetSegment Controller", func() {
 
 			By("Cleaning up test Interface resource")
 			intf := &v1alpha1.Interface{}
-			if err := k8sClient.Get(ctx, key, intf); err == nil {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-			}
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
+			intf.Name = name
+			intf.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 
 			By("Cleaning up the test Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile an EthernetSegment", func() {

--- a/internal/controller/core/evpninstance_controller_test.go
+++ b/internal/controller/core/evpninstance_controller_test.go
@@ -40,26 +40,28 @@ var _ = Describe("EVPNInstance Controller", func() {
 		})
 
 		AfterEach(func() {
-			By("Cleaning up all EVPNInstance resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.EVPNInstance{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			By("Cleaning up the EVPNInstance resource")
+			evi := &v1alpha1.EVPNInstance{}
+			evi.Name = name
+			evi.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, evi))).To(Succeed())
 
 			By("Cleaning up test VLAN resource")
 			vlan := &v1alpha1.VLAN{}
-			if err := k8sClient.Get(ctx, key, vlan); err == nil {
-				Expect(k8sClient.Delete(ctx, vlan)).To(Succeed())
-			}
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleaning up the test Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			vlan.Name = name
+			vlan.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vlan))).To(Succeed())
 
 			By("Verifying the EVPNInstance is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.EVIs.Has(vni)).To(BeFalse(), "Provider shouldn't have VNI configured anymore")
 			}).Should(Succeed())
+
+			By("Cleaning up the test Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile EVPNInstance with VLAN reference", func() {

--- a/internal/controller/core/interface_controller_test.go
+++ b/internal/controller/core/interface_controller_test.go
@@ -43,39 +43,45 @@ var _ = Describe("Interface Controller", func() {
 		})
 
 		AfterEach(func() {
-			By("Cleaning up all Interface resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.Interface{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			By("Cleaning up Interface resources for this device")
+			interfaces := &v1alpha1.InterfaceList{}
+			Expect(k8sClient.List(ctx, interfaces, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			for i := range interfaces.Items {
+				deviceName := interfaces.Items[i].Spec.DeviceRef.Name
+				if deviceName == name || deviceName == "different-device" || deviceName == "non-existing-device" {
+					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &interfaces.Items[i]))).To(Succeed())
+				}
+			}
+
+			By("Waiting for Interfaces to be fully deleted")
+			Eventually(func(g Gomega) {
+				list := &v1alpha1.InterfaceList{}
+				g.Expect(k8sClient.List(ctx, list, client.InNamespace(metav1.NamespaceDefault), client.MatchingLabels{v1alpha1.DeviceLabel: name})).To(Succeed())
+				g.Expect(list.Items).To(BeEmpty())
+			}).Should(Succeed())
 
 			By("Cleaning up test VLAN resource")
 			vlan := &v1alpha1.VLAN{}
-			if err := k8sClient.Get(ctx, key, vlan); err == nil {
-				Expect(k8sClient.Delete(ctx, vlan)).To(Succeed())
-			}
+			vlan.Name = name
+			vlan.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vlan))).To(Succeed())
 
 			By("Cleaning up test VRF resource")
 			vrf := &v1alpha1.VRF{}
-			if err := k8sClient.Get(ctx, key, vrf); err == nil {
-				Expect(k8sClient.Delete(ctx, vrf)).To(Succeed())
-			}
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleaning up the test Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-
-			By("Verifying all Interfaces are deleted")
-			Eventually(func(g Gomega) {
-				intfList := &v1alpha1.InterfaceList{}
-				g.Expect(k8sClient.List(ctx, intfList, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-				g.Expect(intfList.Items).To(BeEmpty())
-			}).Should(Succeed())
+			vrf.Name = name
+			vrf.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vrf))).To(Succeed())
 
 			By("Verifying the Interface is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.Ports.Has(name)).To(BeFalse(), "Provider shouldn't have Interface configured anymore")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile a Physical Interface with IPv4 addresses", func() {
@@ -1364,11 +1370,20 @@ var _ = Describe("Interface Controller", func() {
 			testProvider.Unlock()
 
 			By("Cleaning up all Interface resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.Interface{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			intfList := &v1alpha1.InterfaceList{}
+			Expect(k8sClient.List(ctx, intfList, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+			for i := range intfList.Items {
+				if intfList.Items[i].Spec.DeviceRef.Name == localDevice.Name || intfList.Items[i].Spec.DeviceRef.Name == remoteDevice.Name {
+					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &intfList.Items[i]))).To(Succeed())
+				}
+			}
 			Eventually(func(g Gomega) {
-				intfList := &v1alpha1.InterfaceList{}
-				g.Expect(k8sClient.List(ctx, intfList, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-				g.Expect(intfList.Items).To(BeEmpty())
+				list := &v1alpha1.InterfaceList{}
+				g.Expect(k8sClient.List(ctx, list, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
+				for _, item := range list.Items {
+					g.Expect(item.Spec.DeviceRef.Name).NotTo(Equal(localDevice.Name))
+					g.Expect(item.Spec.DeviceRef.Name).NotTo(Equal(remoteDevice.Name))
+				}
 			}).Should(Succeed())
 
 			By("Cleaning up DNS resource")
@@ -1378,10 +1393,10 @@ var _ = Describe("Interface Controller", func() {
 
 			By("Cleaning up Device resources")
 			if localDevice != nil {
-				Expect(k8sClient.Delete(ctx, localDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+				Expect(k8sClient.Delete(ctx, localDevice)).To(Succeed())
 			}
 			if remoteDevice != nil {
-				Expect(k8sClient.Delete(ctx, remoteDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+				Expect(k8sClient.Delete(ctx, remoteDevice)).To(Succeed())
 			}
 		})
 

--- a/internal/controller/core/isis_controller_test.go
+++ b/internal/controller/core/isis_controller_test.go
@@ -5,7 +5,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,30 +59,22 @@ var _ = Describe("ISIS Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.ISIS{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the ISIS resource")
+			isis := &v1alpha1.ISIS{}
+			isis.Name = name
+			isis.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, isis))).To(Succeed())
 
-			By("Cleanup the specific resource instance ISIS")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for ISIS to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.ISIS{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.ISIS.Has("UNDERLAY")).To(BeFalse(), "Provider should not have ISIS instance configured")
 			}).Should(Succeed())
+
+			By("Cleanup the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -153,15 +144,17 @@ var _ = Describe("ISIS Controller", func() {
 		})
 
 		AfterEach(func() {
-			By("Cleaning up all ISIS resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.ISIS{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the ISIS resource")
+			isis := &v1alpha1.ISIS{}
+			isis.Name = name
+			isis.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, isis))).To(Succeed())
 
 			By("Cleanup the Device resource")
-			Expect(k8sClient.Delete(ctx, device)).To(Succeed())
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should set ConfiguredCondition to false when interfaceRef does not exist", func() {

--- a/internal/controller/core/lldp_controller_test.go
+++ b/internal/controller/core/lldp_controller_test.go
@@ -48,26 +48,26 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the resource has been deleted")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -279,15 +279,9 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp := &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				// Remove finalizer if present to allow deletion
-				if controllerutil.ContainsFinalizer(lldp, v1alpha1.FinalizerName) {
-					controllerutil.RemoveFinalizer(lldp, v1alpha1.FinalizerName)
-					Expect(k8sClient.Update(ctx, lldp)).To(Succeed())
-				}
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
-			}
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 		})
 
 		It("Should not add finalizer when Device does not exist", func() {
@@ -345,33 +339,26 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			device = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				// Ensure device is not paused before deletion
-				if device.Spec.Paused {
-					device.Spec.Paused = false
-					Expect(k8sClient.Update(ctx, device)).To(Succeed())
-				}
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the provider has been cleaned up")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should skip reconciliation when Device is paused", func() {
@@ -476,27 +463,26 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the resource has been deleted")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should handle missing ProviderConfigRef", func() {
@@ -624,27 +610,26 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the resource has been deleted")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should handle missing InterfaceRef", func() {
@@ -746,7 +731,7 @@ var _ = Describe("LLDP Controller", func() {
 
 			By("Cleaning up the other Interface and Device")
 			Expect(k8sClient.Delete(ctx, otherInterface)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, otherDevice, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			Expect(k8sClient.Delete(ctx, otherDevice)).To(Succeed())
 		})
 
 		It("Should successfully reconcile with multiple InterfaceRefs", func() {
@@ -859,27 +844,26 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the resource has been deleted")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should handle AdminState update from Up to Down", func() {
@@ -1103,38 +1087,36 @@ var _ = Describe("LLDP Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Cleaning up the Interface resource")
 			intf = &v1alpha1.Interface{}
-			err = k8sClient.Get(ctx, interfaceKey, intf)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, intf)).To(Succeed())
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, interfaceKey, &v1alpha1.Interface{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			intf.Name = interfaceKey.Name
+			intf.Namespace = interfaceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, interfaceKey, &v1alpha1.Interface{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the provider has been cleaned up")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should re-reconcile LLDP when referenced Interface is created", func() {
@@ -1297,27 +1279,26 @@ var _ = Describe("LLDP Controller", func() {
 
 			By("Cleaning up the LLDP resource")
 			lldp = &v1alpha1.LLDP{}
-			err := k8sClient.Get(ctx, resourceKey, lldp)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, lldp)).To(Succeed())
+			lldp.Name = resourceKey.Name
+			lldp.Namespace = resourceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, lldp))).To(Succeed())
 
-				By("Waiting for LLDP resource to be fully deleted")
-				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
-			}
-
-			By("Cleaning up the Device resource")
-			err = k8sClient.Get(ctx, deviceKey, device)
-			if err == nil {
-				Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
-			}
+			By("Waiting for LLDP resource to be fully deleted")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, resourceKey, &v1alpha1.LLDP{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
 
 			By("Verifying the provider has been cleaned up")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.LLDP).To(BeNil(), "Provider should have no LLDP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device = &v1alpha1.Device{}
+			device.Name = deviceKey.Name
+			device.Namespace = deviceKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should set OperationalCondition to False when LLDP is operationally down", func() {

--- a/internal/controller/core/managementaccess_controller_test.go
+++ b/internal/controller/core/managementaccess_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -57,30 +56,22 @@ var _ = Describe("ManagementAccess Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.ManagementAccess{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the ManagementAccess resource")
+			access := &v1alpha1.ManagementAccess{}
+			access.Name = name
+			access.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, access))).To(Succeed())
 
-			By("Cleanup the specific resource instance ManagementAccess")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for ManagementAccess to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.ManagementAccess{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.Access).To(BeNil(), "Provider should not have ManagementAccess configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/ntp_controller_test.go
+++ b/internal/controller/core/ntp_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -60,30 +59,22 @@ var _ = Describe("NTP Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.NTP{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the NTP resource")
+			ntp := &v1alpha1.NTP{}
+			ntp.Name = name
+			ntp.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ntp))).To(Succeed())
 
-			By("Cleanup the specific resource instance NTP")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for NTP to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.NTP{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.NTP).To(BeNil(), "Provider NTP should be nil")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/nve_controller_test.go
+++ b/internal/controller/core/nve_controller_test.go
@@ -24,7 +24,6 @@ var _ = Describe("NVE Controller", func() {
 		var (
 			name          string
 			nveKey        client.ObjectKey
-			deviceKey     client.ObjectKey
 			interfaceKeys []client.ObjectKey
 			nve           *v1alpha1.NetworkVirtualizationEdge
 		)
@@ -42,7 +41,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating loopback interfaces")
@@ -81,18 +79,20 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			n := &v1alpha1.NetworkVirtualizationEdge{}
+			n.Name = name
+			n.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, n))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
 
 			By("Cleaning up interfaces")
 			for _, ifKey := range interfaceKeys {
-				ifObj := &v1alpha1.Interface{}
-				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				intf := &v1alpha1.Interface{}
+				intf.Name = ifKey.Name
+				intf.Namespace = ifKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 				}).Should(BeTrue())
@@ -100,10 +100,11 @@ var _ = Describe("NVE Controller", func() {
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -192,7 +193,6 @@ var _ = Describe("NVE Controller", func() {
 		var (
 			name          string
 			nveKey        client.ObjectKey
-			deviceKey     client.ObjectKey
 			interfaceKeys []client.ObjectKey
 			nve           *v1alpha1.NetworkVirtualizationEdge
 		)
@@ -210,7 +210,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating loopback interfaces")
@@ -249,18 +248,20 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			nveCleanup := &v1alpha1.NetworkVirtualizationEdge{}
+			nveCleanup.Name = name
+			nveCleanup.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nveCleanup))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
 
 			By("Cleaning up interfaces")
 			for _, ifKey := range interfaceKeys {
-				ifObj := &v1alpha1.Interface{}
-				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				intf := &v1alpha1.Interface{}
+				intf.Name = ifKey.Name
+				intf.Namespace = ifKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 				}).Should(BeTrue())
@@ -268,10 +269,11 @@ var _ = Describe("NVE Controller", func() {
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -310,9 +312,8 @@ var _ = Describe("NVE Controller", func() {
 
 	Context("When source interface is missing", func() {
 		var (
-			name      string
-			nveKey    client.ObjectKey
-			deviceKey client.ObjectKey
+			name   string
+			nveKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -328,7 +329,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating an NVE object with a reference to a non-existent interface")
@@ -346,19 +346,21 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			nve := &v1alpha1.NetworkVirtualizationEdge{}
+			nve.Name = name
+			nve.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nve))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -385,9 +387,8 @@ var _ = Describe("NVE Controller", func() {
 
 	Context("When AnycastSourceInterfaceRef is omitted", func() {
 		var (
-			name      string
-			nveKey    client.ObjectKey
-			deviceKey client.ObjectKey
+			name   string
+			nveKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -402,7 +403,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
@@ -430,28 +430,31 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			nve := &v1alpha1.NetworkVirtualizationEdge{}
+			nve.Name = name
+			nve.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nve))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
 
 			By("Cleaning up interface")
-			ifObj := &v1alpha1.Interface{}
 			ifKey := client.ObjectKey{Name: name + "-lo0", Namespace: metav1.NamespaceDefault}
-			Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+			intf := &v1alpha1.Interface{}
+			intf.Name = ifKey.Name
+			intf.Namespace = ifKey.Namespace
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 			}).Should(BeTrue())
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -478,10 +481,9 @@ var _ = Describe("NVE Controller", func() {
 
 	Context("When creating more than one NVE per device", func() {
 		var (
-			name      string
-			nve1Key   client.ObjectKey
-			nve2Key   client.ObjectKey
-			deviceKey client.ObjectKey
+			name    string
+			nve1Key client.ObjectKey
+			nve2Key client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -496,7 +498,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			for _, ifName := range []string{name + "-lo0", name + "-lo1"} {
 				Expect(k8sClient.Create(ctx, &v1alpha1.Interface{
@@ -538,9 +539,10 @@ var _ = Describe("NVE Controller", func() {
 		AfterEach(func() {
 			By("Cleaning up NVEs")
 			for _, nveKey := range []client.ObjectKey{nve1Key, nve2Key} {
-				nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-				Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+				nve := &v1alpha1.NetworkVirtualizationEdge{}
+				nve.Name = nveKey.Name
+				nve.Namespace = nveKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nve))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 				}).Should(BeTrue())
@@ -551,9 +553,10 @@ var _ = Describe("NVE Controller", func() {
 				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
 				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
 			} {
-				ifObj := &v1alpha1.Interface{}
-				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				intf := &v1alpha1.Interface{}
+				intf.Name = ifKey.Name
+				intf.Namespace = ifKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 				}).Should(BeTrue())
@@ -561,10 +564,11 @@ var _ = Describe("NVE Controller", func() {
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -586,9 +590,8 @@ var _ = Describe("NVE Controller", func() {
 
 	Context("When using erroneous interface references (non loopback type)", func() {
 		var (
-			name      string
-			nveKey    client.ObjectKey
-			deviceKey client.ObjectKey
+			name   string
+			nveKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -604,7 +607,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating interfaces with wrong type")
@@ -638,9 +640,10 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			nve := &v1alpha1.NetworkVirtualizationEdge{}
+			nve.Name = name
+			nve.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nve))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
@@ -650,9 +653,10 @@ var _ = Describe("NVE Controller", func() {
 				{Name: name + "-eth0", Namespace: metav1.NamespaceDefault},
 				{Name: name + "-eth1", Namespace: metav1.NamespaceDefault},
 			} {
-				ifObj := &v1alpha1.Interface{}
-				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				intf := &v1alpha1.Interface{}
+				intf.Name = ifKey.Name
+				intf.Namespace = ifKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 				}).Should(BeTrue())
@@ -660,10 +664,11 @@ var _ = Describe("NVE Controller", func() {
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -685,9 +690,8 @@ var _ = Describe("NVE Controller", func() {
 
 	Context("When using erroneous interface references (cross-device reference)", func() {
 		var (
-			name      string
-			nveKey    client.ObjectKey
-			deviceKey client.ObjectKey
+			name   string
+			nveKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -703,7 +707,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating a second device whose interfaces will be referenced cross-device")
@@ -757,9 +760,10 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			nve := &v1alpha1.NetworkVirtualizationEdge{}
+			nve.Name = name
+			nve.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nve))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
@@ -769,9 +773,10 @@ var _ = Describe("NVE Controller", func() {
 				{Name: name + "-lo0", Namespace: metav1.NamespaceDefault},
 				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
 			} {
-				ifObj := &v1alpha1.Interface{}
-				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				intf := &v1alpha1.Interface{}
+				intf.Name = ifKey.Name
+				intf.Namespace = ifKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 				}).Should(BeTrue())
@@ -779,10 +784,11 @@ var _ = Describe("NVE Controller", func() {
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {
@@ -804,9 +810,8 @@ var _ = Describe("NVE Controller", func() {
 
 	Context("When using a non registered dependency for providerConfigRef", func() {
 		var (
-			name      string
-			nveKey    client.ObjectKey
-			deviceKey client.ObjectKey
+			name   string
+			nveKey client.ObjectKey
 		)
 
 		BeforeEach(func() {
@@ -822,7 +827,6 @@ var _ = Describe("NVE Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			name = device.Name
-			deviceKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 			nveKey = client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}
 
 			By("Creating loopback interfaces")
@@ -859,9 +863,10 @@ var _ = Describe("NVE Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up NVE")
-			nveObj := &v1alpha1.NetworkVirtualizationEdge{}
-			Expect(k8sClient.Get(ctx, nveKey, nveObj)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, nveObj)).To(Succeed())
+			nve := &v1alpha1.NetworkVirtualizationEdge{}
+			nve.Name = name
+			nve.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, nve))).To(Succeed())
 			Eventually(func() bool {
 				return errors.IsNotFound(k8sClient.Get(ctx, nveKey, &v1alpha1.NetworkVirtualizationEdge{}))
 			}).Should(BeTrue())
@@ -872,9 +877,10 @@ var _ = Describe("NVE Controller", func() {
 				{Name: name + "-lo1", Namespace: metav1.NamespaceDefault},
 				{Name: name + "-lo2", Namespace: metav1.NamespaceDefault},
 			} {
-				ifObj := &v1alpha1.Interface{}
-				Expect(k8sClient.Get(ctx, ifKey, ifObj)).To(Succeed())
-				Expect(k8sClient.Delete(ctx, ifObj)).To(Succeed())
+				intf := &v1alpha1.Interface{}
+				intf.Name = ifKey.Name
+				intf.Namespace = ifKey.Namespace
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, intf))).To(Succeed())
 				Eventually(func() bool {
 					return errors.IsNotFound(k8sClient.Get(ctx, ifKey, &v1alpha1.Interface{}))
 				}).Should(BeTrue())
@@ -882,10 +888,11 @@ var _ = Describe("NVE Controller", func() {
 
 			By("Cleaning up Device")
 			d := &v1alpha1.Device{}
-			Expect(k8sClient.Get(ctx, deviceKey, d)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, d)).To(Succeed())
+			d.Name = name
+			d.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, d))).To(Succeed())
 			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, deviceKey, &v1alpha1.Device{}))
+				return errors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: metav1.NamespaceDefault}, &v1alpha1.Device{}))
 			}).Should(BeTrue())
 
 			Eventually(func(g Gomega) {

--- a/internal/controller/core/ospf_controller_test.go
+++ b/internal/controller/core/ospf_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,30 +54,22 @@ var _ = Describe("OSPF Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.OSPF{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the OSPF resource")
+			ospf := &v1alpha1.OSPF{}
+			ospf.Name = name
+			ospf.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ospf))).To(Succeed())
 
-			By("Cleanup the specific resource instance OSPF")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for OSPF to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.OSPF{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.OSPF.Has("UNDERLAY")).ToNot(BeTrue(), "Provider should not have OSPF instance configured")
 			}).Should(Succeed())
+
+			By("Cleanup the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -152,15 +143,17 @@ var _ = Describe("OSPF Controller", func() {
 		})
 
 		AfterEach(func() {
-			By("Cleaning up all OSPF resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.OSPF{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the OSPF resource")
+			ospf := &v1alpha1.OSPF{}
+			ospf.Name = name
+			ospf.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ospf))).To(Succeed())
 
 			By("Cleanup the Device resource")
-			Expect(k8sClient.Delete(ctx, device)).To(Succeed())
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should set ConfiguredCondition to false when interfaceRef does not exist", func() {

--- a/internal/controller/core/pim_controller_test.go
+++ b/internal/controller/core/pim_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,30 +52,22 @@ var _ = Describe("PIM Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.PIM{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the PIM resource")
+			pim := &v1alpha1.PIM{}
+			pim.Name = name
+			pim.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pim))).To(Succeed())
 
-			By("Cleanup the specific resource instance PIM")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for PIM to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.PIM{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.PIM).To(BeNil(), "Provider should not have PIM instance configured")
 			}).Should(Succeed())
+
+			By("Cleanup the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -146,15 +137,17 @@ var _ = Describe("PIM Controller", func() {
 		})
 
 		AfterEach(func() {
-			By("Cleaning up all PIM resources")
-			Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.PIM{}, client.InNamespace(metav1.NamespaceDefault))).To(Succeed())
-
-			device := &v1alpha1.Device{}
-			err := k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the PIM resource")
+			pim := &v1alpha1.PIM{}
+			pim.Name = name
+			pim.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pim))).To(Succeed())
 
 			By("Cleanup the Device resource")
-			Expect(k8sClient.Delete(ctx, device)).To(Succeed())
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should set ReadyCondition to false when interfaceRef does not exist", func() {

--- a/internal/controller/core/prefixset_controller_test.go
+++ b/internal/controller/core/prefixset_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -64,30 +63,22 @@ var _ = Describe("PrefixSet Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.PrefixSet{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the PrefixSet resource")
+			ps := &v1alpha1.PrefixSet{}
+			ps.Name = name
+			ps.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ps))).To(Succeed())
 
-			By("Cleanup the specific resource instance PrefixSet")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for PrefixSet to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.PrefixSet{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.PrefixSets.Has(set)).To(BeFalse(), "Provider should not have PrefixSet configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/routingpolicy_controller_test.go
+++ b/internal/controller/core/routingpolicy_controller_test.go
@@ -42,30 +42,28 @@ var _ = Describe("RoutingPolicy Controller", func() {
 		})
 
 		AfterEach(func() {
-			rp := &v1alpha1.RoutingPolicy{}
-			err := k8sClient.Get(ctx, key, rp)
-			Expect(err).NotTo(HaveOccurred())
-
 			By("Cleaning up the RoutingPolicy resource")
-			Expect(k8sClient.Delete(ctx, rp)).To(Succeed())
+			rp := &v1alpha1.RoutingPolicy{}
+			rp.Name = name
+			rp.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, rp))).To(Succeed())
 
 			By("Cleaning up the PrefixSet resource")
 			ps := &v1alpha1.PrefixSet{}
-			if err := k8sClient.Get(ctx, key, ps); err == nil {
-				Expect(k8sClient.Delete(ctx, ps)).To(Succeed())
-			}
-
-			device := &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleaning up the test Device resource")
-			Expect(k8sClient.Delete(ctx, device, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+			ps.Name = name
+			ps.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ps))).To(Succeed())
 
 			By("Verifying the RoutingPolicy is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.RoutingPolicies.Has(name)).To(BeFalse(), "Provider shouldn't have RoutingPolicy configured anymore")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/snmp_controller_test.go
+++ b/internal/controller/core/snmp_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -71,30 +70,22 @@ var _ = Describe("SNMP Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.SNMP{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the SNMP resource")
+			snmp := &v1alpha1.SNMP{}
+			snmp.Name = name
+			snmp.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, snmp))).To(Succeed())
 
-			By("Cleanup the specific resource instance SNMP")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for SNMP to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.SNMP{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.SNMP).To(BeNil(), "Provider should not have SNMP configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/syslog_controller_test.go
+++ b/internal/controller/core/syslog_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -66,30 +65,22 @@ var _ = Describe("Syslog Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.Syslog{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the Syslog resource")
+			syslog := &v1alpha1.Syslog{}
+			syslog.Name = name
+			syslog.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, syslog))).To(Succeed())
 
-			By("Cleanup the specific resource instance Syslog")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for Syslog to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.Syslog{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.Syslog).To(BeNil(), "Provider should not have Syslog configured")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/user_controller_test.go
+++ b/internal/controller/core/user_controller_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -76,30 +75,22 @@ var _ = Describe("User Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.User{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the User resource")
+			user := &v1alpha1.User{}
+			user.Name = name
+			user.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, user))).To(Succeed())
 
-			By("Cleanup the specific resource instance User")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for User to be fully deleted")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, key, &v1alpha1.User{})
-				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.User.Has(username)).To(BeFalse(), "User should not exist")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/vlan_controller_test.go
+++ b/internal/controller/core/vlan_controller_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -56,30 +55,22 @@ var _ = Describe("VLAN Controller", func() {
 		})
 
 		AfterEach(func() {
-			var resource client.Object = &v1alpha1.VLAN{}
-			err := k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the VLAN resource")
+			vlan := &v1alpha1.VLAN{}
+			vlan.Name = name
+			vlan.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, vlan))).To(Succeed())
 
-			By("Cleanup the specific resource instance VLAN")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Waiting for the VLAN to be fully deleted")
-			Eventually(func(g Gomega) {
-				vlan := &v1alpha1.VLAN{}
-				g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, key, vlan))).To(BeTrue())
-			}).Should(Succeed())
-
-			resource = &v1alpha1.Device{}
-			err = k8sClient.Get(ctx, key, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
 				g.Expect(testProvider.VLANs.Has(id)).To(BeFalse(), "Provider VLAN should not exist")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/controller/core/vrf_controller_test.go
+++ b/internal/controller/core/vrf_controller_test.go
@@ -73,22 +73,22 @@ var _ = Describe("VRF Controller", func() {
 		})
 
 		AfterEach(func() {
-			err := k8sClient.Get(ctx, key, vrf)
-			Expect(err).NotTo(HaveOccurred())
+			By("Cleaning up the VRF resource")
+			v := &v1alpha1.VRF{}
+			v.Name = name
+			v.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, v))).To(Succeed())
 
-			By("Cleanup the specific resource instance NXOSVPC")
-			Expect(k8sClient.Delete(ctx, vrf)).To(Succeed())
-
-			err = k8sClient.Get(ctx, key, device)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Device")
-			Expect(k8sClient.Delete(ctx, device)).To(Succeed())
-
-			By("Ensuring the resource is deleted from the provider")
+			By("Verifying the resource is removed from the provider")
 			Eventually(func(g Gomega) {
-				g.Expect(testProvider.VRF).To(BeEmpty(), "Provider VPC should be empty")
+				g.Expect(testProvider.VRF.Has("CC-ADMIN-TEST")).To(BeFalse(), "Provider should not have VRF configured anymore")
 			}).Should(Succeed())
+
+			By("Cleaning up the Device resource")
+			device := &v1alpha1.Device{}
+			device.Name = name
+			device.Namespace = metav1.NamespaceDefault
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, device))).To(Succeed())
 		})
 
 		It("Should successfully reconcile the resource", func() {

--- a/internal/tftp/server.go
+++ b/internal/tftp/server.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 
 	tftp "github.com/pin/tftp/v3"
@@ -29,6 +30,15 @@ type Server struct {
 }
 
 func (s *Server) Start(ctx context.Context) error {
+	addr := fmt.Sprintf(":%d", s.Port)
+	conn, err := new(net.ListenConfig).ListenPacket(ctx, "udp", addr)
+	if err != nil {
+		return err
+	}
+	return s.serve(ctx, conn)
+}
+
+func (s *Server) serve(ctx context.Context, conn net.PacketConn) error {
 	readHandler := func(filename string, rf io.ReaderFrom) error {
 		log := s.Logger.WithValues("filename", filename)
 
@@ -96,13 +106,12 @@ func (s *Server) Start(ctx context.Context) error {
 		return nil
 	}
 
-	addr := fmt.Sprintf(":%d", s.Port)
 	srv := tftp.NewServer(readHandler, nil)
 	go func() {
 		<-ctx.Done()
 		srv.Shutdown()
 	}()
-	return srv.ListenAndServe(addr)
+	return srv.Serve(conn)
 }
 
 func resolveBootScript(ctx context.Context, r client.Reader, ns string, p *corev1.Provisioning) []byte {

--- a/internal/tftp/server_test.go
+++ b/internal/tftp/server_test.go
@@ -5,6 +5,7 @@ package tftpserver
 
 import (
 	"bytes"
+	"net"
 	"testing"
 
 	tftp "github.com/pin/tftp/v3"
@@ -163,19 +164,25 @@ func TestServer(t *testing.T) {
 				}).
 				Build()
 
+			// Bind to port 0 to get an OS-assigned free port
+			conn, err := new(net.ListenConfig).ListenPacket(t.Context(), "udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			addr := conn.LocalAddr().String()
+
 			srv := &Server{
 				Client:         fc,
 				Logger:         klog.NewKlogr(),
 				ValidateSource: tt.validateSource,
-				Port:           16900,
 			}
 			go func() {
-				if err := srv.Start(t.Context()); err != nil {
+				if err := srv.serve(t.Context(), conn); err != nil {
 					t.Errorf("start server: %v", err)
 				}
 			}()
 
-			tc, err := tftp.NewClient("127.0.0.1:16900")
+			tc, err := tftp.NewClient(addr)
 			if err != nil {
 				t.Fatalf("create TFTP client: %v", err)
 			}


### PR DESCRIPTION
Remove client.PropagationPolicy(metav1.DeletePropagationForeground) and k8sClient.DeleteAllOf from all controller test suites. These do not work reliably in envtest, causing flaky test failures.

Replace with scoped cleanup using client.IgnoreNotFound(Delete) and ensure device is always deleted last (after provider verification) so that controllers can finalize child resources properly.

Also fix cross-test interference in the VRF test by checking specific provider state instead of global emptiness.