### PR TITLE
Allow high part zero in asdot AS number notation per RFC 5396

### DIFF
--- a/api/core/v1alpha1/bgp_peer_types.go
+++ b/api/core/v1alpha1/bgp_peer_types.go
@@ -42,7 +42,7 @@ type BGPPeerSpec struct {
 	Address string `json:"address"`
 
 	// ASNumber is the autonomous system number (ASN) of the BGP peer.
-	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
 	// +required
 	ASNumber intstr.IntOrString `json:"asNumber"`
 

--- a/api/core/v1alpha1/bgp_types.go
+++ b/api/core/v1alpha1/bgp_types.go
@@ -38,7 +38,7 @@ type BGPSpec struct {
 	AdminState AdminState `json:"adminState,omitempty"`
 
 	// ASNumber is the autonomous system number (ASN) for the BGP router.
-	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
 	// Immutable.
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ASNumber is immutable"

--- a/api/core/v1alpha1/routingpolicy_types.go
+++ b/api/core/v1alpha1/routingpolicy_types.go
@@ -125,7 +125,7 @@ type SetASPathAction struct {
 	Replace *SetASPathReplace `json:"replace,omitempty"`
 
 	// ASNumber sets the AS path to the specified AS number.
-	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
 	// +optional
 	ASNumber *intstr.IntOrString `json:"asNumber,omitempty"`
 }
@@ -135,7 +135,7 @@ type SetASPathAction struct {
 // +kubebuilder:validation:XValidation:rule="has(self.asNumber) != has(self.useLastAS)",message="exactly one of asNumber or useLastAS must be specified"
 type SetASPathPrepend struct {
 	// ASNumber is the autonomous system number to prepend to the AS path.
-	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
 	// +optional
 	ASNumber *intstr.IntOrString `json:"asNumber,omitempty"`
 
@@ -155,12 +155,12 @@ type SetASPathReplace struct {
 	PrivateAS bool `json:"privateAS,omitempty"`
 
 	// ASNumber targets a specific AS number in the path for replacement.
-	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
 	// +optional
 	ASNumber *intstr.IntOrString `json:"asNumber,omitempty"`
 
 	// Replacement is the AS number to substitute in place of matched AS numbers.
-	// Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+	// Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
 	// +required
 	Replacement intstr.IntOrString `json:"replacement"`
 }

--- a/charts/network-operator/templates/crd/bgp.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bgp.networking.metal.ironcore.dev.yaml
@@ -298,7 +298,7 @@ spec:
                 - type: string
                 description: |-
                   ASNumber is the autonomous system number (ASN) for the BGP router.
-                  Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                  Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                   Immutable.
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:

--- a/charts/network-operator/templates/crd/bgppeers.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/bgppeers.networking.metal.ironcore.dev.yaml
@@ -289,7 +289,7 @@ spec:
                 - type: string
                 description: |-
                   ASNumber is the autonomous system number (ASN) of the BGP peer.
-                  Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                  Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                 x-kubernetes-int-or-string: true
               bgpRef:
                 description: |-

--- a/charts/network-operator/templates/crd/routingpolicies.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/routingpolicies.networking.metal.ironcore.dev.yaml
@@ -152,7 +152,7 @@ spec:
                                   - type: string
                                   description: |-
                                     ASNumber sets the AS path to the specified AS number.
-                                    Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                    Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                   x-kubernetes-int-or-string: true
                                 prepend:
                                   description: Prepend configures prepending to the
@@ -164,7 +164,7 @@ spec:
                                       - type: string
                                       description: |-
                                         ASNumber is the autonomous system number to prepend to the AS path.
-                                        Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                        Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                       x-kubernetes-int-or-string: true
                                     useLastAS:
                                       description: UseLastAS prepends the last AS
@@ -189,7 +189,7 @@ spec:
                                       - type: string
                                       description: |-
                                         ASNumber targets a specific AS number in the path for replacement.
-                                        Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                        Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                       x-kubernetes-int-or-string: true
                                     privateAS:
                                       description: PrivateAS, when set to true, targets
@@ -201,7 +201,7 @@ spec:
                                       - type: string
                                       description: |-
                                         Replacement is the AS number to substitute in place of matched AS numbers.
-                                        Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                        Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - replacement

--- a/config/crd/bases/networking.metal.ironcore.dev_bgp.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_bgp.yaml
@@ -295,7 +295,7 @@ spec:
                 - type: string
                 description: |-
                   ASNumber is the autonomous system number (ASN) for the BGP router.
-                  Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                  Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                   Immutable.
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:

--- a/config/crd/bases/networking.metal.ironcore.dev_bgppeers.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_bgppeers.yaml
@@ -286,7 +286,7 @@ spec:
                 - type: string
                 description: |-
                   ASNumber is the autonomous system number (ASN) of the BGP peer.
-                  Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                  Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                 x-kubernetes-int-or-string: true
               bgpRef:
                 description: |-

--- a/config/crd/bases/networking.metal.ironcore.dev_routingpolicies.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_routingpolicies.yaml
@@ -149,7 +149,7 @@ spec:
                                   - type: string
                                   description: |-
                                     ASNumber sets the AS path to the specified AS number.
-                                    Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                    Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                   x-kubernetes-int-or-string: true
                                 prepend:
                                   description: Prepend configures prepending to the
@@ -161,7 +161,7 @@ spec:
                                       - type: string
                                       description: |-
                                         ASNumber is the autonomous system number to prepend to the AS path.
-                                        Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                        Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                       x-kubernetes-int-or-string: true
                                     useLastAS:
                                       description: UseLastAS prepends the last AS
@@ -186,7 +186,7 @@ spec:
                                       - type: string
                                       description: |-
                                         ASNumber targets a specific AS number in the path for replacement.
-                                        Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                        Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                       x-kubernetes-int-or-string: true
                                     privateAS:
                                       description: PrivateAS, when set to true, targets
@@ -198,7 +198,7 @@ spec:
                                       - type: string
                                       description: |-
                                         Replacement is the AS number to substitute in place of matched AS numbers.
-                                        Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.
+                                        Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - replacement

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1055,7 +1055,7 @@ _Appears in:_
 | `bgpRef` _[LocalObjectReference](#localobjectreference)_ | BgpRef is a reference to the BGP instance this peer belongs to.<br />The BGP object must exist in the same namespace. |  | Required: \{\} <br /> |
 | `adminState` _[AdminState](#adminstate)_ | AdminState indicates whether this BGP peer is administratively up or down.<br />When Down, the BGP session with this peer is administratively shut down. | Up | Enum: [Up Down] <br />Optional: \{\} <br /> |
 | `address` _string_ | Address is the IPv4 address of the BGP peer. |  | Format: ipv4 <br />Required: \{\} <br /> |
-| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) of the BGP peer.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Required: \{\} <br /> |
+| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) of the BGP peer.<br />Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396. |  | Required: \{\} <br /> |
 | `description` _string_ | Description is an optional human-readable description for this BGP peer.<br />This field is used for documentation purposes and may be displayed in management interfaces. |  | Optional: \{\} <br /> |
 | `localAddress` _[BGPPeerLocalAddress](#bgppeerlocaladdress)_ | LocalAddress specifies the local address configuration for the BGP session with this peer.<br />This determines the source address/interface for BGP packets sent to this peer. |  | Optional: \{\} <br /> |
 | `addressFamilies` _[BGPPeerAddressFamilies](#bgppeeraddressfamilies)_ | AddressFamilies configures address family specific settings for this BGP peer.<br />Controls which address families are enabled and their specific configuration. |  | Optional: \{\} <br /> |
@@ -1133,7 +1133,7 @@ _Appears in:_
 | `vrfRef` _[LocalObjectReference](#localobjectreference)_ | VrfRef is an optional reference to the VRF this BGP instance is scoped to.<br />When omitted, the BGP instance is configured in the default VRF.<br />Immutable. |  | Optional: \{\} <br /> |
 | `providerConfigRef` _[TypedLocalObjectReference](#typedlocalobjectreference)_ | ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.<br />This reference is used to link the BGP to its provider-specific configuration. |  | Optional: \{\} <br /> |
 | `adminState` _[AdminState](#adminstate)_ | AdminState indicates whether this BGP router is administratively up or down. | Up | Enum: [Up Down] <br />Optional: \{\} <br /> |
-| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) for the BGP router.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396.<br />Immutable. |  | Required: \{\} <br /> |
+| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number (ASN) for the BGP router.<br />Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396.<br />Immutable. |  | Required: \{\} <br /> |
 | `routerId` _string_ | RouterID is the BGP router identifier, used in BGP messages to identify the originating router.<br />Follows dotted quad notation (IPv4 format). |  | Format: ipv4 <br />Required: \{\} <br /> |
 | `addressFamilies` _[BGPAddressFamilies](#bgpaddressfamilies)_ | AddressFamilies configures supported BGP address families and their specific settings. |  | Optional: \{\} <br /> |
 
@@ -3782,7 +3782,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `prepend` _[SetASPathPrepend](#setaspathprepend)_ | Prepend configures prepending to the AS path. |  | Optional: \{\} <br /> |
 | `replace` _[SetASPathReplace](#setaspathreplace)_ | Replace configures replacement of AS numbers in the AS path. |  | Optional: \{\} <br /> |
-| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber sets the AS path to the specified AS number.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Optional: \{\} <br /> |
+| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber sets the AS path to the specified AS number.<br />Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396. |  | Optional: \{\} <br /> |
 
 
 #### SetASPathPrepend
@@ -3799,7 +3799,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number to prepend to the AS path.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Optional: \{\} <br /> |
+| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber is the autonomous system number to prepend to the AS path.<br />Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396. |  | Optional: \{\} <br /> |
 | `useLastAS` _integer_ | UseLastAS prepends the last AS number in the existing AS path the specified number of times. |  | Maximum: 10 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 
 
@@ -3818,8 +3818,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `privateAS` _boolean_ | PrivateAS, when set to true, targets all private AS numbers in the path for replacement. |  | Optional: \{\} <br /> |
-| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber targets a specific AS number in the path for replacement.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Optional: \{\} <br /> |
-| `replacement` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | Replacement is the AS number to substitute in place of matched AS numbers.<br />Supports both plain format (1-4294967295) and dotted notation (1-65535.0-65535) as per RFC 5396. |  | Required: \{\} <br /> |
+| `asNumber` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | ASNumber targets a specific AS number in the path for replacement.<br />Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396. |  | Optional: \{\} <br /> |
+| `replacement` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | Replacement is the AS number to substitute in place of matched AS numbers.<br />Supports both plain format (1-4294967295) and dotted notation (0-65535.0-65535) as per RFC 5396. |  | Required: \{\} <br /> |
 
 
 #### SetCommunityAction

--- a/internal/webhook/core/v1alpha1/bgp_webhook.go
+++ b/internal/webhook/core/v1alpha1/bgp_webhook.go
@@ -93,8 +93,8 @@ func validateASNumber(asn intstr.IntOrString) error {
 	if err != nil {
 		return fmt.Errorf("invalid AS number dotted notation %q: high part is not a valid number: %w", asnStr, err)
 	}
-	if high < 1 || high > math.MaxUint16 {
-		return fmt.Errorf("invalid AS number dotted notation %q: high part %d is out of valid range (1-65535)", asnStr, high)
+	if high < 0 || high > math.MaxUint16 {
+		return fmt.Errorf("invalid AS number dotted notation %q: high part %d is out of valid range (0-65535)", asnStr, high)
 	}
 
 	low, err := strconv.ParseInt(parts[1], 10, 64)
@@ -103,6 +103,11 @@ func validateASNumber(asn intstr.IntOrString) error {
 	}
 	if low < 0 || low > math.MaxUint16 {
 		return fmt.Errorf("invalid AS number dotted notation %q: low part %d is out of valid range (0-65535)", asnStr, low)
+	}
+
+	// The combined value must be a valid ASN (>= 1)
+	if high == 0 && low == 0 {
+		return fmt.Errorf("invalid AS number dotted notation %q: AS number 0.0 is reserved", asnStr)
 	}
 
 	return nil

--- a/internal/webhook/core/v1alpha1/bgp_webhook_test.go
+++ b/internal/webhook/core/v1alpha1/bgp_webhook_test.go
@@ -114,8 +114,14 @@ var _ = Describe("BGP Webhook", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("Should deny creation with invalid dotted notation - high part is zero", func() {
+		It("Should allow creation with valid dotted notation - high part is zero", func() {
 			obj.Spec.ASNumber = intstr.FromString("0.100")
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should deny creation with dotted notation 0.0 - reserved AS number", func() {
+			obj.Spec.ASNumber = intstr.FromString("0.0")
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).To(HaveOccurred())
 		})

--- a/internal/webhook/core/v1alpha1/bgppeer_webhook_test.go
+++ b/internal/webhook/core/v1alpha1/bgppeer_webhook_test.go
@@ -112,8 +112,14 @@ var _ = Describe("BGPPeer Webhook", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("Should deny creation with invalid dotted notation - high part is zero", func() {
+		It("Should allow creation with valid dotted notation - high part is zero", func() {
 			obj.Spec.ASNumber = intstr.FromString("0.100")
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should deny creation with dotted notation 0.0 - reserved AS number", func() {
+			obj.Spec.ASNumber = intstr.FromString("0.0")
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).To(HaveOccurred())
 		})


### PR DESCRIPTION
The validateASNumber function incorrectly rejected dotted notation with a zero high part (e.g. "0.100"). Per RFC 5396, asdot notation is <high>.<low> where both parts are 0-65535 and the combined value (high*65536 + low) represents the AS number. Values like "0.100" represent ASN 100 and are valid.

The only invalid zero case is "0.0" which maps to the reserved ASN 0.

Fixes #507