### PR TITLE
Validate consistent IP address family in AccessControlList

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -73,6 +73,9 @@ resources:
   kind: AccessControlList
   path: github.com/ironcore-dev/network-operator/api/core/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/charts/network-operator/templates/webhook/validating-webhook-configuration.yaml
+++ b/charts/network-operator/templates/webhook/validating-webhook-configuration.yaml
@@ -14,6 +14,26 @@ webhooks:
     service:
       name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
       namespace: {{ .Release.Namespace }}
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-accesscontrollist
+  failurePolicy: Fail
+  name: accesscontrollist-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - accesscontrollist
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "network-operator.resourceName" (dict "suffix" "webhook-service" "context" $) }}
+      namespace: {{ .Release.Namespace }}
       path: /validate-networking-metal-ironcore-dev-v1alpha1-bgp
   failurePolicy: Fail
   name: bgp-v1alpha1.kb.io

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -769,6 +769,11 @@ func main() { //nolint:gocyclo
 			os.Exit(1)
 		}
 
+		if err := webhookv1alpha1.SetupAccessControlListWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create webhook", "webhook", "AccessControlList")
+			os.Exit(1)
+		}
+
 		if err := webhooknxv1alpha1.SetupNetworkVirtualizationEdgeConfigWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "NetworkVirtualizationEdgeConfig")
 			os.Exit(1)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,6 +10,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-networking-metal-ironcore-dev-v1alpha1-accesscontrollist
+  failurePolicy: Fail
+  name: accesscontrollist-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - networking.metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - accesscontrollist
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-networking-metal-ironcore-dev-v1alpha1-bgp
   failurePolicy: Fail
   name: bgp-v1alpha1.kb.io

--- a/internal/webhook/core/v1alpha1/acl_webhook.go
+++ b/internal/webhook/core/v1alpha1/acl_webhook.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+)
+
+// log is for logging in this package.
+var acllog = logf.Log.WithName("accesscontrollist-resource")
+
+// SetupAccessControlListWebhookWithManager registers the webhook for AccessControlList in the manager.
+func SetupAccessControlListWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AccessControlList{}).
+		WithValidator(&AccessControlListCustomValidator{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-networking-metal-ironcore-dev-v1alpha1-accesscontrollist,mutating=false,failurePolicy=Fail,sideEffects=None,groups=networking.metal.ironcore.dev,resources=accesscontrollist,verbs=create;update,versions=v1alpha1,name=accesscontrollist-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// AccessControlListCustomValidator struct is responsible for validating the AccessControlList resource
+// when it is created, updated, or deleted.
+type AccessControlListCustomValidator struct{}
+
+var _ admission.Validator[*v1alpha1.AccessControlList] = &AccessControlListCustomValidator{}
+
+// ValidateCreate implements [admission.Validator] so a webhook will be registered for the type AccessControlList.
+func (v *AccessControlListCustomValidator) ValidateCreate(_ context.Context, obj *v1alpha1.AccessControlList) (admission.Warnings, error) {
+	acllog.Info("Validation for AccessControlList upon creation", "name", obj.GetName())
+	return nil, validateACLEntries(obj)
+}
+
+// ValidateUpdate implements [admission.Validator] so a webhook will be registered for the type AccessControlList.
+func (v *AccessControlListCustomValidator) ValidateUpdate(_ context.Context, _, obj *v1alpha1.AccessControlList) (admission.Warnings, error) {
+	acllog.Info("Validation for AccessControlList upon update", "name", obj.GetName())
+	return nil, validateACLEntries(obj)
+}
+
+// ValidateDelete implements [admission.Validator] so a webhook will be registered for the type AccessControlList.
+func (v *AccessControlListCustomValidator) ValidateDelete(_ context.Context, _ *v1alpha1.AccessControlList) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateACLEntries ensures all entries use a consistent IP address family
+// and that each entry's source and destination addresses use the same family.
+func validateACLEntries(acl *v1alpha1.AccessControlList) error {
+	if len(acl.Spec.Entries) == 0 {
+		return nil
+	}
+	// Determine the ACL-wide address family from the first entry's source.
+	is6 := acl.Spec.Entries[0].SourceAddress.Addr().Is6()
+	for i, entry := range acl.Spec.Entries {
+		srcIs6 := entry.SourceAddress.Addr().Is6()
+		dstIs6 := entry.DestinationAddress.Addr().Is6()
+		// Reject mixed families within an entry.
+		if srcIs6 != dstIs6 {
+			return fmt.Errorf("entries[%d]: sourceAddress and destinationAddress must use the same IP address family", i)
+		}
+		// Reject mixed families across entries.
+		if srcIs6 != is6 {
+			return fmt.Errorf("entries[%d]: all entries must use the same IP address family", i)
+		}
+	}
+	return nil
+}

--- a/internal/webhook/core/v1alpha1/acl_webhook_test.go
+++ b/internal/webhook/core/v1alpha1/acl_webhook_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ironcore-dev/network-operator/api/core/v1alpha1"
+)
+
+var _ = Describe("AccessControlList Webhook", func() {
+	var (
+		obj       *v1alpha1.AccessControlList
+		oldObj    *v1alpha1.AccessControlList
+		validator AccessControlListCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &v1alpha1.AccessControlList{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-acl",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.AccessControlListSpec{
+				DeviceRef: v1alpha1.LocalObjectReference{Name: "test-device"},
+				Name:      "test-acl",
+				Entries: []v1alpha1.ACLEntry{
+					{
+						Sequence:           1,
+						Action:             v1alpha1.ActionPermit,
+						Protocol:           v1alpha1.ProtocolIP,
+						SourceAddress:      v1alpha1.MustParsePrefix("10.0.0.0/8"),
+						DestinationAddress: v1alpha1.MustParsePrefix("192.168.0.0/16"),
+					},
+				},
+			},
+		}
+		oldObj = obj.DeepCopy()
+		validator = AccessControlListCustomValidator{}
+	})
+
+	Context("When creating AccessControlList under Validating Webhook", func() {
+		It("Should admit a valid IPv4-only ACL", func() {
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should admit a valid IPv6-only ACL", func() {
+			obj.Spec.Entries = []v1alpha1.ACLEntry{
+				{
+					Sequence:           1,
+					Action:             v1alpha1.ActionDeny,
+					Protocol:           v1alpha1.ProtocolTCP,
+					SourceAddress:      v1alpha1.MustParsePrefix("2001:db8::/32"),
+					DestinationAddress: v1alpha1.MustParsePrefix("fd00::/8"),
+				},
+				{
+					Sequence:           2,
+					Action:             v1alpha1.ActionPermit,
+					Protocol:           v1alpha1.ProtocolIP,
+					SourceAddress:      v1alpha1.MustParsePrefix("::/0"),
+					DestinationAddress: v1alpha1.MustParsePrefix("::/0"),
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should deny an entry with mixed source (IPv4) and destination (IPv6)", func() {
+			obj.Spec.Entries[0].SourceAddress = v1alpha1.MustParsePrefix("10.0.0.0/8")
+			obj.Spec.Entries[0].DestinationAddress = v1alpha1.MustParsePrefix("2001:db8::/32")
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("entries[0]"))
+			Expect(err.Error()).To(ContainSubstring("same IP address family"))
+		})
+
+		It("Should deny an entry with mixed source (IPv6) and destination (IPv4)", func() {
+			obj.Spec.Entries[0].SourceAddress = v1alpha1.MustParsePrefix("2001:db8::/32")
+			obj.Spec.Entries[0].DestinationAddress = v1alpha1.MustParsePrefix("10.0.0.0/8")
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("entries[0]"))
+			Expect(err.Error()).To(ContainSubstring("same IP address family"))
+		})
+
+		It("Should deny entries mixing IPv4 and IPv6 across entries", func() {
+			obj.Spec.Entries = []v1alpha1.ACLEntry{
+				{
+					Sequence:           1,
+					Action:             v1alpha1.ActionPermit,
+					Protocol:           v1alpha1.ProtocolIP,
+					SourceAddress:      v1alpha1.MustParsePrefix("10.0.0.0/8"),
+					DestinationAddress: v1alpha1.MustParsePrefix("0.0.0.0/0"),
+				},
+				{
+					Sequence:           2,
+					Action:             v1alpha1.ActionDeny,
+					Protocol:           v1alpha1.ProtocolIP,
+					SourceAddress:      v1alpha1.MustParsePrefix("2001:db8::/32"),
+					DestinationAddress: v1alpha1.MustParsePrefix("::/0"),
+				},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("entries[1]"))
+			Expect(err.Error()).To(ContainSubstring("same IP address family"))
+		})
+	})
+
+	Context("When updating AccessControlList under Validating Webhook", func() {
+		It("Should admit update with consistent IP families", func() {
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should deny update introducing mixed families", func() {
+			obj.Spec.Entries[0].DestinationAddress = v1alpha1.MustParsePrefix("2001:db8::/32")
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When deleting AccessControlList under Validating Webhook", func() {
+		It("Should admit deletion", func() {
+			_, err := validator.ValidateDelete(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/core/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/core/v1alpha1/webhook_suite_test.go
@@ -110,6 +110,9 @@ var _ = BeforeSuite(func() {
 	err = SetupRoutingPolicyWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = SetupAccessControlListWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:webhook
 
 	go func() {


### PR DESCRIPTION
Add a validating webhook that rejects AccessControlList resources where entries mix IPv4 and IPv6 prefixes. The validation ensures:

- source and destination in each entry use the same IP family
- all entries across the ACL use the same IP family

Closes #506