### PR TITLE
Add unmanaged allowed VLAN mode

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -66,6 +66,7 @@ k8s_resource(new_name='lo1', objects=['lo1:interface'], trigger_mode=TRIGGER_MOD
 k8s_resource(new_name='eth1-1', objects=['eth1-1:interface'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])
 k8s_resource(new_name='eth1-2', objects=['eth1-2:interface'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])
 k8s_resource(new_name='eth1-10', objects=['eth1-10:interface'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])
+k8s_resource(new_name='eth1-11', objects=['eth1-11:interface'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])
 k8s_resource(new_name='po10', objects=['po-10:interface'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])
 k8s_resource(new_name='eth1-3', objects=['eth1-3:interface'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])
 k8s_resource(new_name='po20', objects=['po-20:interface'], resource_deps=['eth1-3'], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, labels=['samples'])

--- a/api/core/v1alpha1/interface_types.go
+++ b/api/core/v1alpha1/interface_types.go
@@ -151,6 +151,7 @@ const (
 
 // Switchport defines the switchport configuration for an interface.
 // +kubebuilder:validation:XValidation:rule="self.mode != 'Access' || has(self.accessVlan)", message="accessVlan must be specified when mode is Access"
+// +kubebuilder:validation:XValidation:rule="!has(self.allowedVlans) || !has(self.allowedVlansMode) || self.allowedVlansMode != 'Unmanaged'", message="allowedVlans must be omitted when allowedVlansMode is Unmanaged"
 type Switchport struct {
 	// Mode defines the switchport mode, such as access or trunk.
 	// +required
@@ -170,10 +171,20 @@ type Switchport struct {
 	// +kubebuilder:validation:Maximum=4094
 	NativeVlan int32 `json:"nativeVlan,omitempty"`
 
-	// AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.
+	// AllowedVlansMode defines how trunk allowed VLANs are managed.
+	// When omitted, the mode is Exact.
+	// Exact means the operator owns the complete allowed VLAN list.
+	// Unmanaged means the operator does not change the allowed VLAN list.
+	// Only applicable when Mode is set to "Trunk".
+	// +optional
+	// +kubebuilder:default=Exact
+	AllowedVlansMode AllowedVlansMode `json:"allowedVlansMode,omitempty"`
+
+	// AllowedVlans is the exact list of VLAN ID ranges allowed on the trunk port.
 	// Each entry is an inclusive range string like "100..200". For compatibility,
 	// a single integer like 100 is also accepted and treated as "100..100".
-	// If not specified, all VLANs (1-4094) are allowed.
+	// If not specified and AllowedVlansMode is Exact, all VLANs (1-4094) are allowed.
+	// Must be omitted when AllowedVlansMode is Unmanaged.
 	// Only applicable when Mode is set to "Trunk".
 	// +optional
 	// +kubebuilder:validation:MinItems=1
@@ -219,6 +230,17 @@ type Encapsulation struct {
 	// +kubebuilder:validation:Maximum=4094
 	OuterTag int32 `json:"outerTag,omitempty"`
 }
+
+// AllowedVlansMode defines how trunk allowed VLANs are managed.
+// +kubebuilder:validation:Enum=Exact;Unmanaged
+type AllowedVlansMode string
+
+const (
+	// AllowedVlansModeExact means the operator owns the complete trunk allow-list.
+	AllowedVlansModeExact AllowedVlansMode = "Exact"
+	// AllowedVlansModeUnmanaged means the operator leaves the trunk allow-list unchanged.
+	AllowedVlansModeUnmanaged AllowedVlansMode = "Unmanaged"
+)
 
 // SwitchportMode represents the switchport mode of an interface.
 // +kubebuilder:validation:Enum=Access;Trunk

--- a/charts/network-operator/templates/crd/interfaces.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/interfaces.networking.metal.ironcore.dev.yaml
@@ -412,10 +412,11 @@ spec:
                     type: integer
                   allowedVlans:
                     description: |-
-                      AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.
+                      AllowedVlans is the exact list of VLAN ID ranges allowed on the trunk port.
                       Each entry is an inclusive range string like "100..200". For compatibility,
                       a single integer like 100 is also accepted and treated as "100..100".
-                      If not specified, all VLANs (1-4094) are allowed.
+                      If not specified and AllowedVlansMode is Exact, all VLANs (1-4094) are allowed.
+                      Must be omitted when AllowedVlansMode is Unmanaged.
                       Only applicable when Mode is set to "Trunk".
                     items:
                       pattern: ^[0-9]+(\.\.[0-9]+)?$
@@ -423,6 +424,18 @@ spec:
                       x-kubernetes-int-or-string: true
                     minItems: 1
                     type: array
+                  allowedVlansMode:
+                    default: Exact
+                    description: |-
+                      AllowedVlansMode defines how trunk allowed VLANs are managed.
+                      When omitted, the mode is Exact.
+                      Exact means the operator owns the complete allowed VLAN list.
+                      Unmanaged means the operator does not change the allowed VLAN list.
+                      Only applicable when Mode is set to "Trunk".
+                    enum:
+                    - Exact
+                    - Unmanaged
+                    type: string
                   mode:
                     description: Mode defines the switchport mode, such as access
                       or trunk.
@@ -444,6 +457,9 @@ spec:
                 x-kubernetes-validations:
                 - message: accessVlan must be specified when mode is Access
                   rule: self.mode != 'Access' || has(self.accessVlan)
+                - message: allowedVlans must be omitted when allowedVlansMode is Unmanaged
+                  rule: '!has(self.allowedVlans) || !has(self.allowedVlansMode) ||
+                    self.allowedVlansMode != ''Unmanaged'''
               type:
                 description: Type indicates the type of the interface.
                 enum:

--- a/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_interfaces.yaml
@@ -409,10 +409,11 @@ spec:
                     type: integer
                   allowedVlans:
                     description: |-
-                      AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.
+                      AllowedVlans is the exact list of VLAN ID ranges allowed on the trunk port.
                       Each entry is an inclusive range string like "100..200". For compatibility,
                       a single integer like 100 is also accepted and treated as "100..100".
-                      If not specified, all VLANs (1-4094) are allowed.
+                      If not specified and AllowedVlansMode is Exact, all VLANs (1-4094) are allowed.
+                      Must be omitted when AllowedVlansMode is Unmanaged.
                       Only applicable when Mode is set to "Trunk".
                     items:
                       pattern: ^[0-9]+(\.\.[0-9]+)?$
@@ -420,6 +421,18 @@ spec:
                       x-kubernetes-int-or-string: true
                     minItems: 1
                     type: array
+                  allowedVlansMode:
+                    default: Exact
+                    description: |-
+                      AllowedVlansMode defines how trunk allowed VLANs are managed.
+                      When omitted, the mode is Exact.
+                      Exact means the operator owns the complete allowed VLAN list.
+                      Unmanaged means the operator does not change the allowed VLAN list.
+                      Only applicable when Mode is set to "Trunk".
+                    enum:
+                    - Exact
+                    - Unmanaged
+                    type: string
                   mode:
                     description: Mode defines the switchport mode, such as access
                       or trunk.
@@ -441,6 +454,9 @@ spec:
                 x-kubernetes-validations:
                 - message: accessVlan must be specified when mode is Access
                   rule: self.mode != 'Access' || has(self.accessVlan)
+                - message: allowedVlans must be omitted when allowedVlansMode is Unmanaged
+                  rule: '!has(self.allowedVlans) || !has(self.allowedVlansMode) ||
+                    self.allowedVlansMode != ''Unmanaged'''
               type:
                 description: Type indicates the type of the interface.
                 enum:

--- a/config/samples/v1alpha1_interface.yaml
+++ b/config/samples/v1alpha1_interface.yaml
@@ -123,6 +123,27 @@ metadata:
     app.kubernetes.io/name: network-operator
     app.kubernetes.io/managed-by: kustomize
     networking.metal.ironcore.dev/device-name: leaf1
+  name: eth1-11
+spec:
+  deviceRef:
+    name: leaf1
+  name: eth1/11
+  description: Host trunk with externally managed VLAN allow-list
+  adminState: Up
+  type: Physical
+  mtu: 1500
+  switchport:
+    mode: Trunk
+    nativeVlan: 1
+    allowedVlansMode: Unmanaged
+---
+apiVersion: networking.metal.ironcore.dev/v1alpha1
+kind: Interface
+metadata:
+  labels:
+    app.kubernetes.io/name: network-operator
+    app.kubernetes.io/managed-by: kustomize
+    networking.metal.ironcore.dev/device-name: leaf1
   name: po-10
 spec:
   deviceRef:

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -722,6 +722,24 @@ _Appears in:_
 | `multichassis` _[MultiChassis](#multichassis)_ | Multichassis defines the multichassis configuration for the aggregate interface. |  | Optional: \{\} <br /> |
 
 
+#### AllowedVlansMode
+
+_Underlying type:_ _string_
+
+AllowedVlansMode defines how trunk allowed VLANs are managed.
+
+_Validation:_
+- Enum: [Exact Unmanaged]
+
+_Appears in:_
+- [Switchport](#switchport)
+
+| Field | Description |
+| --- | --- |
+| `Exact` | AllowedVlansModeExact means the operator owns the complete trunk allow-list.<br /> |
+| `Unmanaged` | AllowedVlansModeUnmanaged means the operator leaves the trunk allow-list unchanged.<br /> |
+
+
 #### AnycastGateway
 
 
@@ -3876,7 +3894,8 @@ _Appears in:_
 | `mode` _[SwitchportMode](#switchportmode)_ | Mode defines the switchport mode, such as access or trunk. |  | Enum: [Access Trunk] <br />Required: \{\} <br /> |
 | `accessVlan` _integer_ | AccessVlan specifies the VLAN ID for access mode switchports.<br />Only applicable when Mode is set to "Access". |  | Maximum: 4094 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 | `nativeVlan` _integer_ | NativeVlan specifies the native VLAN ID for trunk mode switchports.<br />Only applicable when Mode is set to "Trunk". |  | Maximum: 4094 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `allowedVlans` _[IndexRange](#indexrange) array_ | AllowedVlans is a list of VLAN ID ranges that are allowed on the trunk port.<br />Each entry is an inclusive range string like "100..200". For compatibility,<br />a single integer like 100 is also accepted and treated as "100..100".<br />If not specified, all VLANs (1-4094) are allowed.<br />Only applicable when Mode is set to "Trunk". |  | MinItems: 1 <br />Pattern: `^[0-9]+(\.\.[0-9]+)?$` <br />Type: string <br />XIntOrString: \{\} <br />Optional: \{\} <br /> |
+| `allowedVlansMode` _[AllowedVlansMode](#allowedvlansmode)_ | AllowedVlansMode defines how trunk allowed VLANs are managed.<br />When omitted, the mode is Exact.<br />Exact means the operator owns the complete allowed VLAN list.<br />Unmanaged means the operator does not change the allowed VLAN list.<br />Only applicable when Mode is set to "Trunk". | Exact | Enum: [Exact Unmanaged] <br />Optional: \{\} <br /> |
+| `allowedVlans` _[IndexRange](#indexrange) array_ | AllowedVlans is the exact list of VLAN ID ranges allowed on the trunk port.<br />Each entry is an inclusive range string like "100..200". For compatibility,<br />a single integer like 100 is also accepted and treated as "100..100".<br />If not specified and AllowedVlansMode is Exact, all VLANs (1-4094) are allowed.<br />Must be omitted when AllowedVlansMode is Unmanaged.<br />Only applicable when Mode is set to "Trunk". |  | MinItems: 1 <br />Pattern: `^[0-9]+(\.\.[0-9]+)?$` <br />Type: string <br />XIntOrString: \{\} <br />Optional: \{\} <br /> |
 
 
 #### SwitchportMode

--- a/internal/provider/cisco/nxos/intf.go
+++ b/internal/provider/cisco/nxos/intf.go
@@ -24,6 +24,7 @@ var (
 	_ gnmiext.DataElement = (*PhysIf)(nil)
 	_ gnmiext.Defaultable = (*PhysIf)(nil)
 	_ gnmiext.DataElement = (*PhysIfOperItems)(nil)
+	_ gnmiext.DataElement = (*TrunkVlans)(nil)
 	_ gnmiext.DataElement = (*VrfMember)(nil)
 	_ gnmiext.DataElement = (*SpanningTree)(nil)
 	_ gnmiext.DataElement = (*MultisiteIfTracking)(nil)
@@ -81,7 +82,6 @@ type PhysIf struct {
 	Medium        Medium         `json:"medium"`
 	Mode          SwitchportMode `json:"mode"`
 	NativeVlan    string         `json:"nativeVlan"`
-	TrunkVlans    string         `json:"trunkVlans"`
 	UserCfgdFlags UserFlags      `json:"userCfgdFlags"`
 	RtvrfMbrItems *VrfMember     `json:"rtvrfMbr-items,omitempty"`
 	PhysExtdItems struct {
@@ -116,7 +116,6 @@ func (p *PhysIf) Default() {
 	p.Mode = SwitchportModeAccess
 	p.AccessVlan = DefaultVLAN
 	p.NativeVlan = DefaultVLAN
-	p.TrunkVlans = DefaultVLANRange
 	p.PhysExtdItems.BufferBoost = AdminStEnable
 }
 
@@ -124,6 +123,26 @@ type PhysIfOperItems struct {
 	ID         string `json:"-"`
 	OperSt     OperSt `json:"operSt"`
 	OperStQual string `json:"operStQual"`
+}
+
+type TrunkVlans struct {
+	IfName string `json:"-"`
+	Vlans  string `json:"-"`
+}
+
+func (t *TrunkVlans) XPath() string {
+	if portchannelRe.MatchString(t.IfName) {
+		return "System/intf-items/aggr-items/AggrIf-list[id=" + t.IfName + "]/trunkVlans"
+	}
+	return "System/intf-items/phys-items/PhysIf-list[id=" + t.IfName + "]/trunkVlans"
+}
+
+func (t TrunkVlans) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Vlans)
+}
+
+func (t *TrunkVlans) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, &t.Vlans)
 }
 
 func (p *PhysIfOperItems) XPath() string {
@@ -273,7 +292,6 @@ type PortChannel struct {
 	PcMode         PortChannelMode `json:"pcMode"`
 	NativeVlan     string          `json:"nativeVlan"`
 	SuspIndividual AdminSt4        `json:"suspIndividual"`
-	TrunkVlans     string          `json:"trunkVlans"`
 	UserCfgdFlags  UserFlags       `json:"userCfgdFlags"`
 	RtvrfMbrItems  *VrfMember      `json:"rtvrfMbr-items,omitempty"`
 	RsmbrIfsItems  struct {

--- a/internal/provider/cisco/nxos/intf_test.go
+++ b/internal/provider/cisco/nxos/intf_test.go
@@ -4,10 +4,30 @@
 package nxos
 
 import (
+	"encoding/json"
 	"testing"
 
 	corev1alpha1 "github.com/ironcore-dev/network-operator/api/core/v1alpha1"
 )
+
+func TestTrunkVlansJSON(t *testing.T) {
+	trunkVlans := &TrunkVlans{IfName: "eth1/10", Vlans: "10"}
+	got, err := json.Marshal(trunkVlans)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if string(got) != `"10"` {
+		t.Fatalf("json.Marshal() = %s, want %s", got, `"10"`)
+	}
+
+	var decoded TrunkVlans
+	if err := json.Unmarshal([]byte(`"20-30"`), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.Vlans != "20-30" {
+		t.Fatalf("Unmarshaled Vlans = %q, want %q", decoded.Vlans, "20-30")
+	}
+}
 
 func TestRange(t *testing.T) {
 	tests := []struct {
@@ -68,7 +88,6 @@ func init() {
 		Mode:          SwitchportModeAccess,
 		AccessVlan:    DefaultVLAN,
 		NativeVlan:    DefaultVLAN,
-		TrunkVlans:    DefaultVLANRange,
 		UserCfgdFlags: UserFlagAdminState | UserFlagAdminLayer | UserFlagAdminMTU,
 	})
 
@@ -83,9 +102,10 @@ func init() {
 		Mode:          SwitchportModeTrunk,
 		AccessVlan:    DefaultVLAN,
 		NativeVlan:    DefaultVLAN,
-		TrunkVlans:    "10",
 		UserCfgdFlags: UserFlagAdminState,
 	})
+
+	Register("physif_trunk_vlans", &TrunkVlans{IfName: "eth1/10", Vlans: "10"})
 
 	Register("subinterface", &EncapRoutedInterface{
 		ID:         "eth1/1.100",
@@ -119,11 +139,11 @@ func init() {
 		PcMode:         PortChannelModeActive,
 		NativeVlan:     DefaultVLAN,
 		SuspIndividual: AdminStEnable,
-		TrunkVlans:     "10",
 		UserCfgdFlags:  UserFlagAdminState,
 	}
 	pc.RsmbrIfsItems.RsMbrIfsList.Set(NewPortChannelMember("eth1/10"))
 	Register("pc", pc)
+	Register("pc_trunk_vlans", &TrunkVlans{IfName: "po10", Vlans: "10"})
 
 	Register("pc_rtd", &PortChannel{
 		AccessVlan:     "unknown",
@@ -138,7 +158,6 @@ func init() {
 		NativeVlan:     "unknown",
 		PcMode:         PortChannelModeActive,
 		SuspIndividual: AdminStEnable,
-		TrunkVlans:     DefaultVLANRange,
 		UserCfgdFlags:  UserFlagAdminState | UserFlagAdminLayer | UserFlagAdminMTU,
 		RtvrfMbrItems:  NewVrfMember("po20", "default"),
 		AggrExtdItems: struct {
@@ -159,7 +178,6 @@ func init() {
 		PcMode:         PortChannelModeActive,
 		NativeVlan:     DefaultVLAN,
 		SuspIndividual: AdminStDisable,
-		TrunkVlans:     "10",
 		UserCfgdFlags:  UserFlagAdminState,
 	}
 	pcLacp.RsmbrIfsItems.RsMbrIfsList.Set(NewPortChannelMember("eth1/1"))
@@ -193,7 +211,6 @@ func init() {
 		Medium:               MediumPointToPoint,
 		Mode:                 SwitchportModeAccess,
 		NativeVlan:           DefaultVLAN,
-		TrunkVlans:           DefaultVLANRange,
 		UserCfgdFlags:        UserFlagAdminState | UserFlagAdminLayer | UserFlagAdminMTU,
 		ESICoreTrackingItems: &ESICoreTracking{CoreTracking: AdminStEnabled},
 	})

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -1313,8 +1313,12 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 				if req.Interface.Spec.Switchport.NativeVlan != 0 {
 					p.NativeVlan = fmt.Sprintf("vlan-%d", req.Interface.Spec.Switchport.NativeVlan)
 				}
-				if len(req.Interface.Spec.Switchport.AllowedVlans) > 0 {
-					p.TrunkVlans = Range(req.Interface.Spec.Switchport.AllowedVlans)
+				if req.Interface.Spec.Switchport.AllowedVlansMode != v1alpha1.AllowedVlansModeUnmanaged {
+					vlans := DefaultVLANRange
+					if len(req.Interface.Spec.Switchport.AllowedVlans) > 0 {
+						vlans = Range(req.Interface.Spec.Switchport.AllowedVlans)
+					}
+					sb.Patch(&TrunkVlans{IfName: name, Vlans: vlans})
 				}
 			default:
 				return fmt.Errorf("invalid switchport mode: %s", req.Interface.Spec.Switchport.Mode)
@@ -1376,7 +1380,6 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		pc.Medium = MediumBroadcast
 		pc.AccessVlan = DefaultVLAN
 		pc.NativeVlan = DefaultVLAN
-		pc.TrunkVlans = DefaultVLANRange
 		pc.UserCfgdFlags = UserFlagAdminState | UserFlagAdminLayer
 		pc.AggrExtdItems.BufferBoost = AdminStEnable
 
@@ -1417,8 +1420,12 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 				if req.Interface.Spec.Switchport.NativeVlan != 0 {
 					pc.NativeVlan = fmt.Sprintf("vlan-%d", req.Interface.Spec.Switchport.NativeVlan)
 				}
-				if len(req.Interface.Spec.Switchport.AllowedVlans) > 0 {
-					pc.TrunkVlans = Range(req.Interface.Spec.Switchport.AllowedVlans)
+				if req.Interface.Spec.Switchport.AllowedVlansMode != v1alpha1.AllowedVlansModeUnmanaged {
+					vlans := DefaultVLANRange
+					if len(req.Interface.Spec.Switchport.AllowedVlans) > 0 {
+						vlans = Range(req.Interface.Spec.Switchport.AllowedVlans)
+					}
+					sb.Patch(&TrunkVlans{IfName: name, Vlans: vlans})
 				}
 			default:
 				return fmt.Errorf("invalid switchport mode: %s", req.Interface.Spec.Switchport.Mode)
@@ -1692,6 +1699,7 @@ func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceR
 		i := new(PhysIf)
 		i.ID = name
 		sb.Delete(i)
+		sb.Patch(&TrunkVlans{IfName: name, Vlans: DefaultVLANRange})
 
 		stp := new(SpanningTree)
 		stp.IfName = name

--- a/internal/provider/cisco/nxos/testdata/pc.json
+++ b/internal/provider/cisco/nxos/testdata/pc.json
@@ -14,7 +14,6 @@
           "mode": "trunk",
           "pcMode": "active",
           "nativeVlan": "vlan-1",
-          "trunkVlans": "10",
           "suspIndividual": "enable",
           "userCfgdFlags": "admin_state",
           "rsmbrIfs-items": {

--- a/internal/provider/cisco/nxos/testdata/pc_lacp.json
+++ b/internal/provider/cisco/nxos/testdata/pc_lacp.json
@@ -15,7 +15,6 @@
           "pcMode": "active",
           "nativeVlan": "vlan-1",
           "suspIndividual": "disable",
-          "trunkVlans": "10",
           "userCfgdFlags": "admin_state",
           "rsmbrIfs-items": {
             "RsMbrIfs-list": [

--- a/internal/provider/cisco/nxos/testdata/pc_rtd.json
+++ b/internal/provider/cisco/nxos/testdata/pc_rtd.json
@@ -15,7 +15,6 @@
           "pcMode": "active",
           "nativeVlan": "unknown",
           "suspIndividual": "enable",
-          "trunkVlans": "1-4094",
           "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
           "rtvrfMbr-items": {
             "tDn": "/System/inst-items/Inst-list[name='default']"

--- a/internal/provider/cisco/nxos/testdata/pc_trunk_vlans.json
+++ b/internal/provider/cisco/nxos/testdata/pc_trunk_vlans.json
@@ -1,0 +1,12 @@
+{
+  "intf-items": {
+    "aggr-items": {
+      "AggrIf-list": [
+        {
+          "id": "po10",
+          "trunkVlans": "10"
+        }
+      ]
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/pc_trunk_vlans.json.txt
+++ b/internal/provider/cisco/nxos/testdata/pc_trunk_vlans.json.txt
@@ -1,0 +1,2 @@
+interface Port-channel10
+ switchport trunk allowed vlan 10

--- a/internal/provider/cisco/nxos/testdata/physif_coretracking.json
+++ b/internal/provider/cisco/nxos/testdata/physif_coretracking.json
@@ -13,7 +13,6 @@
           "medium": "p2p",
           "mode": "access",
           "nativeVlan": "vlan-1",
-          "trunkVlans": "1-4094",
           "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
           "esimhcoretracking-items": {
             "coretracking": "enabled"

--- a/internal/provider/cisco/nxos/testdata/physif_rtd.json
+++ b/internal/provider/cisco/nxos/testdata/physif_rtd.json
@@ -13,7 +13,6 @@
           "medium": "p2p",
           "mode": "access",
           "nativeVlan": "vlan-1",
-          "trunkVlans": "1-4094",
           "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
         }
       ]

--- a/internal/provider/cisco/nxos/testdata/physif_switchport.json
+++ b/internal/provider/cisco/nxos/testdata/physif_switchport.json
@@ -13,7 +13,6 @@
           "medium": "broadcast",
           "mode": "trunk",
           "nativeVlan": "vlan-1",
-          "trunkVlans": "10",
           "userCfgdFlags": "admin_state"
         }
       ]

--- a/internal/provider/cisco/nxos/testdata/physif_trunk_vlans.json
+++ b/internal/provider/cisco/nxos/testdata/physif_trunk_vlans.json
@@ -1,0 +1,12 @@
+{
+  "intf-items": {
+    "phys-items": {
+      "PhysIf-list": [
+        {
+          "id": "eth1/10",
+          "trunkVlans": "10"
+        }
+      ]
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/physif_trunk_vlans.json.txt
+++ b/internal/provider/cisco/nxos/testdata/physif_trunk_vlans.json.txt
@@ -1,0 +1,2 @@
+interface Ethernet1/10
+ switchport trunk allowed vlan 10

--- a/internal/provider/openconfig/interface.go
+++ b/internal/provider/openconfig/interface.go
@@ -5,6 +5,7 @@ package openconfig
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
@@ -87,10 +88,28 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		})
 	}
 
+	sb := new(gnmiext.SetBuilder)
 	if spec.Switchport != nil {
 		i.Config.TPID = InterfaceTPIDDot1Q
 		if err := i.SetSwitchport(spec.Switchport, spec.Type); err != nil {
 			return err
+		}
+		if spec.Switchport.Mode == v1alpha1.SwitchportModeTrunk && spec.Switchport.AllowedVlansMode != v1alpha1.AllowedVlansModeUnmanaged {
+			switch allowedVlans := spec.Switchport.AllowedVlans; {
+			case len(allowedVlans) == 0:
+				// If no allowed VLANs are specified, we default to allowing all VLANs (1..4094).
+				sb.Patch(&TrunkVlans{InterfaceName: spec.Name, InterfaceType: spec.Type, Vlans: []any{"1..4094"}})
+			default:
+				vlans := make([]any, 0, len(spec.Switchport.AllowedVlans))
+				for _, vlanRange := range spec.Switchport.AllowedVlans {
+					if vlanRange.Start == vlanRange.End {
+						vlans = append(vlans, uint16(vlanRange.Start)) //nolint:gosec
+						continue
+					}
+					vlans = append(vlans, vlanRange.String())
+				}
+				sb.Patch(&TrunkVlans{InterfaceName: spec.Name, InterfaceType: spec.Type, Vlans: vlans})
+			}
 		}
 	}
 
@@ -148,7 +167,8 @@ func (p *Provider) EnsureInterface(ctx context.Context, req *provider.EnsureInte
 		})
 	}
 
-	return p.client.Update(ctx, i)
+	sb.Update(i)
+	return p.client.Do(ctx, sb)
 }
 
 func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceRequest) error {
@@ -164,7 +184,8 @@ func (p *Provider) DeleteInterface(ctx context.Context, req *provider.InterfaceR
 				Enabled: false,
 			},
 		}
-		return p.client.Update(ctx, i)
+		vlans := &TrunkVlans{InterfaceName: spec.Name, InterfaceType: spec.Type, Vlans: []any{"1..4094"}}
+		return p.client.Update(ctx, i, vlans)
 
 	case v1alpha1.InterfaceTypeLoopback, v1alpha1.InterfaceTypeAggregate, v1alpha1.InterfaceTypeRoutedVLAN:
 		i := &Interface{Name: spec.Name}
@@ -357,6 +378,7 @@ var (
 	_ gnmiext.DataElement = (*Interface)(nil)
 	_ gnmiext.DataElement = (*InterfaceOperState)(nil)
 	_ gnmiext.DataElement = (*SubinterfaceEntry)(nil)
+	_ gnmiext.DataElement = (*TrunkVlans)(nil)
 )
 
 // Interface represents an OpenConfig interface list entry.
@@ -383,13 +405,6 @@ func (i *Interface) SetSwitchport(sp *v1alpha1.Switchport, ifType v1alpha1.Inter
 	case v1alpha1.SwitchportModeTrunk:
 		config.InterfaceMode = SwitchportModeTrunk
 		config.NativeVlan = uint16(sp.NativeVlan) //nolint:gosec
-		for _, vlanRange := range sp.AllowedVlans {
-			if vlanRange.Start == vlanRange.End {
-				config.TrunkVlans = append(config.TrunkVlans, uint16(vlanRange.Start)) //nolint:gosec
-				continue
-			}
-			config.TrunkVlans = append(config.TrunkVlans, vlanRange.String())
-		}
 	default:
 		return apistatus.NewUnsupportedFieldError(apistatus.FieldViolation{
 			Field:       "spec.switchport.mode",
@@ -553,6 +568,29 @@ type SwitchedVlanConfig struct {
 	AccessVlan    uint16         `json:"access-vlan,omitempty"`
 	NativeVlan    uint16         `json:"native-vlan,omitempty"`
 	TrunkVlans    []any          `json:"trunk-vlans,omitempty"`
+}
+
+type TrunkVlans struct {
+	InterfaceName string                 `json:"-"`
+	InterfaceType v1alpha1.InterfaceType `json:"-"`
+	Vlans         []any                  `json:"-"`
+}
+
+func (t *TrunkVlans) XPath() string {
+	switch t.InterfaceType {
+	case v1alpha1.InterfaceTypeAggregate:
+		return fmt.Sprintf("openconfig-interfaces:interfaces/interface[name=%s]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans", t.InterfaceName)
+	default:
+		return fmt.Sprintf("openconfig-interfaces:interfaces/interface[name=%s]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans", t.InterfaceName)
+	}
+}
+
+func (t TrunkVlans) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Vlans)
+}
+
+func (t *TrunkVlans) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, &t.Vlans)
 }
 
 // InterfaceAggregation holds the openconfig-if-aggregate augmentation.

--- a/internal/provider/openconfig/interface_test.go
+++ b/internal/provider/openconfig/interface_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package openconfig
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+)
+
+func TestOpenConfigTrunkVlansJSON(t *testing.T) {
+	trunkVlans := &TrunkVlans{
+		InterfaceName: "ethernet-1/1",
+		InterfaceType: v1alpha1.InterfaceTypePhysical,
+		Vlans:         []any{uint16(10), "20..30"},
+	}
+	got, err := json.Marshal(trunkVlans)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if string(got) != `[10,"20..30"]` {
+		t.Fatalf("json.Marshal() = %s, want %s", got, `[10,"20..30"]`)
+	}
+
+	var decoded TrunkVlans
+	if err := json.Unmarshal([]byte(`[10,"20..30"]`), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	want := []any{float64(10), "20..30"}
+	if !reflect.DeepEqual(decoded.Vlans, want) {
+		t.Fatalf("Unmarshaled Vlans = %#v, want %#v", decoded.Vlans, want)
+	}
+}
+
+func TestOpenConfigTrunkVlansXPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *TrunkVlans
+		want string
+	}{
+		{
+			name: "physical",
+			in:   &TrunkVlans{InterfaceName: "ethernet-1/1", InterfaceType: v1alpha1.InterfaceTypePhysical},
+			want: "openconfig-interfaces:interfaces/interface[name=ethernet-1/1]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans",
+		},
+		{
+			name: "aggregate",
+			in:   &TrunkVlans{InterfaceName: "lag1", InterfaceType: v1alpha1.InterfaceTypeAggregate},
+			want: "openconfig-interfaces:interfaces/interface[name=lag1]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.in.XPath(); got != test.want {
+				t.Fatalf("XPath() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestInterfaceSetSwitchportOmitsTrunkVlans(t *testing.T) {
+	i := &Interface{Name: "ethernet-1/1"}
+	if err := i.SetSwitchport(&v1alpha1.Switchport{
+		Mode:         v1alpha1.SwitchportModeTrunk,
+		AllowedVlans: []v1alpha1.IndexRange{v1alpha1.MustParseIndexRange("10..10")},
+	}, v1alpha1.InterfaceTypePhysical); err != nil {
+		t.Fatalf("SetSwitchport() error = %v", err)
+	}
+
+	got := i.Ethernet.SwitchedVlan.Config
+	if got.TrunkVlans != nil {
+		t.Fatalf("TrunkVlans = %#v, want nil", got.TrunkVlans)
+	}
+	if got.InterfaceMode != SwitchportModeTrunk {
+		t.Fatalf("InterfaceMode = %q, want %q", got.InterfaceMode, SwitchportModeTrunk)
+	}
+}


### PR DESCRIPTION
Introduce allowedVlansMode on switchport configuration so trunk VLAN ownership is explicit. The default 'Exact' mode preserves the existing behavior, while a newly added 'Unmanaged' lets external automation own the trunk allow-list.

Realize trunk VLANs as dedicated provider data elements for NX-OS and OpenConfig so interface reconciliation can still manage the rest of the port without diffing or replacing externally managed VLANs.