### PR TITLE
Ensure Certificate ID is alphanumeric

### DIFF
--- a/api/core/v1alpha1/certificate_types.go
+++ b/api/core/v1alpha1/certificate_types.go
@@ -30,6 +30,7 @@ type CertificateSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ID is immutable"
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]+$`
 	ID string `json:"id"`
 
 	// Secret containing the certificate source.

--- a/charts/network-operator/templates/crd/certificates.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/certificates.networking.metal.ironcore.dev.yaml
@@ -89,6 +89,7 @@ spec:
                   Immutable.
                 maxLength: 63
                 minLength: 1
+                pattern: ^[a-zA-Z0-9]+$
                 type: string
                 x-kubernetes-validations:
                 - message: ID is immutable

--- a/config/crd/bases/networking.metal.ironcore.dev_certificates.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_certificates.yaml
@@ -86,6 +86,7 @@ spec:
                   Immutable.
                 maxLength: 63
                 minLength: 1
+                pattern: ^[a-zA-Z0-9]+$
                 type: string
                 x-kubernetes-validations:
                 - message: ID is immutable

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1312,7 +1312,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `deviceRef` _[LocalObjectReference](#localobjectreference)_ | DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.<br />Immutable. |  | Required: \{\} <br /> |
 | `providerConfigRef` _[TypedLocalObjectReference](#typedlocalobjectreference)_ | ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.<br />This reference is used to link the Certificate to its provider-specific configuration. |  | Optional: \{\} <br /> |
-| `id` _string_ | The certificate management id.<br />Immutable. |  | MaxLength: 63 <br />MinLength: 1 <br />Required: \{\} <br /> |
+| `id` _string_ | The certificate management id.<br />Immutable. |  | MaxLength: 63 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z0-9]+$` <br />Required: \{\} <br /> |
 | `secretRef` _[SecretReference](#secretreference)_ | Secret containing the certificate source.<br />The secret must be of type kubernetes.io/tls and as such contain the following keys: 'tls.crt' and 'tls.key'. |  | Required: \{\} <br /> |
 
 


### PR DESCRIPTION
the ID is passed through to nxapi run bash commands
this is to ensure no injection is possible

Signed-off-by: Ivo Gosemann <ivo.gosemann@sap.com>
