### PR TITLE
Validate reserved VLANs on Cisco NX-OS

### DIFF
--- a/api/cisco/nx/v1alpha1/nveconfig_types.go
+++ b/api/cisco/nx/v1alpha1/nveconfig_types.go
@@ -27,6 +27,8 @@ type NetworkVirtualizationEdgeConfigSpec struct {
 	HoldDownTime int16 `json:"holdDownTime,omitempty"`
 
 	// InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.
+	// Valid VLAN IDs are 1-4092 because NX-OS always reserves VLANs 4093-4095 for internal use.
+	// The provider also checks these VLANs against the device's configurable internal reserved VLAN range.
 	// The total number of VLANs configured must not exceed 512.
 	// Elements in the list must not overlap with each other.
 	// +optional
@@ -42,15 +44,15 @@ type NetworkVirtualizationEdgeConfigSpec struct {
 type VLANListItem struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3967
+	// +kubebuilder:validation:Maximum=4092
 	ID int16 `json:"id,omitempty"`
 	// +optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3967
+	// +kubebuilder:validation:Maximum=4092
 	RangeMin int16 `json:"rangeMin,omitempty"`
 	// +optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3967
+	// +kubebuilder:validation:Maximum=4092
 	RangeMax int16 `json:"rangeMax,omitempty"`
 }
 

--- a/api/core/v1alpha1/vlan_types.go
+++ b/api/core/v1alpha1/vlan_types.go
@@ -24,11 +24,11 @@ type VLANSpec struct {
 	// +optional
 	ProviderConfigRef *TypedLocalObjectReference `json:"providerConfigRef,omitempty"`
 
-	// ID is the VLAN ID. Valid values are between 1 and 4094.
+	// ID is the VLAN ID. Valid values are between 1 and 4095.
 	// Immutable.
 	// +required
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=4094
+	// +kubebuilder:validation:Maximum=4095
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Name is immutable"
 	ID int16 `json:"id"`
 

--- a/charts/network-operator/templates/crd/networkvirtualizationedgeconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/networkvirtualizationedgeconfigs.nx.cisco.networking.metal.ironcore.dev.yaml
@@ -60,6 +60,8 @@ spec:
               infraVLANs:
                 description: |-
                   InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.
+                  Valid VLAN IDs are 1-4092 because NX-OS always reserves VLANs 4093-4095 for internal use.
+                  The provider also checks these VLANs against the device's configurable internal reserved VLAN range.
                   The total number of VLANs configured must not exceed 512.
                   Elements in the list must not overlap with each other.
                 items:
@@ -68,15 +70,15 @@ spec:
                     and rangeMax must be set.
                   properties:
                     id:
-                      maximum: 3967
+                      maximum: 4092
                       minimum: 1
                       type: integer
                     rangeMax:
-                      maximum: 3967
+                      maximum: 4092
                       minimum: 1
                       type: integer
                     rangeMin:
-                      maximum: 3967
+                      maximum: 4092
                       minimum: 1
                       type: integer
                   type: object

--- a/charts/network-operator/templates/crd/vlans.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/vlans.networking.metal.ironcore.dev.yaml
@@ -105,9 +105,9 @@ spec:
                   rule: self == oldSelf
               id:
                 description: |-
-                  ID is the VLAN ID. Valid values are between 1 and 4094.
+                  ID is the VLAN ID. Valid values are between 1 and 4095.
                   Immutable.
-                maximum: 4094
+                maximum: 4095
                 minimum: 1
                 type: integer
                 x-kubernetes-validations:

--- a/config/crd/bases/networking.metal.ironcore.dev_vlans.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_vlans.yaml
@@ -102,9 +102,9 @@ spec:
                   rule: self == oldSelf
               id:
                 description: |-
-                  ID is the VLAN ID. Valid values are between 1 and 4094.
+                  ID is the VLAN ID. Valid values are between 1 and 4095.
                   Immutable.
-                maximum: 4094
+                maximum: 4095
                 minimum: 1
                 type: integer
                 x-kubernetes-validations:

--- a/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_networkvirtualizationedgeconfigs.yaml
+++ b/config/crd/bases/nx.cisco.networking.metal.ironcore.dev_networkvirtualizationedgeconfigs.yaml
@@ -57,6 +57,8 @@ spec:
               infraVLANs:
                 description: |-
                   InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.
+                  Valid VLAN IDs are 1-4092 because NX-OS always reserves VLANs 4093-4095 for internal use.
+                  The provider also checks these VLANs against the device's configurable internal reserved VLAN range.
                   The total number of VLANs configured must not exceed 512.
                   Elements in the list must not overlap with each other.
                 items:
@@ -65,15 +67,15 @@ spec:
                     and rangeMax must be set.
                   properties:
                     id:
-                      maximum: 3967
+                      maximum: 4092
                       minimum: 1
                       type: integer
                     rangeMax:
-                      maximum: 3967
+                      maximum: 4092
                       minimum: 1
                       type: integer
                     rangeMin:
-                      maximum: 3967
+                      maximum: 4092
                       minimum: 1
                       type: integer
                   type: object

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -4226,7 +4226,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `deviceRef` _[LocalObjectReference](#localobjectreference)_ | DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.<br />Immutable. |  | Required: \{\} <br /> |
 | `providerConfigRef` _[TypedLocalObjectReference](#typedlocalobjectreference)_ | ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this vlan.<br />This reference is used to link the VLAN to its provider-specific configuration. |  | Optional: \{\} <br /> |
-| `id` _integer_ | ID is the VLAN ID. Valid values are between 1 and 4094.<br />Immutable. |  | Maximum: 4094 <br />Minimum: 1 <br />Required: \{\} <br /> |
+| `id` _integer_ | ID is the VLAN ID. Valid values are between 1 and 4095.<br />Immutable. |  | Maximum: 4095 <br />Minimum: 1 <br />Required: \{\} <br /> |
 | `name` _string_ | Name is the name of the VLAN. |  | MaxLength: 128 <br />MinLength: 1 <br />Pattern: `^[^\s]+$` <br />Optional: \{\} <br /> |
 | `adminState` _[AdminState](#adminstate)_ | AdminState indicates whether the VLAN is administratively active or inactive/suspended. | Up | Enum: [Up Down] <br />Optional: \{\} <br /> |
 
@@ -4835,7 +4835,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `advertiseVirtualMAC` _boolean_ | AdvertiseVirtualMAC controls if the NVE should advertise a virtual MAC address | false | Optional: \{\} <br /> |
 | `holdDownTime` _integer_ | HoldDownTime defines the duration for which the switch suppresses the advertisement of the NVE loopback address. | 180 | Maximum: 1500 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `infraVLANs` _[VLANListItem](#vlanlistitem) array_ | InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.<br />The total number of VLANs configured must not exceed 512.<br />Elements in the list must not overlap with each other. |  | MaxItems: 10 <br />Optional: \{\} <br /> |
+| `infraVLANs` _[VLANListItem](#vlanlistitem) array_ | InfraVLANs specifies VLANs used by all SVI interfaces for uplink and vPC peer-links in VXLAN as infra-VLANs.<br />Valid VLAN IDs are 1-4092 because NX-OS always reserves VLANs 4093-4095 for internal use.<br />The provider also checks these VLANs against the device's configurable internal reserved VLAN range.<br />The total number of VLANs configured must not exceed 512.<br />Elements in the list must not overlap with each other. |  | MaxItems: 10 <br />Optional: \{\} <br /> |
 
 
 #### Peer
@@ -5075,9 +5075,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `id` _integer_ |  |  | Maximum: 3967 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `rangeMin` _integer_ |  |  | Maximum: 3967 <br />Minimum: 1 <br />Optional: \{\} <br /> |
-| `rangeMax` _integer_ |  |  | Maximum: 3967 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `id` _integer_ |  |  | Maximum: 4092 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `rangeMin` _integer_ |  |  | Maximum: 4092 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `rangeMax` _integer_ |  |  | Maximum: 4092 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### VPCDomain

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -2857,7 +2857,34 @@ func (p *Provider) DeleteSyslog(ctx context.Context) error {
 	)
 }
 
+// ValidateReservedVLANs rejects VLANs reserved for internal use by NX-OS.
+func (p *Provider) ValidateReservedVLANs(ctx context.Context, vlans []int16) error {
+	reservation := new(VLANReservation)
+	if err := p.client.GetConfig(ctx, reservation); err != nil {
+		if !errors.Is(err, gnmiext.ErrNil) {
+			return err
+		}
+		reservation.Default()
+	}
+
+	start := int16(*reservation)
+	// NX-OS reserves a block of 128 VLANs, including the starting VLAN.
+	end := start + 127
+	for _, vlan := range vlans {
+		// VLANs 4093-4095 are always reserved for internal use.
+		// https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/106x/configuration/layer-2-switching/cisco-nexus-9000-series-nx-os-layer-2-switching-configuration-guide-106x/m-configuring-vlans.html#Cisco_Concept.dita_959060E7B6704F6B82CB6552F74458CA
+		if vlan >= start && vlan <= end || vlan >= 4093 {
+			return apistatus.NewFailedPreconditionError(fmt.Sprintf("VLAN %d is reserved for internal device use", vlan))
+		}
+	}
+	return nil
+}
+
 func (p *Provider) EnsureVLAN(ctx context.Context, req *provider.VLANRequest) error {
+	if err := p.ValidateReservedVLANs(ctx, []int16{req.VLAN.Spec.ID}); err != nil {
+		return err
+	}
+
 	v := new(VLAN)
 	v.FabEncap = fmt.Sprintf("vlan-%d", req.VLAN.Spec.ID)
 	v.AdminSt = BdStateActive
@@ -3432,6 +3459,16 @@ func (p *Provider) EnsureNVE(ctx context.Context, req *provider.NVERequest) erro
 		}
 		for i := ivList.RangeMin; i <= ivList.RangeMax; i++ {
 			iv.InfraVLANList = append(iv.InfraVLANList, &NVEInfraVLAN{ID: uint32(i)}) // #nosec G115 -- kubebuilder validation
+		}
+	}
+
+	infraVLANs := make([]int16, len(iv.InfraVLANList))
+	for i := range iv.InfraVLANList {
+		infraVLANs[i] = int16(iv.InfraVLANList[i].ID) // #nosec G115 -- kubebuilder validation
+	}
+	if len(infraVLANs) > 0 {
+		if err := p.ValidateReservedVLANs(ctx, infraVLANs); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Read the configured VLAN reservation before realizing VLAN and NVE resources. Return a failed precondition when requested IDs overlap the configurable 128-VLAN block or the permanently reserved 4093-4095 range.