### PR TITLE
Support ranges for switchport allowed VLANs

### DIFF
--- a/api/core/v1alpha1/index_range.go
+++ b/api/core/v1alpha1/index_range.go
@@ -12,16 +12,24 @@ import (
 
 // IndexRange represents an inclusive range of indices.
 // +kubebuilder:validation:Type=string
-// +kubebuilder:validation:Pattern=`^[0-9]+\.\.[0-9]+$`
+// +kubebuilder:validation:XIntOrString
+// +kubebuilder:validation:Pattern=`^[0-9]+(\.\.[0-9]+)?$`
 // +kubebuilder:object:generate=false
 type IndexRange struct {
 	Start int64 `json:"-"`
 	End   int64 `json:"-"`
 }
 
-// ParseIndexRange parses a string in the format "start..end" into an [IndexRange].
+// ParseIndexRange parses a string in the format "single-index" or "start..end" into an [IndexRange].
 func ParseIndexRange(s string) (IndexRange, error) {
 	parts := strings.Split(s, "..")
+	if len(parts) == 1 {
+		idx, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+		if err != nil {
+			return IndexRange{}, fmt.Errorf("invalid index %q: %w", parts[0], err)
+		}
+		return IndexRange{Start: idx, End: idx}, nil
+	}
 	if len(parts) != 2 {
 		return IndexRange{}, fmt.Errorf("invalid index range %q", s)
 	}
@@ -55,24 +63,28 @@ func (r IndexRange) String() string {
 
 // MarshalJSON implements [json.Marshaler].
 func (r IndexRange) MarshalJSON() ([]byte, error) {
+	if r.Start == r.End {
+		return json.Marshal(r.Start)
+	}
 	return json.Marshal(r.String())
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (r *IndexRange) UnmarshalJSON(data []byte) error {
 	var str string
-	if err := json.Unmarshal(data, &str); err != nil {
-		return err
-	}
-	if str == "" || str == "null" {
-		*r = IndexRange{}
+	if err := json.Unmarshal(data, &str); err == nil {
+		parsed, err := ParseIndexRange(str)
+		if err != nil {
+			return err
+		}
+		*r = parsed
 		return nil
 	}
-	parsed, err := ParseIndexRange(str)
-	if err != nil {
+	var idx int64
+	if err := json.Unmarshal(data, &idx); err != nil {
 		return err
 	}
-	*r = parsed
+	*r = IndexRange{Start: idx, End: idx}
 	return nil
 }
 

--- a/api/core/v1alpha1/index_range_test.go
+++ b/api/core/v1alpha1/index_range_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIndexRangeUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want IndexRange
+	}{
+		{
+			name: "range string",
+			data: `"10..20"`,
+			want: IndexRange{Start: 10, End: 20},
+		},
+		{
+			name: "single integer string",
+			data: `"10"`,
+			want: IndexRange{Start: 10, End: 10},
+		},
+		{
+			name: "integer singleton",
+			data: `10`,
+			want: IndexRange{Start: 10, End: 10},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got IndexRange
+			if err := json.Unmarshal([]byte(test.data), &got); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("json.Unmarshal() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIndexRangeUnmarshalJSONRejectsInvalidStrings(t *testing.T) {
+	for _, data := range []string{`""`, `"null"`} {
+		t.Run(data, func(t *testing.T) {
+			var got IndexRange
+			if err := json.Unmarshal([]byte(data), &got); err == nil {
+				t.Fatalf("json.Unmarshal(%s) succeeded, want error", data)
+			}
+		})
+	}
+}
+
+func TestIndexRangeMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		in   IndexRange
+		want string
+	}{
+		{
+			name: "single integer",
+			in:   IndexRange{Start: 10, End: 10},
+			want: `10`,
+		},
+		{
+			name: "range string",
+			in:   IndexRange{Start: 10, End: 20},
+			want: `"10..20"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("json.Marshal() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -170,14 +170,14 @@ type Switchport struct {
 	// +kubebuilder:validation:Maximum=4094
 	NativeVlan int32 `json:"nativeVlan,omitempty"`
 
-	// AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+	// AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.
+	// Each entry is an inclusive range string like "100..200". For compatibility,
+	// a single integer like 100 is also accepted and treated as "100..100".
 	// If not specified, all VLANs (1-4094) are allowed.
 	// Only applicable when Mode is set to "Trunk".
 	// +optional
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:items:Minimum=1
-	// +kubebuilder:validation:items:Maximum=4094
-	AllowedVlans []int32 `json:"allowedVlans,omitempty"`
+	AllowedVlans []IndexRange `json:"allowedVlans,omitempty"`
 }
 
 // EncapType represents the encapsulation type used for a subinterface.

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -4244,8 +4244,10 @@ func (in *Switchport) DeepCopyInto(out *Switchport) {
 	*out = *in
 	if in.AllowedVlans != nil {
 		in, out := &in.AllowedVlans, &out.AllowedVlans
-		*out = make([]int32, len(*in))
-		copy(*out, *in)
+		*out = make([]IndexRange, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/charts/network-operator/templates/crd/indexpools.pool.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/indexpools.pool.networking.metal.ironcore.dev.yaml
@@ -65,8 +65,9 @@ spec:
                   Ranges defines the inclusive index ranges that can be allocated.
                   Example: "64512..65534".
                 items:
-                  pattern: ^[0-9]+\.\.[0-9]+$
+                  pattern: ^[0-9]+(\.\.[0-9]+)?$
                   type: string
+                  x-kubernetes-int-or-string: true
                 minItems: 1
                 type: array
               reclaimPolicy:

--- a/charts/network-operator/templates/crd/interfaces.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/interfaces.networking.metal.ironcore.dev.yaml
@@ -412,14 +412,15 @@ spec:
                     type: integer
                   allowedVlans:
                     description: |-
-                      AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+                      AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.
+                      Each entry is an inclusive range string like "100..200". For compatibility,
+                      a single integer like 100 is also accepted and treated as "100..100".
                       If not specified, all VLANs (1-4094) are allowed.
                       Only applicable when Mode is set to "Trunk".
                     items:
-                      format: int32
-                      maximum: 4094
-                      minimum: 1
-                      type: integer
+                      pattern: ^[0-9]+(\.\.[0-9]+)?$
+                      type: string
+                      x-kubernetes-int-or-string: true
                     minItems: 1
                     type: array
                   mode:

--- a/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
@@ -409,14 +409,15 @@ spec:
                     type: integer
                   allowedVlans:
                     description: |-
-                      AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.
+                      AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.
+                      Each entry is an inclusive range string like "100..200". For compatibility,
+                      a single integer like 100 is also accepted and treated as "100..100".
                       If not specified, all VLANs (1-4094) are allowed.
                       Only applicable when Mode is set to "Trunk".
                     items:
-                      format: int32
-                      maximum: 4094
-                      minimum: 1
-                      type: integer
+                      pattern: ^[0-9]+(\.\.[0-9]+)?$
+                      type: string
+                      x-kubernetes-int-or-string: true
                     minItems: 1
                     type: array
                   mode:

--- a/config/crd/bases/pool.networking.metal.ironcore.dev_indexpools.yaml
+++ b/config/crd/bases/pool.networking.metal.ironcore.dev_indexpools.yaml
@@ -62,8 +62,9 @@ spec:
                   Ranges defines the inclusive index ranges that can be allocated.
                   Example: "64512..65534".
                 items:
-                  pattern: ^[0-9]+\.\.[0-9]+$
+                  pattern: ^[0-9]+(\.\.[0-9]+)?$
                   type: string
+                  x-kubernetes-int-or-string: true
                 minItems: 1
                 type: array
               reclaimPolicy:

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -2287,11 +2287,13 @@ _Appears in:_
 IndexRange represents an inclusive range of indices.
 
 _Validation:_
-- Pattern: `^[0-9]+\.\.[0-9]+$`
+- Pattern: `^[0-9]+(\.\.[0-9]+)?$`
 - Type: string
+- XIntOrString: {}
 
 _Appears in:_
 - [IndexPoolSpec](#indexpoolspec)
+- [Switchport](#switchport)
 
 
 
@@ -3874,7 +3876,7 @@ _Appears in:_
 | `mode` _[SwitchportMode](#switchportmode)_ | Mode defines the switchport mode, such as access or trunk. |  | Enum: [Access Trunk] <br />Required: \{\} <br /> |
 | `accessVlan` _integer_ | AccessVlan specifies the VLAN ID for access mode switchports.<br />Only applicable when Mode is set to "Access". |  | Maximum: 4094 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 | `nativeVlan` _integer_ | NativeVlan specifies the native VLAN ID for trunk mode switchports.<br />Only applicable when Mode is set to "Trunk". |  | Maximum: 4094 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `allowedVlans` _integer array_ | AllowedVlans is a list of VLAN IDs that are allowed on the trunk port.<br />If not specified, all VLANs (1-4094) are allowed.<br />Only applicable when Mode is set to "Trunk". |  | MinItems: 1 <br />items:Maximum: 4094 <br />items:Minimum: 1 <br />Optional: \{\} <br /> |
+| `allowedVlans` _[IndexRange](#indexrange) array_ | AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.<br />Each entry is an inclusive range string like "100..200". For compatibility,<br />a single integer like 100 is also accepted and treated as "100..100".<br />If not specified, all VLANs (1-4094) are allowed.<br />Only applicable when Mode is set to "Trunk". |  | MinItems: 1 <br />Pattern: `^[0-9]+(\.\.[0-9]+)?$` <br />Type: string <br />XIntOrString: \{\} <br />Optional: \{\} <br /> |
 
 
 #### SwitchportMode
@@ -5439,7 +5441,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `ranges` _[IndexRange](#indexrange) array_ | Ranges defines the inclusive index ranges that can be allocated.<br />Example: "64512..65534". |  | MinItems: 1 <br />Required: \{\} <br /> |
+| `ranges` _[IndexRange](#indexrange) array_ | Ranges defines the inclusive index ranges that can be allocated.<br />Example: "64512..65534". |  | MinItems: 1 <br />Pattern: `^[0-9]+(\.\.[0-9]+)?$` <br />Type: string <br />XIntOrString: \{\} <br />Required: \{\} <br /> |
 | `reclaimPolicy` _[ReclaimPolicy](#reclaimpolicy)_ | ReclaimPolicy controls what happens to an allocation when a claim is deleted.<br />Recycle returns the allocation to the pool. Retain keeps it reserved.<br />Immutable. | Recycle | Enum: [Recycle Retain] <br />Optional: \{\} <br /> |
 
 

--- a/internal/provider/cisco/nxos/intf.go
+++ b/internal/provider/cisco/nxos/intf.go
@@ -4,6 +4,7 @@
 package nxos
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	nxv1alpha1 "github.com/ironcore-dev/network-operator/api/cisco/nx/v1alpha1"
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 	"github.com/ironcore-dev/network-operator/internal/transport/gnmiext"
 )
 
@@ -455,33 +457,27 @@ func (*FabricFwdAnycastMAC) XPath() string {
 	return "System/hmm-items/fwdinst-items/amac"
 }
 
-// Range provides a string representation of identifiers (typically VLAN IDs) that formats the range in a human-readable way.
-// Consecutive IDs are represented as a range (e.g., "10-12"), while single IDs are shown individually (e.g., "15").
-// All values are joined in a comma-separated list of ranges and individual IDs, e.g. "10-12,15,20-22".
-func Range(r []int32) string {
+// Range returns a compact comma-separated string for index ranges.
+// Single-value ranges are rendered as an ID (for example, "15"), while wider
+// ranges are rendered as start-end (for example, "10-12").
+func Range(r []v1alpha1.IndexRange) string {
 	if len(r) == 0 {
 		return ""
 	}
 
-	slices.Sort(r)
+	// Sort the ranges by their start value to ensure proper range formatting.
+	// Validation ensures that the ranges are non-overlapping and non-adjacent.
+	slices.SortFunc(r, func(a, b v1alpha1.IndexRange) int {
+		return cmp.Compare(a.Start, b.Start)
+	})
+
 	var ranges []string
-	start, curr := r[0], r[0]
-	for _, id := range r[1:] {
-		if id == curr+1 {
-			curr = id
+	for _, ir := range r {
+		if ir.Start == ir.End {
+			ranges = append(ranges, strconv.FormatInt(ir.Start, 10))
 			continue
 		}
-		if curr != start {
-			ranges = append(ranges, fmt.Sprintf("%d-%d", start, curr))
-		} else {
-			ranges = append(ranges, strconv.FormatInt(int64(start), 10))
-		}
-		start, curr = id, id
-	}
-	if curr != start {
-		ranges = append(ranges, fmt.Sprintf("%d-%d", start, curr))
-	} else {
-		ranges = append(ranges, strconv.FormatInt(int64(start), 10))
+		ranges = append(ranges, fmt.Sprintf("%d-%d", ir.Start, ir.End))
 	}
 
 	return strings.Join(ranges, ",")

--- a/internal/provider/cisco/nxos/intf_test.go
+++ b/internal/provider/cisco/nxos/intf_test.go
@@ -3,6 +3,52 @@
 
 package nxos
 
+import (
+	"testing"
+
+	corev1alpha1 "github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+)
+
+func TestRange(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []corev1alpha1.IndexRange
+		want string
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "single vlan",
+			in:   []corev1alpha1.IndexRange{corev1alpha1.MustParseIndexRange("10..10")},
+			want: "10",
+		},
+		{
+			name: "range",
+			in:   []corev1alpha1.IndexRange{corev1alpha1.MustParseIndexRange("10..20")},
+			want: "10-20",
+		},
+		{
+			name: "sorted ranges",
+			in: []corev1alpha1.IndexRange{
+				corev1alpha1.MustParseIndexRange("30..40"),
+				corev1alpha1.MustParseIndexRange("10..20"),
+			},
+			want: "10-20,30-40",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Range(test.in); got != test.want {
+				t.Fatalf("Range() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func init() {
 	Register("loopback", &Loopback{
 		ID:            "lo0",

--- a/internal/provider/openconfig/interface.go
+++ b/internal/provider/openconfig/interface.go
@@ -383,8 +383,12 @@ func (i *Interface) SetSwitchport(sp *v1alpha1.Switchport, ifType v1alpha1.Inter
 	case v1alpha1.SwitchportModeTrunk:
 		config.InterfaceMode = SwitchportModeTrunk
 		config.NativeVlan = uint16(sp.NativeVlan) //nolint:gosec
-		for _, vlan := range sp.AllowedVlans {
-			config.TrunkVlans = append(config.TrunkVlans, uint16(vlan)) //nolint:gosec
+		for _, vlanRange := range sp.AllowedVlans {
+			if vlanRange.Start == vlanRange.End {
+				config.TrunkVlans = append(config.TrunkVlans, uint16(vlanRange.Start)) //nolint:gosec
+				continue
+			}
+			config.TrunkVlans = append(config.TrunkVlans, vlanRange.String())
 		}
 	default:
 		return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
@@ -548,7 +552,7 @@ type SwitchedVlanConfig struct {
 	InterfaceMode SwitchportMode `json:"interface-mode,omitempty"`
 	AccessVlan    uint16         `json:"access-vlan,omitempty"`
 	NativeVlan    uint16         `json:"native-vlan,omitempty"`
-	TrunkVlans    []uint16       `json:"trunk-vlans,omitempty"`
+	TrunkVlans    []any          `json:"trunk-vlans,omitempty"`
 }
 
 // InterfaceAggregation holds the openconfig-if-aggregate augmentation.

--- a/internal/webhook/core/v1alpha1/interface_webhook.go
+++ b/internal/webhook/core/v1alpha1/interface_webhook.go
@@ -74,6 +74,12 @@ func validateInterfaceSpec(intf *v1alpha1.Interface) error {
 		}
 	}
 
+	if intf.Spec.Switchport != nil {
+		if err := validateSwitchport(intf.Spec.Switchport); err != nil {
+			errAgg = append(errAgg, err)
+		}
+	}
+
 	return errors.Join(errAgg...)
 }
 
@@ -113,6 +119,22 @@ func validatePhysicalInterfaceNeighborMutualExclusion(intf *v1alpha1.Interface) 
 	}
 
 	return nil
+}
+
+func validateSwitchport(sp *v1alpha1.Switchport) error {
+	var errAgg []error
+	for i, a := range sp.AllowedVlans {
+		if a.Start < 1 || a.End > 4094 {
+			errAgg = append(errAgg, fmt.Errorf("spec.switchport.allowedVlans[%d] (%d..%d) must be between 1 and 4094", i, a.Start, a.End))
+		}
+		for j := i + 1; j < len(sp.AllowedVlans); j++ {
+			b := sp.AllowedVlans[j]
+			if a.Start <= b.End && b.Start <= a.End {
+				errAgg = append(errAgg, fmt.Errorf("spec.switchport.allowedVlans[%d] (%d..%d) overlaps with spec.switchport.allowedVlans[%d] (%d..%d)", i, a.Start, a.End, j, b.Start, b.End))
+			}
+		}
+	}
+	return errors.Join(errAgg...)
 }
 
 // validateInterfaceIPv4 performs validation on the InterfaceIPv4 spec.

--- a/internal/webhook/core/v1alpha1/interface_webhook_test.go
+++ b/internal/webhook/core/v1alpha1/interface_webhook_test.go
@@ -165,5 +165,55 @@ var _ = Describe("Interface Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("cannot set both"))
 		})
+
+		It("Should allow non-overlapping allowed VLAN ranges", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Spec.Switchport = &v1alpha1.Switchport{
+				Mode: v1alpha1.SwitchportModeTrunk,
+				AllowedVlans: []v1alpha1.IndexRange{
+					v1alpha1.MustParseIndexRange("10..20"),
+					v1alpha1.MustParseIndexRange("30..30"),
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should reject overlapping allowed VLAN ranges", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Spec.Switchport = &v1alpha1.Switchport{
+				Mode: v1alpha1.SwitchportModeTrunk,
+				AllowedVlans: []v1alpha1.IndexRange{
+					v1alpha1.MustParseIndexRange("10..20"),
+					v1alpha1.MustParseIndexRange("20..30"),
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("allowedVlans"))
+			Expect(err.Error()).To(ContainSubstring("overlaps"))
+		})
+
+		It("Should reject allowed VLAN ranges below one", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Spec.Switchport = &v1alpha1.Switchport{
+				Mode:         v1alpha1.SwitchportModeTrunk,
+				AllowedVlans: []v1alpha1.IndexRange{{Start: 0, End: 10}},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be between 1 and 4094"))
+		})
+
+		It("Should reject allowed VLAN ranges above 4094", func() {
+			obj.Spec.Type = v1alpha1.InterfaceTypePhysical
+			obj.Spec.Switchport = &v1alpha1.Switchport{
+				Mode:         v1alpha1.SwitchportModeTrunk,
+				AllowedVlans: []v1alpha1.IndexRange{{Start: 4094, End: 4095}},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be between 1 and 4094"))
+		})
 	})
 })


### PR DESCRIPTION
Change allowedVlans to use IndexRange entries so users can express large
trunk VLAN sets without listing every ID.

Keep single VLAN IDs compatible by accepting integer and string singleton
values. Render compact ranges in providers and validate bounds and overlap
in the Interface webhook.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>