### PR TITLE
feat: Add OSPF placeholder for OpenConfig

### DIFF
--- a/internal/provider/openconfig/ospf.go
+++ b/internal/provider/openconfig/ospf.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package openconfig
+
+import (
+	"context"
+
+	"github.com/ironcore-dev/network-operator/internal/apistatus"
+	"github.com/ironcore-dev/network-operator/internal/provider"
+)
+
+var _ provider.OSPFProvider = (*Provider)(nil)
+
+func (p *Provider) EnsureOSPF(_ context.Context, _ *provider.EnsureOSPFRequest) error {
+	return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
+		Field:       "spec",
+		Description: "openconfig provider does not support OSPF configuration on SRLinux",
+	})
+}
+
+func (p *Provider) DeleteOSPF(_ context.Context, _ *provider.DeleteOSPFRequest) error {
+	return nil
+}
+
+func (p *Provider) GetOSPFStatus(_ context.Context, _ *provider.OSPFStatusRequest) (provider.OSPFStatus, error) {
+	return provider.OSPFStatus{}, nil
+}

--- a/test/gnmi/testdata/openconfig/ospf.txt
+++ b/test/gnmi/testdata/openconfig/ospf.txt
@@ -1,0 +1,23 @@
+# OSPF Configuration
+# NOTE: OSPF via OpenConfig gNMI is not supported on Nokia SR Linux.
+# The OpenConfig ospfv2 container is defined in the YANG model but not
+# exposed in the Nokia SRL gNMI schema. EnsureOSPF returns UnsupportedField.
+-- ospf/ospf --
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: OSPF
+metadata:
+  name: ospf
+  namespace: default
+spec:
+  deviceRef:
+    name: device
+  instance: UNDERLAY
+  routerId: 10.0.0.10
+  interfaceRefs:
+    - name: lo0
+      area: "0.0.0.0"
+      passive: true
+    - name: ethernet-1-1
+      area: "0.0.0.0"
+-- state --
+{}


### PR DESCRIPTION
The Nokia SRL device do not support configuration of OSPFv2 or OSPFv3 throw OpenConfig, only throw native native data schema.