### PR TITLE
reduce Eventually Polling interval to 200ms

### DIFF
--- a/internal/controller/cisco/nx/suite_test.go
+++ b/internal/controller/cisco/nx/suite_test.go
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	SetDefaultEventuallyTimeout(time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
 
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -64,8 +64,8 @@ func TestControllers(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	SetDefaultEventuallyTimeout(time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyTimeout(90 * time.Second)
+	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
 
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 

--- a/internal/controller/evpn/suite_test.go
+++ b/internal/controller/evpn/suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	SetDefaultEventuallyTimeout(time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
 
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 

--- a/internal/controller/pool/suite_test.go
+++ b/internal/controller/pool/suite_test.go
@@ -48,7 +48,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	SetDefaultEventuallyTimeout(time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyPollingInterval(200 * time.Millisecond)
 
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 


### PR DESCRIPTION
increase core suite EventuallyTimeout due to flakiness of
controller locks

Signed-off-by: Ivo Gosemann <ivo.gosemann@sap.com>
