### PR TITLE
Prepare Multi Provider Setup

### DIFF
--- a/api/core/v1alpha1/device_types.go
+++ b/api/core/v1alpha1/device_types.go
@@ -24,6 +24,11 @@ type DeviceSpec struct {
 	// +required
 	Endpoint Endpoint `json:"endpoint"`
 
+	// Provider is the name of the provider plugin which is responsible for reconciling the CRD connected to the device
+	// +optional
+	// +immutable
+	Provider string `json:"provider,omitempty"`
+
 	// Provisioning is an optional configuration for the device provisioning process.
 	// It can be used to provide initial configuration templates or scripts that are applied during the device provisioning.
 	// +optional

--- a/charts/network-operator/templates/crd/devices.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/devices.networking.metal.ironcore.dev.yaml
@@ -194,6 +194,10 @@ spec:
                 description: Paused can be used to prevent controllers from processing
                   the Device and its associated objects.
                 type: boolean
+              provider:
+                description: Provider is the name of the provider plugin which is
+                  responsible for reconciling the CRD connected to the device
+                type: string
               provisioning:
                 description: |-
                   Provisioning is an optional configuration for the device provisioning process.

--- a/config/crd/bases/networking.metal.ironcore.dev_devices.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_devices.yaml
@@ -191,6 +191,10 @@ spec:
                 description: Paused can be used to prevent controllers from processing
                   the Device and its associated objects.
                 type: boolean
+              provider:
+                description: Provider is the name of the provider plugin which is
+                  responsible for reconciling the CRD connected to the device
+                type: string
               provisioning:
                 description: |-
                   Provisioning is an optional configuration for the device provisioning process.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1786,6 +1786,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `paused` _boolean_ | Paused can be used to prevent controllers from processing the Device and its associated objects. | false | Optional: \{\} <br /> |
 | `endpoint` _[Endpoint](#endpoint)_ | Endpoint contains the connection information for the device. |  | Required: \{\} <br /> |
+| `provider` _string_ | Provider is the name of the provider plugin which is responsible for reconciling the CRD connected to the device |  | Optional: \{\} <br /> |
 | `provisioning` _[Provisioning](#provisioning)_ | Provisioning is an optional configuration for the device provisioning process.<br />It can be used to provide initial configuration templates or scripts that are applied during the device provisioning. |  | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
The network-operator currently requires a single provider to be selected at startup via the --provider flag. Every controller receives the same ProviderFunc and calls it unconditionally.

The goal is to move provider selection from a startup flag to the Device resource, so a single operator deployment can manage devices running different operating systems. Therefore, a new field `provider` is introduced.

After migration this field will become required, once rolled out and introduced everywhere. Provider flag will be removed.