### PR TITLE
fix add delay to gnoi reboot request

### DIFF
--- a/internal/provider/cisco/nxos/system.go
+++ b/internal/provider/cisco/nxos/system.go
@@ -103,8 +103,8 @@ func (t *UnixTime) UnmarshalJSON(b []byte) error {
 func Reboot(ctx context.Context, conn *grpc.ClientConn) error {
 	req := &systempb.RebootRequest{
 		Method:  systempb.RebootMethod_COLD,
-		Delay:   0,  // Unsupported on NX-OS, must be 0
-		Message: "", // Unsupported on NX-OS, must be empty
+		Delay:   5000000000, // 5 seconds in nanoseconds
+		Message: "",         // Unsupported on NX-OS, must be empty
 		Force:   true,
 	}
 	c := systempb.NewSystemClient(conn)


### PR DESCRIPTION
NX-OS does support the delay: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/106x/programmability/cisco-nexus-9000-series-nx-os-programmability-guide-106x/gnoi---operation-interface.html#:~:text=Delay%20option%20is%20supported%20for%20switch%20reload

Previously the rebootRequest was issued and then the client timed out waiting for a response. With the delay the reboot is issued and the request returns successfully.

fixes #494 