### PR TITLE
Move NX-API address parsing into NewClient

### DIFF
--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -101,10 +101,7 @@ func (p *Provider) Connect(ctx context.Context, conn *deviceutil.Connection) (er
 	if err != nil {
 		return fmt.Errorf("failed to create gnmi client: %w", err)
 	}
-	// NXAPI only uses the address for URI construction.
-	c := *conn
-	c.Address = netip.MustParseAddrPort(conn.Address).Addr().String()
-	p.nxapi, err = nxapi.NewClient(&c, nxapi.WithTimeout(timeout))
+	p.nxapi, err = nxapi.NewClient(conn, nxapi.WithTimeout(timeout))
 	if err != nil {
 		return fmt.Errorf("failed to create nxapi client: %w", err)
 	}

--- a/internal/transport/nxapi/nxapi.go
+++ b/internal/transport/nxapi/nxapi.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"time"
 
@@ -93,8 +94,9 @@ func NewClient(conn *deviceutil.Connection, opts ...Option) (*Client, error) {
 		},
 		url: url.URL{
 			Scheme: proto,
-			Host:   conn.Address,
-			Path:   "/ins",
+			// NXAPI only uses the address for URI construction.
+			Host: netip.MustParseAddrPort(conn.Address).Addr().String(),
+			Path: "/ins",
 		},
 	}
 	for _, opt := range opts {

--- a/internal/transport/nxapi/nxapi_test.go
+++ b/internal/transport/nxapi/nxapi_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/ironcore-dev/network-operator/internal/deviceutil"
@@ -22,16 +23,19 @@ func TestUri(t *testing.T) {
 	tests := []struct {
 		desc      string
 		conn      *deviceutil.Connection
+		wantAddr  string
 		wantProto string
 	}{
 		{
 			desc:      "no TLS uses http",
 			conn:      &deviceutil.Connection{Address: "10.0.0.1:80"},
+			wantAddr:  "10.0.0.1",
 			wantProto: "http",
 		},
 		{
 			desc:      "with TLS uses https",
 			conn:      &deviceutil.Connection{Address: "10.0.0.1:443", TLS: &tls.Config{MinVersion: tls.VersionTLS12}},
+			wantAddr:  "10.0.0.1",
 			wantProto: "https",
 		},
 	}
@@ -44,8 +48,8 @@ func TestUri(t *testing.T) {
 			if c.url.Scheme != test.wantProto {
 				t.Errorf("scheme = %q, want %q", c.url.Scheme, test.wantProto)
 			}
-			if c.url.Host != test.conn.Address {
-				t.Errorf("host = %q, want %q", c.url.Host, test.conn.Address)
+			if c.url.Host != test.wantAddr {
+				t.Errorf("host = %q, want %q", c.url.Host, test.wantAddr)
 			}
 			if c.url.Path != "/ins" {
 				t.Errorf("path = %q, want %q", c.url.Path, "/ins")
@@ -286,7 +290,7 @@ func TestDo(t *testing.T) {
 				Username: "admin",
 				Password: "secret",
 			}
-			c, err := NewClient(conn)
+			c, err := NewClient(conn, WithPort(strings.Split(conn.Address, ":")[1]))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
this is to ensure callers of NewClient do not need to
prepare the host address

for the firmware upgrade a client with longer client timeout is needed

Signed-off-by: Ivo Gosemann <ivo.gosemann@sap.com>
