### PR TITLE
Add design documents section

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,6 +93,18 @@ export default withMermaid({
                 ],
             },
             {
+                text: 'Design Documents',
+                items: [
+                    { text: 'Index', link: '/designs/' },
+                    { text: '0001: Device Lifecycle Phases', link: '/designs/0001-device-lifecycle' },
+                    { text: '0002: Provider Interface', link: '/designs/0002-provider-interface' },
+                    { text: '0003: Status Conditions', link: '/designs/0003-status-conditions' },
+                    { text: '0004: Device Resource Locking', link: '/designs/0004-device-resource-locking' },
+                    { text: '0005: Brick Architecture', link: '/designs/0005-brick-architecture' },
+                    { text: '0006: API Deprecation Strategy', link: '/designs/0006-api-deprecation-strategy' },
+                ],
+            },
+            {
                 text: 'API References',
                 items: [{ text: 'Index', link: '/api-reference/' }],
             },

--- a/docs/designs/0001-device-lifecycle.md
+++ b/docs/designs/0001-device-lifecycle.md
@@ -1,0 +1,78 @@
+# 0001: Device Lifecycle Phases
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Authors:** @network-operator-maintainers
+
+## Summary
+
+A Device resource progresses through a fixed set of phases that
+represent its provisioning and operational state. Configuration
+resources are automatically held back until their device reaches the
+appropriate phase.
+
+## Motivation
+
+Network devices go through distinct stages: initial discovery, optional
+zero-touch provisioning, post-provisioning verification, and
+steady-state operation. Without explicit phase tracking, controllers
+cannot determine whether a device is ready to accept configuration.
+
+## Goals
+
+- Define a clear progression of device states.
+- Ensure configuration resources only apply when the device is ready.
+- Provide a recovery path from terminal failure states.
+- Support devices that skip provisioning entirely.
+
+## Non-Goals
+
+- Defining provisioning script content or format.
+- Specifying vendor-specific boot sequences.
+
+## Decision
+
+A Device has exactly one phase at any time: `Pending`, `Provisioning`,
+`Provisioned`, `Running`, or `Failed`. The phase progresses linearly
+from Pending toward Running, with failure branches leading to Failed.
+
+Devices without provisioning configuration skip directly from Pending
+to Running. The Failed phase is terminal and requires explicit manual
+intervention to reset.
+
+### Automatic Pausing of Child Resources
+
+Configuration resources are automatically paused when their referenced
+device is not in Running phase or is not reachable. This is enforced
+centrally by the `paused` package, which all child-resource controllers
+invoke before reconciliation. Individual controllers do not need to
+check device phase themselves.
+
+Reconciliation can also be paused explicitly through a field on the
+Device spec (affecting the device and all its children) or through an
+annotation on any individual resource.
+
+**Guardrails:**
+
+- The device controller must not skip phases or transition backwards
+  except through explicit maintenance operations.
+- A device in Failed phase must not automatically retry.
+- New configuration resource controllers must call the shared paused
+  check — they inherit phase gating without additional logic.
+
+## Consequences
+
+- Adding new configuration resources does not require per-controller
+  phase checks.
+- Adding new phases requires updating the paused package, not every
+  controller.
+
+## Alternatives Considered
+
+**Single Ready condition instead of phases:** Rejected because a single
+condition cannot distinguish provisioning-in-progress from
+post-verification from failed.
+
+**Automatic retry on failure:** Rejected because provisioning failures
+often require physical intervention and retries would mask persistent
+problems.

--- a/docs/designs/0002-provider-interface.md
+++ b/docs/designs/0002-provider-interface.md
@@ -1,0 +1,129 @@
+# 0002: Provider Interface
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Authors:** @network-operator-maintainers
+
+## Summary
+
+All device communication is abstracted behind a provider interface.
+Controllers never interact with devices directly — they go through a
+provider that encapsulates vendor-specific and protocol-specific logic.
+
+## Motivation
+
+The operator supports multiple device vendors and protocols. Without a
+provider abstraction, every controller would need vendor-specific
+branches, making the codebase unmaintainable and untestable.
+
+## Goals
+
+- Decouple controller logic from device communication details.
+- Allow adding new vendors without modifying existing controllers.
+- Enable testing controllers without real hardware.
+- Support capability-based feature detection at runtime.
+- Allow vendor-specific configuration extensions without polluting the
+  core API.
+
+## Non-Goals
+
+- Defining a universal network configuration data model.
+
+## Decision
+
+### Registration
+
+Providers self-register at startup. The operator selects the active
+provider(s) based on configuration. Provider implementations are
+compiled in and imported in the main entrypoint.
+
+### Capability Interfaces
+
+Each resource type has a corresponding provider interface. Providers
+implement only the interfaces they support. Controllers use type
+assertions to detect capabilities at runtime and report an error
+condition when a required capability is missing.
+
+All per-resource interfaces follow a consistent Ensure/Delete pattern,
+with optional status retrieval methods for operational state.
+
+### Vendor-Specific Extensions (providerConfigRef)
+
+Core API resources define a vendor-neutral configuration surface. When
+a vendor requires additional settings, they are expressed as a separate
+vendor-specific CRD referenced via `spec.providerConfigRef`.
+
+The controller fetches the referenced object as unstructured data and
+passes it through to the provider, which deserializes it into the
+appropriate type. This keeps vendor awareness entirely within the
+provider — core controllers never interpret vendor-specific content.
+
+Vendor-specific CRDs live under dedicated API groups, separate from
+the core API group.
+
+### Vendor-Specific Resources
+
+Some resources are entirely vendor-specific with no core equivalent.
+These are defined as standalone CRDs under the vendor API group with
+their own controllers, following the same patterns as core controllers
+(device reference, pausing, conditions).
+
+### Structured Errors (apistatus)
+
+The core API includes fields supported by the majority of vendors.
+Providers that cannot support a field communicate this through
+structured errors with three categories:
+
+- **Unsupported field** — terminal; the resource cannot be realized
+  until the field is removed.
+- **Invalid argument** — terminal; the value violates
+  provider-specific constraints.
+- **Failed precondition** — retryable; a device-side dependency is
+  not yet met.
+
+These errors are surfaced to the user through status conditions with
+the specific field path and description.
+
+### Protocol Preferences
+
+gNMI is the preferred protocol. Provider implementations use
+hand-crafted Go structs rather than code generated from YANG models.
+Complete YANG models generate large amounts of code covering far more
+than what this project needs. Additionally, generating from a model at
+a particular version makes cross-version compatibility difficult, while
+hand-crafted structs can accommodate version-specific differences
+through custom marshalling.
+
+A shared transport layer provides gRPC client setup with automatic
+terminal error detection — non-retryable gRPC status codes are wrapped
+to prevent infinite retry loops.
+
+### In-Tree Implementations
+
+Provider implementations live in-tree. Splitting into dedicated
+repositories is deferred until complexity justifies it.
+
+**Guardrails:**
+
+- Controllers must never import vendor-specific packages.
+- New device features must be added as capability interfaces — never
+  as provider-specific code in a controller.
+- Vendor-specific extensions to core resources must use
+  providerConfigRef — never additional fields on the core type.
+- All provider request structs include a ProviderConfig field;
+  providers ignore it when nil.
+
+## Consequences
+
+- Adding a new vendor requires only implementing interfaces and
+  registering. No controller changes needed.
+- Controllers must gracefully handle missing capabilities.
+- The providerConfigRef mechanism allows extending any core resource
+  without forking the core API.
+
+## Alternatives Considered
+
+**Out-of-process provider as a gRPC service:** A provider could run as
+a separate service, potentially on the device itself. Rejected for now
+due to operational complexity. Remains an option if provider isolation
+or on-device execution becomes a requirement.

--- a/docs/designs/0003-status-conditions.md
+++ b/docs/designs/0003-status-conditions.md
@@ -1,0 +1,120 @@
+# 0003: Status Conditions
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Authors:** @network-operator-maintainers
+
+## Summary
+
+All managed resources use a layered set of status conditions to
+communicate their state. A top-level Ready condition is derived from
+independent sub-conditions, each representing a distinct stage of
+reconciliation. Staleness is communicated through observedGeneration.
+
+## Motivation
+
+Network resources go through multiple stages during reconciliation:
+dependency resolution, device connection, configuration, and
+operational state retrieval. A single top-level Ready condition cannot
+express which stage failed or whether a resource is configured but
+operationally degraded.
+
+## Goals
+
+- Provide clear, independent signals for each reconciliation stage.
+- Ensure stale conditions are distinguishable from current ones.
+- Define a consistent pattern all controllers must follow.
+- Allow the top-level Ready condition to be computed automatically.
+
+## Non-Goals
+
+- Defining resource-specific status fields beyond conditions.
+- Prescribing how external systems consume conditions.
+
+## Decision
+
+### Condition Types
+
+Configuration resources carry these condition types:
+
+- **Ready** — top-level rollup. True only when all other conditions
+  (except Paused) are True. Computed automatically at the end of
+  every reconciliation; controllers never set it directly.
+- **Configured** — whether the desired state has been applied to the
+  device. Updated at multiple points during reconciliation.
+- **Operational** — live state read back from the device. Only updated
+  after successful configuration.
+- **Paused** — whether reconciliation is suspended. Excluded from the
+  Ready rollup.
+
+The Device resource uses a different set appropriate to its role
+(it represents the device itself, not configuration applied to it).
+
+### ObservedGeneration
+
+Every condition carries observedGeneration, set automatically to the
+object's current generation. This is critical for interpretation:
+
+- If observedGeneration is less than the object's generation, the
+  condition is stale. This can mean reconciliation has not yet run,
+  or that an earlier stage failed and prevented the condition from
+  being re-evaluated.
+- Helper functions that check whether a resource is ready or
+  configured return false when observedGeneration does not match,
+  regardless of the condition's status value.
+
+This is especially important for the Operational condition: when
+configuration fails, the Operational condition retains its previous
+value since the device was never queried for the new spec. The stale
+observedGeneration tells consumers not to trust it.
+
+### Reconciliation Flow
+
+Controllers follow this sequence:
+
+1. **Initialize** — first reconciliation sets all conditions to Unknown.
+2. **Resolve dependencies** — if missing or invalid, set
+   Configured=False with an appropriate reason and return. Watches on
+   dependencies trigger re-reconciliation when they become ready.
+3. **Connect and apply** — call the provider. The result is reflected
+   in the Configured condition.
+4. **Fetch operational state** — only if configuration succeeded.
+   Update the Operational condition. Skipped on failure, leaving the
+   previous value with a now-stale observedGeneration.
+5. **Recompute Ready** — derive from sub-conditions via deferred call.
+
+**Guardrails:**
+
+- The Configured condition must be updated before returning from
+  reconciliation, even if failure occurred during dependency
+  resolution.
+- The Operational condition must only be updated after successful
+  configuration.
+- Controllers must not set Ready directly — it is always derived.
+- Consumers must compare observedGeneration before trusting a
+  condition's status.
+
+## Consequences
+
+- Users can determine at a glance whether failure is in dependency
+  resolution, configuration, or operational health.
+- Automation can wait for Ready=True with matching observedGeneration
+  to confirm a spec change is fully applied and verified.
+- The Operational condition may appear True while Configured is False
+  after a spec change — the stale observedGeneration communicates this
+  correctly.
+
+## Alternatives Considered
+
+**Single Ready condition with detailed message:** Rejected because it
+forces consumers to parse messages to determine the failure stage.
+
+**Resetting conditions at the start of every reconciliation:** Rejected
+because updating a condition's lastTransitionTime on every loop (even
+Success→Success) triggers infinite reconciliation. Conditions must be
+set explicitly at each failure/success point.
+
+**Setting Operational to Unknown on configuration failure:** Rejected
+because the device may still be running the previous configuration.
+ObservedGeneration already communicates staleness without misreporting
+the actual device state.

--- a/docs/designs/0004-device-resource-locking.md
+++ b/docs/designs/0004-device-resource-locking.md
@@ -1,0 +1,99 @@
+# 0004: Device Resource Locking
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Authors:** @network-operator-maintainers
+
+## Summary
+
+Only one controller may configure a given device at a time. A
+per-device lock serializes all configuration operations targeting the
+same device. Controllers that cannot acquire the lock requeue with
+priority-based ordering to reduce starvation.
+
+## Motivation
+
+Network devices expose management APIs with limited concurrency
+capabilities. Some reject concurrent sessions, others produce
+inconsistent state under parallel writes. Since each configuration
+operation is applied as a single atomic gNMI Set request, the lock
+prevents interleaving of multiple atomic operations that could leave
+the device in an inconsistent intermediate state.
+
+## Goals
+
+- Prevent concurrent configuration of the same device.
+- Minimize latency for resources waiting to configure a device.
+- Prioritize foundational resources whose reconciliation unblocks
+  dependent resources.
+
+## Non-Goals
+
+- Fine-grained locking per configuration subtree.
+- Fairness guarantees across controllers.
+- Distributed locking across multiple operator instances (handled by
+  the watch-filter mechanism which partitions devices).
+
+## Decision
+
+### Per-Device Lock
+
+A single lock is held per device, implemented as a Kubernetes Lease
+resource. When a controller begins reconciliation, it attempts to
+acquire the lock. If held by another controller, it requeues with a
+short jittered delay and an elevated priority. After reconciliation,
+the lock is released. Leases expire automatically if a controller
+crashes without releasing.
+
+### Wait Priorities
+
+When a controller cannot acquire the lock, it requeues at one of two
+priority levels:
+
+- **High** — foundational resource types commonly referenced by other
+  resources. Reconciling them first unblocks dependent resources.
+- **Default** — all other resource types. Higher than the queue
+  baseline used by periodic requeues of already-reconciled resources,
+  ensuring lock-waiting resources are always served first.
+
+A jitter of ±10% is applied to all periodic requeues to reduce lock
+convoy effects.
+
+### Known Shortcomings
+
+**Coarse granularity:** The lock covers the entire device. Controllers
+configuring independent subtrees are serialized unnecessarily, adding
+latency during initial device onboarding.
+
+**No fairness guarantee:** Lower-priority resources may be repeatedly
+delayed under sustained contention from higher-priority resources.
+The jittered delay provides randomization but not bounded wait time.
+
+**Lease overhead:** Each lock operation involves Kubernetes API calls.
+Under high contention this adds API server load proportional to
+waiting controllers times retry frequency.
+
+## Consequences
+
+- Initial device configuration is serialized and takes longer than
+  parallel application would.
+- New resource types automatically participate by following the
+  established controller pattern.
+- The priority mechanism ensures dependent resources are not blocked
+  indefinitely by foundational resources.
+
+## Alternatives Considered
+
+**Per-subtree locking:** Lock at configuration path granularity to
+allow safe parallelism. Rejected due to the complexity of defining
+non-overlapping subtrees across vendors and because some devices have
+global commit semantics.
+
+**No locking:** Rely on the device API to handle concurrency. Rejected
+because device behavior under concurrent access varies by vendor —
+some silently corrupt state, and finding a safe concurrency limit per
+model is impractical.
+
+**Queue-based serialization:** Route all configuration through a
+single work queue per device. Rejected because it requires
+architectural changes to controller-runtime's reconciliation model.

--- a/docs/designs/0005-brick-architecture.md
+++ b/docs/designs/0005-brick-architecture.md
@@ -1,0 +1,109 @@
+# 0005: Brick Architecture
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Authors:** @network-operator-maintainers
+
+## Summary
+
+Every configuration resource (called a "brick") represents exactly one
+configuration stanza applied to exactly one device. Bricks are the
+atomic unit of network configuration in this project.
+
+## Motivation
+
+Network device configuration is composed of many independent stanzas.
+Representing each as a separate Kubernetes resource enables independent
+lifecycle management, fine-grained RBAC, selective reconciliation, and
+clear ownership boundaries.
+
+## Goals
+
+- Define the smallest meaningful unit of configuration.
+- Enable independent reconciliation of each stanza.
+- Support applying configuration to multiple devices through
+  composition, not resource-level multi-targeting.
+- Support pausing and excluding individual units.
+
+## Non-Goals
+
+- Defining higher-level abstractions that compose bricks.
+- Prescribing how bricks are generated or templated.
+
+## Decision
+
+### Definition
+
+A brick is a Kubernetes custom resource that:
+
+1. Corresponds to exactly one configuration stanza on exactly one
+   device.
+2. References its target device via a device reference field.
+3. Is reconciled by its own dedicated controller.
+4. Reports its own status conditions independently.
+
+### One Brick, One Stanza
+
+A brick must not span multiple independent configuration sections.
+If a feature requires configuration across multiple sections, it is
+modeled as multiple bricks with cross-references between them.
+
+### One Brick, One Device
+
+A brick targets exactly one device. Applying the same configuration
+to multiple devices requires one brick per device. Higher-level tools
+(Helm, fabric controllers) automate this.
+
+### Eventual Consistency
+
+Bricks are reconciled independently and without a prescribed order.
+The operator does not enforce sequencing. Instead:
+
+- Bricks that depend on other bricks check whether their dependency
+  is ready at reconciliation time.
+- If not ready, the brick reports a waiting state and returns without
+  connecting to the device.
+- Watches on dependencies trigger re-reconciliation when they become
+  ready.
+
+All bricks for a device can be created simultaneously in any order.
+The system converges through repeated reconciliation.
+
+### Ownership and Lifecycle
+
+- Bricks are owned by their device. Deleting a Device cascades
+  deletion to all its bricks. This relies on foreground cascading
+  deletion, as owner-blocking semantics are only evaluated in that
+  mode.[^1]
+- A finalizer on each brick triggers cleanup on the device before
+  the Kubernetes resource is removed.
+- Bricks can be individually paused or collectively paused through
+  their device.
+
+**Guardrails:**
+
+- New configuration resources must follow the brick pattern.
+- Bricks must not embed configuration for another brick's domain.
+- Cross-references between bricks must validate that both target the
+  same device.
+- Bricks must be reconcilable in any order — dependency ordering is
+  handled through waiting and watches, never explicit sequencing.
+
+## Consequences
+
+- A fully configured device has many brick resources. This is by
+  design — it enables independent management.
+- Higher-level abstractions compose bricks but do not replace them.
+- Adding a new device feature means adding a new CRD, controller, and
+  provider interface following established patterns.
+
+## Alternatives Considered
+
+**Monolithic device configuration resource:** Rejected because it
+prevents independent lifecycle management and makes RBAC coarse-grained.
+
+**Grouped resources (e.g. one "routing" resource):** Rejected because
+stanza boundaries differ per vendor, grouping creates implicit
+dependencies, and it prevents selective provider implementation.
+
+[^1]: https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/#use-foreground-cascading-deletion

--- a/docs/designs/0006-api-deprecation-strategy.md
+++ b/docs/designs/0006-api-deprecation-strategy.md
@@ -1,0 +1,64 @@
+# 0006: API Deprecation Strategy
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Authors:** @network-operator-maintainers
+
+## Summary
+
+Breaking changes to CRD specs follow a multi-step deprecation process
+that prevents disruption to existing deployments.
+
+## Motivation
+
+The operator's CRDs are consumed by multiple teams and automated
+systems. Removing or renaming a field without a migration path breaks
+existing deployments.
+
+## Goals
+
+- Prevent breaking existing deployments on upgrades.
+- Provide a clear, repeatable process for API evolution.
+- Ensure deprecated fields are eventually removed.
+
+## Non-Goals
+
+- Defining when a new API version is warranted.
+- Versioning strategy for the Helm chart.
+
+## Decision
+
+Breaking API changes must follow four steps:
+
+1. **Add the new field** alongside the old one. Mark the old field as
+   deprecated.
+2. **Support both fields** in the controller. The old field is used
+   when the new one is absent; the new field takes precedence when
+   both are set.
+3. **Migrate consumers** — update all known deployments to use the
+   new field. Communicate via release notes.
+4. **Remove the old field** once no known consumer uses it.
+
+**Guardrails:**
+
+- Each step must be a separate release.
+- The old field must remain functional for at least one release cycle
+  after the new field is introduced.
+- Removal requires confirmation that known deployments have migrated.
+
+## Consequences
+
+- API evolution is slower but safe.
+- The codebase temporarily carries compatibility code. This is
+  acceptable as it is time-bounded.
+- External consumers can migrate at their own pace within the
+  deprecation window.
+
+## Alternatives Considered
+
+**Immediate removal with API version bump:** Rejected because CRD
+conversion webhooks add significant complexity, especially for alpha
+APIs with frequent changes.
+
+**Never remove deprecated fields:** Rejected because it accumulates
+maintenance burden and confuses users with redundant fields.

--- a/docs/designs/NNNN-template.md
+++ b/docs/designs/NNNN-template.md
@@ -1,0 +1,35 @@
+# NNNN: Title
+
+- **Status:** Proposed | Accepted | Superseded | Deprecated
+- **Date:** YYYY-MM-DD
+- **Authors:** @github-handle
+
+## Summary
+
+One or two sentences describing the decision.
+
+## Motivation
+
+What problem does this solve? Why is a decision needed now?
+
+## Goals
+
+- What this decision enables or enforces.
+
+## Non-Goals
+
+- What is explicitly out of scope.
+
+## Decision
+
+The concrete decision. Be specific about what is required, allowed, and
+prohibited.
+
+## Consequences
+
+What follows from this decision — tradeoffs, constraints on future work,
+migration requirements.
+
+## Alternatives Considered
+
+Other approaches that were evaluated and why they were rejected.

--- a/docs/designs/index.md
+++ b/docs/designs/index.md
@@ -1,0 +1,32 @@
+# Design Documents
+
+This directory contains design documents for the Network Operator project.
+They record architectural decisions and serve as guardrails for new
+development.
+
+Not every change requires a design document — only those that introduce
+new abstractions, change existing behavior in a non-trivial way, or
+establish patterns that future contributions must follow. Bug fixes,
+new brick implementations following existing patterns, and additive
+API fields do not need a design doc.
+
+## Process
+
+1. Copy `NNNN-template.md` and assign the next number.
+2. Fill in the sections. Keep it concise.
+3. Submit as a pull request for review.
+4. Once merged with status `Accepted`, the decision is binding.
+
+To supersede a design document, create a new one referencing the
+original and update the original's status to `Superseded by NNNN`.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](./0001-device-lifecycle.md) | Device Lifecycle Phases | Accepted |
+| [0002](./0002-provider-interface.md) | Provider Interface | Accepted |
+| [0003](./0003-status-conditions.md) | Status Conditions | Accepted |
+| [0004](./0004-device-resource-locking.md) | Device Resource Locking | Accepted |
+| [0005](./0005-brick-architecture.md) | Brick Architecture | Accepted |
+| [0006](./0006-api-deprecation-strategy.md) | API Deprecation Strategy | Accepted |


### PR DESCRIPTION
Introduce docs/designs/ with a template and six architectural decision
records:

- 0001: Device Lifecycle (phase progression, automatic pausing)
- 0002: Provider Interface (capability interfaces, providerConfigRef,
  apistatus errors, protocol preferences)
- 0003: Status Conditions (Configured/Operational/Ready,
  observedGeneration semantics)
- 0004: Device Resource Locking (per-device Lease, wait priorities)
- 0005: Brick Architecture (one-stanza one-device pattern, eventual
  consistency, ownership)
- 0006: API Deprecation Strategy (four-step field deprecation)

Update VitePress sidebar to include the new section.