### PR TITLE
Enforce stricter checks in gnmi integration tests

### DIFF
--- a/test/gnmi/gnmi_test.go
+++ b/test/gnmi/gnmi_test.go
@@ -128,7 +128,7 @@ var _ = Describe("gNMI requests tests", func() {
 					if len(stateJSON) == 0 {
 						stateJSON = []byte("{}")
 					}
-					g.Expect(stateJSON).To(ContainUnorderedJSON(statePost), "gNMI state does not match expected JSON")
+					g.Expect(stateJSON).To(MatchUnorderedJSON(statePost), "gNMI state does not match expected JSON")
 				}).Should(Succeed())
 
 				By("deleting all intermeadiate test resources created in test")
@@ -140,7 +140,7 @@ var _ = Describe("gNMI requests tests", func() {
 					if len(stateJSON) == 0 {
 						stateJSON = []byte("{}")
 					}
-					g.Expect(stateJSON).To(ContainUnorderedJSON(stateDelete), "gNMI state does not match expected JSON")
+					g.Expect(stateJSON).To(MatchUnorderedJSON(stateDelete), "gNMI state does not match expected JSON")
 				}).Should(Succeed())
 
 				By("deleting the test device")

--- a/test/gnmi/testdata/cisco-nxos-gnmi/aaa.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/aaa.txtar
@@ -68,8 +68,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "fm-items": {
       "tacacsplus-items": {
         "adminSt": "enabled"
@@ -113,6 +117,13 @@ spec:
           "local": "yes",
           "errEn": true
         },
+        "consoleauth-items": {
+          "realm": "local",
+          "providerGroup": "",
+          "fallback": "yes",
+          "local": "yes",
+          "errEn": false
+        },
         "defaultauthor-items": {
           "DefaultAuthor-list": [
             {
@@ -128,31 +139,65 @@ spec:
           "localRbac": true
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "fm-items": {
+      "tacacsplus-items": {
+        "adminSt": "disabled"
+      }
+    },
     "userext-items": {
+      "tacacsext-items": {},
       "authrealm-items": {
-        "defaultauth-items": {
+        "consoleauth-items": {
           "realm": "local",
+          "providerGroup": "",
+          "fallback": "yes",
           "local": "yes",
-          "fallback": "yes"
+          "errEn": false
+        },
+        "defaultauthor-items": {
+          "DefaultAuthor-list": [
+            {
+              "cmdType": "config",
+              "providerGroup": "",
+              "localRbac": true
+            }
+          ]
         },
         "defaultacc-items": {
           "realm": "local",
+          "providerGroup": "",
           "localRbac": true
+        },
+        "defaultauth-items": {
+          "realm": "local",
+          "providerGroup": "",
+          "fallback": "yes",
+          "local": "yes",
+          "errEn": false
+        }
+      },
+      "radiusext-items": {
+        "radiusprovidergroup-items": {
+          "RadiusProviderGroup-list": [
+            {
+              "name": "radius",
+              "vrf": "default",
+              "srcIf": "DME_UNSET_PROPERTY_MARKER"
+            }
+          ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/acl.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/acl.txtar
@@ -32,8 +32,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "acl-items": {
       "ipv4-items": {
         "name-items": {
@@ -43,19 +47,19 @@ spec:
               "seq-items": {
                 "ACE-list": [
                   {
-                    "action": "deny",
-                    "dstPrefix": "0.0.0.0",
+                    "seqNum": 10,
+                    "action": "permit",
                     "protocol": 0,
-                    "seqNum": 20,
-                    "srcPrefix": "0.0.0.0"
+                    "srcPrefix": "10.0.0.0",
+                    "srcPrefixLength": 8,
+                    "dstPrefix": "0.0.0.0"
                   },
                   {
-                    "action": "permit",
-                    "dstPrefix": "0.0.0.0",
+                    "seqNum": 20,
+                    "action": "deny",
                     "protocol": 0,
-                    "seqNum": 10,
-                    "srcPrefix": "10.0.0.0",
-                    "srcPrefixLength": 8
+                    "srcPrefix": "0.0.0.0",
+                    "dstPrefix": "0.0.0.0"
                   }
                 ]
               }
@@ -63,18 +67,46 @@ spec:
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "acl-items": {
+      "ipv4-items": {
+        "name-items": {
+          "ACL-list": [
+            {
+              "name": "BLOCK-EXTERNAL",
+              "seq-items": {
+                "ACE-list": [
+                  {
+                    "seqNum": 20,
+                    "action": "deny",
+                    "protocol": 0,
+                    "srcPrefix": "0.0.0.0",
+                    "dstPrefix": "0.0.0.0"
+                  },
+                  {
+                    "seqNum": 10,
+                    "action": "permit",
+                    "protocol": 0,
+                    "srcPrefix": "10.0.0.0",
+                    "srcPrefixLength": 8,
+                    "dstPrefix": "0.0.0.0"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/banner.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/banner.txtar
@@ -21,31 +21,33 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "userext-items": {
       "preloginbanner-items": {
         "delimiter": "^",
         "message": "Authorized users only. All activity is monitored."
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "userext-items": {
       "preloginbanner-items": {
         "delimiter": "#",
         "message": "User Access Verification\n"
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/bgp_peer.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/bgp_peer.txtar
@@ -79,8 +79,81 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": [
+          {
+            "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "id": "lo0",
+            "rtvrfMbr-items": {
+              "tDn": "/System/inst-items/Inst-list[name='default']"
+            }
+          }
+        ]
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo0",
+                    "addr-items": {
+                      "Addr-list": [
+                        {
+                          "addr": "10.0.0.1/32",
+                          "pref": 0,
+                          "tag": 0,
+                          "type": "primary"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo0",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "bgp-items": {
+        "adminSt": "enabled"
+      },
+      "evpn-items": {
+        "adminSt": "enabled"
+      }
+    },
     "bgp-items": {
       "inst-items": {
         "adminSt": "enabled",
@@ -94,13 +167,13 @@ spec:
               "af-items": {
                 "DomAf-list": [
                   {
-                    "advPip": "enabled",
-                    "exportGwIp": "disabled",
                     "maxEcmp": 1,
                     "maxExtEcmp": 1,
+                    "exportGwIp": "disabled",
+                    "type": "l2vpn-evpn",
+                    "advPip": "enabled",
                     "retainRttAll": "enabled",
-                    "retainRttRtMap": "DME_UNSET_PROPERTY_MARKER",
-                    "type": "l2vpn-evpn"
+                    "retainRttRtMap": "DME_UNSET_PROPERTY_MARKER"
                   }
                 ]
               },
@@ -130,13 +203,34 @@ spec:
           ]
         }
       }
+    }
+  }
+}
+
+-- state/delete --
+
+{
+  "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
-    "fm-items": {
-      "bgp-items": {
-        "adminSt": "enabled"
-      },
-      "evpn-items": {
-        "adminSt": "enabled"
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
       }
     },
     "icmpv4-items": {
@@ -148,8 +242,8 @@ spec:
               "if-items": {
                 "If-list": [
                   {
-                    "ctrl": "port-unreachable,redirect",
-                    "id": "lo0"
+                    "id": "lo0",
+                    "ctrl": "port-unreachable,redirect"
                   }
                 ]
               }
@@ -158,57 +252,6 @@ spec:
         }
       }
     },
-    "intf-items": {
-      "lb-items": {
-        "LbRtdIf-list": [
-          {
-            "adminSt": "up",
-            "id": "lo0",
-            "descr": "DME_UNSET_PROPERTY_MARKER",
-            "rtvrfMbr-items": {
-              "tDn": "/System/inst-items/Inst-list[name='default']"
-            }
-          }
-        ]
-      }
-    },
-    "ipv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "addr-items": {
-                      "Addr-list": [
-                        {
-                          "addr": "10.0.0.1/32",
-                          "pref": 0,
-                          "tag": 0,
-                          "type": "primary"
-                        }
-                      ]
-                    },
-                    "id": "lo0"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
-    }
-  }
-}
-
--- state/delete --
-{
-  "System": {
     "fm-items": {
       "bgp-items": {
         "adminSt": "enabled"
@@ -217,8 +260,6 @@ spec:
         "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
-    }
+    "bgp-items": {}
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/dhcprelay.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/dhcprelay.txtar
@@ -166,13 +166,62 @@ spec:
 -- state/delete --
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "bd-items": {
+      "bd-items": {
+        "BD-list": []
+      }
+    },
     "fm-items": {
       "ifvlan-items": {
         "adminSt": "enabled"
+      },
+      "dhcp-items": {
+        "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "intf-items": {
+      "svi-items": {
+        "If-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "vlan100",
+                    "ctrl": "port-unreachable"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "dhcp-items": {
+      "inst-items": {}
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/dns.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/dns.txtar
@@ -23,17 +23,18 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "dns-items": {
       "adminSt": "enabled",
       "prof-items": {
         "Prof-list": [
           {
             "name": "default",
-            "dom-items": {
-              "name": "example.com"
-            },
             "vrf-items": {
               "Vrf-list": [
                 {
@@ -47,18 +48,19 @@ spec:
                   }
                 }
               ]
+            },
+            "dom-items": {
+              "name": "example.com"
             }
           }
         ]
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {

--- a/test/gnmi/testdata/cisco-nxos-gnmi/evpninstance.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/evpninstance.txtar
@@ -45,18 +45,11 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "bd-items": {
-      "bd-items": {
-        "BD-list": [
-          {
-            "fabEncap": "vlan-100",
-            "accEncap": "vxlan-10100",
-            "name": "EVPN-VLAN-100"
-          }
-        ]
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "fm-items": {
       "evpn-items": {
@@ -69,15 +62,83 @@ spec:
         "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "bd-items": {
+      "bd-items": {
+        "BD-list": [
+          {
+            "adminSt": "active",
+            "BdState": "active",
+            "fabEncap": "vlan-100",
+            "name": "EVPN-VLAN-100",
+            "accEncap": "vxlan-10100"
+          }
+        ]
+      }
+    },
+    "eps-items": {
+      "epId-items": {
+        "Ep-list": [
+          {
+            "epId": 1,
+            "nws-items": {
+              "vni-items": {
+                "Nw-list": [
+                  {
+                    "associateVrfFlag": false,
+                    "mcastGroup": "DME_UNSET_PROPERTY_MARKER",
+                    "vni": 10100
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "evpn-items": {
+      "bdevi-items": {
+        "BDEvi-list": [
+          {
+            "encap": "vxlan-10100",
+            "rd": "DME_UNSET_PROPERTY_MARKER",
+            "rttp-items": {
+              "RttP-list": [
+                {
+                  "type": "import",
+                  "ent-items": {
+                    "RttEntry-list": [
+                      {
+                        "rtt": "route-target:unknown:0:0"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "export",
+                  "ent-items": {
+                    "RttEntry-list": [
+                      {
+                        "rtt": "route-target:unknown:0:0"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "fm-items": {
       "evpn-items": {
         "adminSt": "enabled"
@@ -89,8 +150,29 @@ spec:
         "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "bd-items": {
+      "bd-items": {
+        "BD-list": []
+      }
+    },
+    "eps-items": {
+      "epId-items": {
+        "Ep-list": [
+          {
+            "epId": 1,
+            "nws-items": {
+              "vni-items": {
+                "Nw-list": []
+              }
+            }
+          }
+        ]
+      }
+    },
+    "evpn-items": {
+      "bdevi-items": {
+        "BDEvi-list": []
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_aggregate_l2_trunk.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_aggregate_l2_trunk.txtar
@@ -47,44 +47,13 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
-      "aggr-items": {
-        "AggrIf-list": [
-          {
-            "accessVlan": "vlan-1",
-            "adminSt": "up",
-            "aggrExtd-items": {
-              "bufferBoost": "enable"
-            },
-            "descr": "vPC Leaf1 to Host1",
-            "id": "po10",
-            "lacpVpcConvergence": "disable",
-            "layer": "Layer2",
-            "medium": "broadcast",
-            "mode": "trunk",
-            "mtu": 1500,
-            "nativeVlan": "vlan-1",
-            "pcMode": "active",
-            "rsmbrIfs-items": {
-              "RsMbrIfs-list": [
-                {
-                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/10']"
-                }
-              ]
-            },
-            "suspIndividual": "enable",
-            "trunkVlans": "10",
-            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
-          }
-        ]
-      },
       "phys-items": {
         "PhysIf-list": [
           {
@@ -94,14 +63,44 @@ spec:
             "FECMode": "auto",
             "id": "eth1/10",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
             "physExtd-items": {
               "bufferBoost": "enable"
+            }
+          }
+        ]
+      },
+      "aggr-items": {
+        "AggrIf-list": [
+          {
+            "accessVlan": "vlan-1",
+            "adminSt": "up",
+            "descr": "vPC Leaf1 to Host1",
+            "id": "po10",
+            "lacpVpcConvergence": "disable",
+            "layer": "Layer2",
+            "mtu": 1500,
+            "medium": "broadcast",
+            "mode": "trunk",
+            "pcMode": "active",
+            "nativeVlan": "vlan-1",
+            "suspIndividual": "enable",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
+            "rsmbrIfs-items": {
+              "RsMbrIfs-list": [
+                {
+                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/10']"
+                }
+              ]
             },
-            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
+            "aggrExtd-items": {
+              "bufferBoost": "enable"
+            },
+            "trunkVlans": "10"
           }
         ]
       }
@@ -111,55 +110,85 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/10",
               "mode": "default",
               "bpdufilter": "default",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "eth1/10"
             },
             {
-              "id": "po10",
               "mode": "default",
               "bpdufilter": "default",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "po10"
             }
           ]
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
+      }
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/10",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "userCfgdFlags": "",
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            },
+            "trunkVlans": "1-4094"
           }
         ]
+      },
+      "aggr-items": {
+        "AggrIf-list": []
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "stp-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": [
+            {
+              "mode": "default",
+              "bpdufilter": "default",
+              "bpduguard": "default",
+              "id": "po10"
+            },
+            {
+              "mode": "default",
+              "bpdufilter": "default",
+              "bpduguard": "default",
+              "id": "eth1/10"
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_aggregate_l3.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_aggregate_l3.txtar
@@ -45,46 +45,13 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
-      "aggr-items": {
-        "AggrIf-list": [
-          {
-            "accessVlan": "unknown",
-            "adminSt": "up",
-            "aggrExtd-items": {
-              "bufferBoost": "enable"
-            },
-            "descr": "L3 Port-Channel to Spine1",
-            "id": "po20",
-            "lacpVpcConvergence": "disable",
-            "layer": "Layer3",
-            "medium": "broadcast",
-            "mode": "access",
-            "mtu": 9216,
-            "nativeVlan": "unknown",
-            "pcMode": "active",
-            "rsmbrIfs-items": {
-              "RsMbrIfs-list": [
-                {
-                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/3']"
-                }
-              ]
-            },
-            "rtvrfMbr-items": {
-              "tDn": "/System/inst-items/Inst-list[name='default']"
-            },
-            "suspIndividual": "enable",
-            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
-          }
-        ]
-      },
       "phys-items": {
         "PhysIf-list": [
           {
@@ -94,19 +61,70 @@ spec:
             "FECMode": "auto",
             "id": "eth1/3",
             "layer": "Layer3",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "unknown",
-            "physExtd-items": {
-              "bufferBoost": "enable"
-            },
+            "userCfgdFlags": "admin_layer,admin_state",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
             },
-            "userCfgdFlags": "admin_layer,admin_state"
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            }
           }
         ]
+      },
+      "aggr-items": {
+        "AggrIf-list": [
+          {
+            "accessVlan": "unknown",
+            "adminSt": "up",
+            "descr": "L3 Port-Channel to Spine1",
+            "id": "po20",
+            "lacpVpcConvergence": "disable",
+            "layer": "Layer3",
+            "mtu": 9216,
+            "medium": "broadcast",
+            "mode": "access",
+            "pcMode": "active",
+            "nativeVlan": "unknown",
+            "suspIndividual": "enable",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
+            "rtvrfMbr-items": {
+              "tDn": "/System/inst-items/Inst-list[name='default']"
+            },
+            "rsmbrIfs-items": {
+              "RsMbrIfs-list": [
+                {
+                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/3']"
+                }
+              ]
+            },
+            "aggrExtd-items": {
+              "bufferBoost": "enable"
+            }
+          }
+        ]
+      }
+    },
+    "stp-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": [
+            {
+              "mode": "default",
+              "bpdufilter": "default",
+              "bpduguard": "default",
+              "id": "eth1/3"
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
       }
     },
     "ipv4-items": {
@@ -118,6 +136,7 @@ spec:
               "if-items": {
                 "If-list": [
                   {
+                    "id": "po20",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -127,8 +146,7 @@ spec:
                           "type": "primary"
                         }
                       ]
-                    },
-                    "id": "po20"
+                    }
                   }
                 ]
               }
@@ -136,54 +154,40 @@ spec:
           ]
         }
       }
-    },
-    "stp-items": {
-      "inst-items": {
-        "if-items": {
-          "If-list": [
-            {
-              "id": "eth1/3",
-              "mode": "default",
-              "bpdufilter": "default",
-              "bpduguard": "default"
-            }
-          ]
-        }
-      }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
             "FECMode": "auto",
             "id": "eth1/3",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
+      },
+      "aggr-items": {
+        "AggrIf-list": []
       }
     },
     "stp-items": {
@@ -191,17 +195,33 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/3",
               "mode": "default",
               "bpdufilter": "default",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "eth1/3"
             }
           ]
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_aggregate_vpc_stp_lacp.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_aggregate_vpc_stp_lacp.txtar
@@ -91,44 +91,13 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
-      "aggr-items": {
-        "AggrIf-list": [
-          {
-            "accessVlan": "vlan-1",
-            "adminSt": "up",
-            "aggrExtd-items": {
-              "bufferBoost": "enable"
-            },
-            "descr": "vPC to Host with STP and LACP config",
-            "id": "po10",
-            "lacpVpcConvergence": "enable",
-            "layer": "Layer2",
-            "medium": "broadcast",
-            "mode": "trunk",
-            "mtu": 1500,
-            "nativeVlan": "vlan-1",
-            "pcMode": "active",
-            "rsmbrIfs-items": {
-              "RsMbrIfs-list": [
-                {
-                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/2']"
-                }
-              ]
-            },
-            "suspIndividual": "disable",
-            "trunkVlans": "10",
-            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
-          }
-        ]
-      },
       "phys-items": {
         "PhysIf-list": [
           {
@@ -138,15 +107,45 @@ spec:
             "FECMode": "auto",
             "id": "eth1/2",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "trunk",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
-            "trunkVlans": "10",
             "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
             "physExtd-items": {
               "bufferBoost": "disable"
-            }
+            },
+            "trunkVlans": "10"
+          }
+        ]
+      },
+      "aggr-items": {
+        "AggrIf-list": [
+          {
+            "accessVlan": "vlan-1",
+            "adminSt": "up",
+            "descr": "vPC to Host with STP and LACP config",
+            "id": "po10",
+            "lacpVpcConvergence": "enable",
+            "layer": "Layer2",
+            "mtu": 1500,
+            "medium": "broadcast",
+            "mode": "trunk",
+            "pcMode": "active",
+            "nativeVlan": "vlan-1",
+            "suspIndividual": "disable",
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
+            "rsmbrIfs-items": {
+              "RsMbrIfs-list": [
+                {
+                  "tDn": "/System/intf-items/phys-items/PhysIf-list[id='eth1/2']"
+                }
+              ]
+            },
+            "aggrExtd-items": {
+              "bufferBoost": "enable"
+            },
+            "trunkVlans": "10"
           }
         ]
       }
@@ -156,19 +155,24 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/2",
               "mode": "edge",
               "bpdufilter": "default",
-              "bpduguard": "enable"
+              "bpduguard": "enable",
+              "id": "eth1/2"
             },
             {
-              "id": "po10",
               "mode": "network",
               "bpdufilter": "enable",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "po10"
             }
           ]
         }
+      }
+    },
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
       }
     },
     "vpc-items": {
@@ -186,40 +190,40 @@ spec:
           }
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/2",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
+      },
+      "aggr-items": {
+        "AggrIf-list": []
       }
     },
     "stp-items": {
@@ -227,23 +231,34 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/2",
-              "mode": "default",
-              "bpdufilter": "default",
-              "bpduguard": "enable"
-            },
-            {
-              "id": "po10",
               "mode": "network",
               "bpdufilter": "enable",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "po10"
+            },
+            {
+              "mode": "default",
+              "bpdufilter": "default",
+              "bpduguard": "enable",
+              "id": "eth1/2"
             }
           ]
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "vpc-items": {
+      "inst-items": {
+        "dom-items": {
+          "if-items": {
+            "If-list": []
+          }
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_loopback.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_loopback.txtar
@@ -25,26 +25,11 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "ctrl": "port-unreachable,redirect",
-                    "id": "lo0"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "lb-items": {
@@ -69,6 +54,7 @@ spec:
               "if-items": {
                 "If-list": [
                   {
+                    "id": "lo0",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -78,8 +64,7 @@ spec:
                           "type": "primary"
                         }
                       ]
-                    },
-                    "id": "lo0"
+                    }
                   }
                 ]
               }
@@ -88,17 +73,72 @@ spec:
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo0",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo0",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_loopback_multi_addr.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_loopback_multi_addr.txtar
@@ -26,26 +26,11 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "ctrl": "port-unreachable,redirect",
-                    "id": "lo1"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "lb-items": {
@@ -70,6 +55,7 @@ spec:
               "if-items": {
                 "If-list": [
                   {
+                    "id": "lo1",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -85,8 +71,7 @@ spec:
                           "type": "secondary"
                         }
                       ]
-                    },
-                    "id": "lo1"
+                    }
                   }
                 ]
               }
@@ -95,17 +80,72 @@ spec:
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo1",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo1",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_ipv4.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_ipv4.txtar
@@ -26,29 +26,33 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "unknown",
             "adminSt": "up",
             "descr": "Leaf1 to Spine1",
+            "FECMode": "auto",
             "id": "eth1/1",
             "layer": "Layer3",
+            "mtu": 9216,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 9216,
             "nativeVlan": "unknown",
-            "physExtd-items": {
-              "bufferBoost": "enable"
-            },
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
             },
-            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            }
           }
         ]
       }
@@ -62,6 +66,7 @@ spec:
               "if-items": {
                 "If-list": [
                   {
+                    "id": "eth1/1",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -71,8 +76,7 @@ spec:
                           "type": "primary"
                         }
                       ]
-                    },
-                    "id": "eth1/1"
+                    }
                   }
                 ]
               }
@@ -80,39 +84,52 @@ spec:
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/1",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_switchport_access.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_switchport_access.txtar
@@ -25,8 +25,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
@@ -37,14 +41,14 @@ spec:
             "FECMode": "auto",
             "id": "eth1/3",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "admin_layer,admin_state",
             "physExtd-items": {
               "bufferBoost": "enable"
-            },
-            "userCfgdFlags": "admin_layer,admin_state"
+            }
           }
         ]
       }
@@ -54,41 +58,43 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/3",
               "mode": "default",
               "bpdufilter": "default",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "eth1/3"
             }
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
             "FECMode": "auto",
             "id": "eth1/3",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
       }
@@ -98,17 +104,14 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/3",
               "mode": "default",
               "bpdufilter": "default",
-              "bpduguard": "default"
+              "bpduguard": "default",
+              "id": "eth1/3"
             }
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_switchport_trunk.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_switchport_trunk.txtar
@@ -45,8 +45,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
@@ -57,15 +61,15 @@ spec:
             "FECMode": "auto",
             "id": "eth1/2",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "trunk",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
-            "trunkVlans": "10",
             "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
             "physExtd-items": {
               "bufferBoost": "disable"
-            }
+            },
+            "trunkVlans": "10"
           }
         ]
       }
@@ -75,41 +79,43 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/2",
               "mode": "edge",
               "bpdufilter": "default",
-              "bpduguard": "enable"
+              "bpduguard": "enable",
+              "id": "eth1/2"
             }
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/2",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
       }
@@ -119,17 +125,14 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/2",
               "mode": "default",
               "bpdufilter": "default",
-              "bpduguard": "enable"
+              "bpduguard": "enable",
+              "id": "eth1/2"
             }
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_unnumbered.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_physical_unnumbered.txtar
@@ -49,52 +49,11 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "bfd-items": {
-      "inst-items": {
-        "if-items": {
-          "If-list": [
-            {
-              "adminSt": "enabled",
-              "id": "eth1/1",
-              "ifka-items": {
-                "detectMult": 3,
-                "minRxIntvl": 300,
-                "minTxIntvl": 300
-              }
-            }
-          ]
-        }
-      }
-    },
-    "fm-items": {
-      "bfd-items": {
-        "adminSt": "enabled"
-      }
-    },
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "ctrl": "port-unreachable,redirect",
-                    "id": "lo0"
-                  },
-                  {
-                    "ctrl": "port-unreachable",
-                    "id": "eth1/1"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "lb-items": {
@@ -112,23 +71,23 @@ spec:
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "unknown",
             "adminSt": "up",
             "descr": "Leaf1 to Spine1",
+            "FECMode": "auto",
             "id": "eth1/1",
             "layer": "Layer3",
+            "mtu": 9216,
             "medium": "p2p",
             "mode": "access",
-            "mtu": 9216,
             "nativeVlan": "unknown",
-            "physExtd-items": {
-              "bufferBoost": "enable"
-            },
+            "userCfgdFlags": "admin_layer,admin_mtu,admin_state",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
             },
-            "userCfgdFlags": "admin_layer,admin_mtu,admin_state"
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            }
           }
         ]
       }
@@ -142,6 +101,7 @@ spec:
               "if-items": {
                 "If-list": [
                   {
+                    "id": "lo0",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -151,8 +111,7 @@ spec:
                           "type": "primary"
                         }
                       ]
-                    },
-                    "id": "lo0"
+                    }
                   },
                   {
                     "id": "eth1/1",
@@ -165,43 +124,130 @@ spec:
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
-    }
-  }
-}
-
--- state/delete --
-{
-  "System": {
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo0",
+                    "ctrl": "port-unreachable,redirect"
+                  },
+                  {
+                    "id": "eth1/1",
+                    "ctrl": "port-unreachable"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "fm-items": {
       "bfd-items": {
         "adminSt": "enabled"
       }
     },
+    "bfd-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": [
+            {
+              "id": "eth1/1",
+              "adminSt": "enabled",
+              "ifka-items": {
+                "detectMult": 3,
+                "minRxIntvl": 300,
+                "minTxIntvl": 300
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+-- state/delete --
+
+{
+  "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      },
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/1",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo0",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "bfd-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "bfd-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": []
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/interface_routed_vlan.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/interface_routed_vlan.txtar
@@ -40,8 +40,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "bd-items": {
       "bd-items": {
         "BD-list": [
@@ -57,25 +61,6 @@ spec:
     "fm-items": {
       "ifvlan-items": {
         "adminSt": "enabled"
-      }
-    },
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "ctrl": "port-unreachable",
-                    "id": "vlan10"
-                  }
-                ]
-              }
-            }
-          ]
-        }
       }
     },
     "intf-items": {
@@ -104,6 +89,7 @@ spec:
               "if-items": {
                 "If-list": [
                   {
+                    "id": "vlan10",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -113,8 +99,7 @@ spec:
                           "type": "primary"
                         }
                       ]
-                    },
-                    "id": "vlan10"
+                    }
                   }
                 ]
               }
@@ -123,22 +108,82 @@ spec:
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "vlan10",
+                    "ctrl": "port-unreachable"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "bd-items": {
+      "bd-items": {
+        "BD-list": []
+      }
+    },
     "fm-items": {
       "ifvlan-items": {
         "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "intf-items": {
+      "svi-items": {
+        "If-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "vlan10",
+                    "ctrl": "port-unreachable"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/isis.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/isis.txtar
@@ -42,33 +42,33 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "isis-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "unknown",
             "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/1",
             "layer": "Layer3",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "unknown",
-            "physExtd-items": {
-              "bufferBoost": "enable"
-            },
+            "userCfgdFlags": "admin_layer,admin_state",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
             },
-            "userCfgdFlags": "admin_layer,admin_state"
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            }
           }
         ]
       }
@@ -78,9 +78,11 @@ spec:
         "dom-items": {
           "Dom-list": [
             {
+              "name": "default",
               "if-items": {
                 "If-list": [
                   {
+                    "id": "eth1/1",
                     "addr-items": {
                       "Addr-list": [
                         {
@@ -90,15 +92,18 @@ spec:
                           "type": "primary"
                         }
                       ]
-                    },
-                    "id": "eth1/1"
+                    }
                   }
                 ]
-              },
-              "name": "default"
+              }
             }
           ]
         }
+      }
+    },
+    "fm-items": {
+      "isis-items": {
+        "adminSt": "enabled"
       }
     },
     "isis-items": {
@@ -106,9 +111,14 @@ spec:
         "Inst-list": [
           {
             "adminSt": "enabled",
+            "name": "FABRIC",
             "dom-items": {
               "Dom-list": [
                 {
+                  "isType": "l2",
+                  "name": "default",
+                  "net": "49.0001.0000.0000.0001.00",
+                  "passiveDflt": "l2",
                   "af-items": {
                     "DomAf-list": [
                       {
@@ -127,56 +137,69 @@ spec:
                         "v6enable": false
                       }
                     ]
-                  },
-                  "isType": "l2",
-                  "name": "default",
-                  "net": "49.0001.0000.0000.0001.00",
-                  "passiveDflt": "l2"
+                  }
                 }
               ]
-            },
-            "name": "FABRIC"
+            }
           }
         ]
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
-    "fm-items": {
-      "isis-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
             "id": "eth1/1",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "trunkVlans": "1-4094",
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "isis-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "isis-items": {
+      "inst-items": {
+        "Inst-list": []
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/lldp.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/lldp.txtar
@@ -33,8 +33,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "fm-items": {
       "lldp-items": {
         "adminSt": "enabled"
@@ -45,23 +49,27 @@ spec:
         "holdTime": 90,
         "initDelayTime": 5
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "fm-items": {
       "lldp-items": {
         "adminSt": "disabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "lldp-items": {
+      "inst-items": {
+        "holdTime": 90,
+        "initDelayTime": 5
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/managementaccess.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/managementaccess.txtar
@@ -45,8 +45,93 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "fm-items": {
+      "grpc-items": {
+        "adminSt": "enabled"
+      },
+      "ssh-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "grpc-items": {
+      "port": 9339,
+      "useVrf": "default",
+      "gnmi-items": {
+        "keepAliveTimeout": 600,
+        "maxCalls": 8
+      }
+    },
+    "terml-items": {
+      "ln-items": {
+        "vty-items": {
+          "execTmeout-items": {
+            "timeout": 10
+          },
+          "ssLmt-items": {
+            "sesLmt": 32
+          }
+        },
+        "cons-items": {
+          "execTmeout-items": {
+            "timeout": 15
+          }
+        }
+      }
+    },
+    "acl-items": {
+      "ipv4-items": {
+        "policy-items": {
+          "ingress-items": {
+            "vty-items": {
+              "acl-items": {
+                "name": "MGMT-ACL"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+-- state/delete --
+
+{
+  "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "fm-items": {
+      "grpc-items": {
+        "adminSt": "enabled"
+      },
+      "ssh-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "terml-items": {
+      "ln-items": {
+        "cons-items": {
+          "execTmeout-items": {
+            "timeout": 30
+          }
+        },
+        "vty-items": {
+          "execTmeout-items": {
+            "timeout": 30
+          },
+          "ssLmt-items": {
+            "sesLmt": 32
+          }
+        }
+      }
+    },
     "acl-items": {
       "ipv4-items": {
         "policy-items": {
@@ -60,79 +145,12 @@ spec:
         }
       }
     },
-    "fm-items": {
-      "grpc-items": {
-        "adminSt": "enabled"
-      },
-      "ssh-items": {
-        "adminSt": "enabled"
-      }
-    },
     "grpc-items": {
+      "port": 50051,
       "gnmi-items": {
         "keepAliveTimeout": 600,
         "maxCalls": 8
-      },
-      "port": 9339,
-      "useVrf": "default"
-    },
-    "terml-items": {
-      "ln-items": {
-        "cons-items": {
-          "execTmeout-items": {
-            "timeout": 15
-          }
-        },
-        "vty-items": {
-          "execTmeout-items": {
-            "timeout": 10
-          },
-          "ssLmt-items": {
-            "sesLmt": 32
-          }
-        }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
-    }
-  }
-}
-
--- state/delete --
-{
-  "System": {
-    "fm-items": {
-      "grpc-items": {
-        "adminSt": "enabled"
-      }
-    },
-    "grpc-items": {
-      "gnmi-items": {
-        "keepAliveTimeout": 600,
-        "maxCalls": 8
-      },
-      "port": 50051
-    },
-    "terml-items": {
-      "ln-items": {
-        "cons-items": {
-          "execTmeout-items": {
-            "timeout": 30
-          }
-        },
-        "vty-items": {
-          "execTmeout-items": {
-            "timeout": 30
-          },
-          "ssLmt-items": {
-            "sesLmt": 32
-          }
-        }
-      }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/ntp.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/ntp.txtar
@@ -24,8 +24,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "fm-items": {
       "ntpd-items": {
         "adminSt": "enabled"
@@ -50,16 +54,17 @@ spec:
       "srcIf-items": {
         "srcIf": "mgmt0"
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "fm-items": {
       "ntpd-items": {
         "adminSt": "disabled"
@@ -68,9 +73,6 @@ spec:
     "time-items": {
       "adminSt": "disabled",
       "logging": "disabled"
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/nve.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/nve.txtar
@@ -54,77 +54,18 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "eps-items": {
-      "epId-items": {
-        "Ep-list": [
-          {
-            "epId": 1,
-            "adminSt": "enabled",
-            "advertiseVmac": true,
-            "holdDownTime": 200,
-            "hostReach": "bgp",
-            "sourceInterface": "lo1",
-            "suppressARP": false
-          }
-        ]
-      }
-    },
-    "pltfm-items": {
-      "nve-items": {
-        "NVE-list": [
-          {
-            "id": 1,
-            "infravlan-items": {
-              "InfraVlan-list": [
-                {
-                  "id": 3966
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "fm-items": {
-      "evpn-items": {
-        "adminSt": "enabled"
-      },
-      "nvo-items": {
-        "adminSt": "enabled"
-      }
-    },
-    "hmm-items": {
-      "fwdinst-items": {
-        "adminSt": "disabled",
-        "amac": ""
-      }
-    },
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "id": "lo1",
-                    "ctrl": "port-unreachable,redirect"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "lb-items": {
         "LbRtdIf-list": [
           {
             "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
             "id": "lo1",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
@@ -161,15 +102,25 @@ spec:
         }
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
-    }
-  }
-}
-
--- state/delete --
-{
-  "System": {
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo1",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "fm-items": {
       "evpn-items": {
         "adminSt": "enabled"
@@ -178,8 +129,116 @@ spec:
         "adminSt": "enabled"
       }
     },
+    "eps-items": {
+      "epId-items": {
+        "Ep-list": [
+          {
+            "epId": 1,
+            "adminSt": "enabled",
+            "advertiseVmac": true,
+            "sourceInterface": "lo1",
+            "anycastIntf": "DME_UNSET_PROPERTY_MARKER",
+            "holdDownTime": 200,
+            "hostReach": "bgp",
+            "mcastGroupL2": "DME_UNSET_PROPERTY_MARKER",
+            "mcastGroupL3": "DME_UNSET_PROPERTY_MARKER",
+            "suppressARP": false
+          }
+        ]
+      }
+    },
+    "pltfm-items": {
+      "nve-items": {
+        "NVE-list": [
+          {
+            "id": 1,
+            "infravlan-items": {
+              "InfraVlan-list": [
+                {
+                  "id": 3966
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "hmm-items": {
+      "fwdinst-items": {
+        "adminSt": "disabled",
+        "amac": ""
+      }
+    }
+  }
+}
+
+-- state/delete --
+
+{
+  "System": {
     "procsys-items": {
       "bootTime": "1700000000"
-    }
+    },
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo1",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "evpn-items": {
+        "adminSt": "enabled"
+      },
+      "nvo-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "eps-items": {
+      "epId-items": {
+        "Ep-list": []
+      }
+    },
+    "pltfm-items": {
+      "nve-items": {
+        "NVE-list": [
+          {
+            "id": 1
+          }
+        ]
+      }
+    },
+    "hmm-items": {}
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/ospf.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/ospf.txtar
@@ -40,37 +40,18 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "ospf-items": {
-        "adminSt": "enabled"
-      }
-    },
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "id": "lo10",
-                    "ctrl": "port-unreachable,redirect"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "lb-items": {
         "LbRtdIf-list": [
           {
             "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
             "id": "lo10",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
@@ -107,33 +88,57 @@ spec:
         }
       }
     },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo10",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "ospf-items": {
+        "adminSt": "enabled"
+      }
+    },
     "ospf-items": {
       "inst-items": {
         "Inst-list": [
           {
-            "name": "UNDERLAY",
             "adminSt": "enabled",
+            "name": "UNDERLAY",
             "dom-items": {
               "Dom-list": [
                 {
-                  "name": "default",
-                  "adminSt": "enabled",
                   "adjChangeLogLevel": "none",
+                  "adminSt": "enabled",
                   "bwRef": 40000,
                   "bwRefUnit": "mbps",
                   "ctrl": "default-passive",
                   "dist": 110,
+                  "name": "default",
                   "rtrId": "10.255.255.10",
                   "if-items": {
                     "If-list": [
                       {
-                        "id": "lo10",
                         "adminSt": "enabled",
                         "advertiseSecondaries": true,
                         "area": "0.0.0.0",
-                        "bfdCtrl": "unspecified",
+                        "id": "lo10",
                         "nwT": "unspecified",
-                        "passiveCtrl": "disabled"
+                        "passiveCtrl": "disabled",
+                        "bfdCtrl": "unspecified"
                       }
                     ]
                   }
@@ -143,23 +148,64 @@ spec:
           }
         ]
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo10",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "fm-items": {
       "ospf-items": {
         "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "ospf-items": {
+      "inst-items": {
+        "Inst-list": []
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/pim.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/pim.txtar
@@ -38,37 +38,18 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "pim-items": {
-        "adminSt": "enabled"
-      }
-    },
-    "icmpv4-items": {
-      "inst-items": {
-        "dom-items": {
-          "Dom-list": [
-            {
-              "name": "default",
-              "if-items": {
-                "If-list": [
-                  {
-                    "id": "lo20",
-                    "ctrl": "port-unreachable,redirect"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
       "lb-items": {
         "LbRtdIf-list": [
           {
             "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
             "id": "lo20",
             "rtvrfMbr-items": {
               "tDn": "/System/inst-items/Inst-list[name='default']"
@@ -105,6 +86,30 @@ spec:
         }
       }
     },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo20",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "pim-items": {
+        "adminSt": "enabled"
+      }
+    },
     "pim-items": {
       "adminSt": "enabled",
       "inst-items": {
@@ -126,23 +131,73 @@ spec:
           ]
         }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "intf-items": {
+      "lb-items": {
+        "LbRtdIf-list": []
+      }
+    },
+    "ipv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": []
+              }
+            }
+          ]
+        }
+      }
+    },
+    "icmpv4-items": {
+      "inst-items": {
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "if-items": {
+                "If-list": [
+                  {
+                    "id": "lo20",
+                    "ctrl": "port-unreachable,redirect"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "fm-items": {
       "pim-items": {
         "adminSt": "enabled"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "pim-items": {
+      "adminSt": "disabled",
+      "inst-items": {
+        "adminSt": "disabled",
+        "dom-items": {
+          "Dom-list": [
+            {
+              "name": "default",
+              "adminSt": "disabled"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/routingpolicy.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/routingpolicy.txtar
@@ -62,8 +62,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "rpm-items": {
       "pfxlistv4-items": {
         "RuleV4-list": [
@@ -140,18 +144,27 @@ spec:
           }
         ]
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "rpm-items": {
+      "pfxlistv4-items": {
+        "RuleV4-list": []
+      },
+      "pfxlistv6-items": {
+        "RuleV6-list": []
+      },
+      "rtmap-items": {
+        "Rule-list": []
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/snmp.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/snmp.txtar
@@ -26,10 +26,26 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "snmp-items": {
       "inst-items": {
+        "sysinfo-items": {
+          "sysContact": "admin@example.com",
+          "sysLocation": "foobar"
+        },
+        "globals-items": {
+          "srcInterfaceTraps-items": {
+            "ifname": "mgmt0"
+          },
+          "srcInterfaceInforms-items": {
+            "ifname": "mgmt0"
+          }
+        },
         "community-items": {
           "CommSecP-list": [
             {
@@ -39,17 +55,11 @@ spec:
             }
           ]
         },
-        "globals-items": {
-          "srcInterfaceInforms-items": {
-            "ifname": "mgmt0"
-          },
-          "srcInterfaceTraps-items": {
-            "ifname": "mgmt0"
-          }
-        },
+        "traps-items": {},
         "host-items": {
           "Host-list": [
             {
+              "commName": "DME_UNSET_PROPERTY_MARKER",
               "hostName": "10.0.0.100",
               "notifType": "traps",
               "secLevel": "noauth",
@@ -57,30 +67,24 @@ spec:
               "version": "v2c"
             }
           ]
-        },
-        "sysinfo-items": {
-          "sysContact": "admin@example.com",
-          "sysLocation": "foobar"
-        },
-        "traps-items": {}
+        }
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
-    "snmp-items": {
-      "inst-items": {
-        "traps-items": {}
-      }
-    },
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "snmp-items": {
+      "inst-items": {
+        "globals-items": {},
+        "traps-items": {}
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/syslog.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/syslog.txtar
@@ -25,28 +25,24 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "logging-items": {
-      "loglevel-items": {
-        "facility-items": {
-          "Facility-list": [
-            {
-              "facilityName": "Local7",
-              "severityLevel": "information"
-            }
-          ]
-        }
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "syslog-items": {
-      "logginghistory-items": {
-        "level": "information",
-        "size": 500
-      },
       "originid-items": {
         "idtype": "string",
         "idvalue": "logging"
+      },
+      "source-items": {
+        "adminState": "enabled",
+        "ifName": "mgmt0"
+      },
+      "logginghistory-items": {
+        "level": "information",
+        "size": 500
       },
       "rdst-items": {
         "RemoteDest-list": [
@@ -59,23 +55,33 @@ spec:
             "vrfName": "management"
           }
         ]
-      },
-      "source-items": {
-        "adminState": "enabled",
-        "ifName": "mgmt0"
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "logging-items": {
+      "loglevel-items": {
+        "facility-items": {
+          "Facility-list": [
+            {
+              "facilityName": "Local7",
+              "severityLevel": "information"
+            }
+          ]
+        }
+      }
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "syslog-items": {},
+    "logging-items": {
+      "loglevel-items": {}
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/system.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/system.txtar
@@ -21,29 +21,51 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "vlanmgr-items": {
+      "inst-items": {
+        "longName": false
+      }
+    },
+    "bd-items": {
+      "resvlan-items": {
+        "sysVlan": 3968
+      }
+    },
     "ethpm-items": {
       "inst-items": {
         "systemJumboMtu": 9214
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
+    "vlanmgr-items": {
+      "inst-items": {
+        "longName": false
+      }
+    },
+    "bd-items": {
+      "resvlan-items": {
+        "sysVlan": 3968
+      }
+    },
     "ethpm-items": {
       "inst-items": {
         "systemJumboMtu": 9216
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/user.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/user.txtar
@@ -35,8 +35,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "userext-items": {
       "user-items": {
         "User-list": [
@@ -64,18 +68,21 @@ spec:
           }
         ]
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "userext-items": {
+      "user-items": {
+        "User-list": []
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/vlan.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/vlan.txtar
@@ -20,8 +20,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "bd-items": {
       "bd-items": {
         "BD-list": [
@@ -33,18 +37,21 @@ spec:
           }
         ]
       }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "bd-items": {
+      "bd-items": {
+        "BD-list": []
+      }
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/vpcdomain.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/vpcdomain.txtar
@@ -61,33 +61,49 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
-    "fm-items": {
-      "lacp-items": {
-        "adminSt": "enabled"
-      },
-      "vpc-items": {
-        "adminSt": "enabled"
-      }
+    "procsys-items": {
+      "bootTime": "1700000000"
     },
     "intf-items": {
+      "phys-items": {
+        "PhysIf-list": [
+          {
+            "accessVlan": "vlan-1",
+            "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
+            "id": "eth1/1",
+            "layer": "Layer2",
+            "mtu": 1500,
+            "medium": "broadcast",
+            "mode": "access",
+            "nativeVlan": "vlan-1",
+            "userCfgdFlags": "admin_layer,admin_state",
+            "physExtd-items": {
+              "bufferBoost": "enable"
+            }
+          }
+        ]
+      },
       "aggr-items": {
         "AggrIf-list": [
           {
-            "id": "po1",
-            "adminSt": "up",
             "accessVlan": "vlan-1",
-            "aggrExtd-items": {
-              "bufferBoost": "enable"
-            },
+            "adminSt": "up",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "id": "po1",
             "lacpVpcConvergence": "disable",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
-            "nativeVlan": "vlan-1",
             "pcMode": "active",
+            "nativeVlan": "vlan-1",
+            "suspIndividual": "enable",
+            "userCfgdFlags": "admin_layer,admin_state",
             "rsmbrIfs-items": {
               "RsMbrIfs-list": [
                 {
@@ -95,27 +111,9 @@ spec:
                 }
               ]
             },
-            "suspIndividual": "enable",
-            "userCfgdFlags": "admin_layer,admin_state"
-          }
-        ]
-      },
-      "phys-items": {
-        "PhysIf-list": [
-          {
-            "id": "eth1/1",
-            "FECMode": "auto",
-            "accessVlan": "vlan-1",
-            "adminSt": "up",
-            "layer": "Layer2",
-            "medium": "broadcast",
-            "mode": "access",
-            "mtu": 1500,
-            "nativeVlan": "vlan-1",
-            "physExtd-items": {
+            "aggrExtd-items": {
               "bufferBoost": "enable"
-            },
-            "userCfgdFlags": "admin_layer,admin_state"
+            }
           }
         ]
       }
@@ -125,57 +123,21 @@ spec:
         "if-items": {
           "If-list": [
             {
-              "id": "eth1/1",
+              "mode": "default",
               "bpdufilter": "default",
               "bpduguard": "default",
-              "mode": "default"
+              "id": "eth1/1"
             },
             {
-              "id": "po1",
+              "mode": "default",
               "bpdufilter": "default",
               "bpduguard": "default",
-              "mode": "default"
+              "id": "po1"
             }
           ]
         }
       }
     },
-    "vpc-items": {
-      "inst-items": {
-        "dom-items": {
-          "id": 100,
-          "adminSt": "enabled",
-          "autoRecovery": "disabled",
-          "autoRecoveryIntvl": 240,
-          "delayRestoreSVI": 10,
-          "delayRestoreVPC": 30,
-          "fastConvergence": "disabled",
-          "keepalive-items": {
-            "destIp": "10.0.0.2",
-            "srcIp": "10.0.0.1",
-            "vrf": "management",
-            "peerlink-items": {
-              "adminSt": "enabled",
-              "id": "po1"
-            }
-          },
-          "l3PeerRouter": "disabled",
-          "peerGw": "disabled",
-          "peerSwitch": "disabled",
-          "rolePrio": 32667,
-          "sysPrio": 32667
-        }
-      }
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
-    }
-  }
-}
-
--- state/delete --
-{
-  "System": {
     "fm-items": {
       "lacp-items": {
         "adminSt": "enabled"
@@ -184,28 +146,98 @@ spec:
         "adminSt": "enabled"
       }
     },
+    "vpc-items": {
+      "inst-items": {
+        "dom-items": {
+          "adminSt": "enabled",
+          "autoRecovery": "disabled",
+          "autoRecoveryIntvl": 240,
+          "delayRestoreSVI": 10,
+          "delayRestoreVPC": 30,
+          "fastConvergence": "disabled",
+          "id": 100,
+          "l3PeerRouter": "disabled",
+          "peerGw": "disabled",
+          "peerSwitch": "disabled",
+          "rolePrio": 32667,
+          "sysPrio": 32667,
+          "keepalive-items": {
+            "destIp": "10.0.0.2",
+            "srcIp": "10.0.0.1",
+            "vrf": "management",
+            "peerlink-items": {
+              "adminSt": "enabled",
+              "id": "po1"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+-- state/delete --
+
+{
+  "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "intf-items": {
       "phys-items": {
         "PhysIf-list": [
           {
-            "id": "eth1/1",
-            "FECMode": "auto",
             "accessVlan": "vlan-1",
+            "descr": "DME_UNSET_PROPERTY_MARKER",
+            "FECMode": "auto",
+            "id": "eth1/1",
             "layer": "Layer2",
+            "mtu": 1500,
             "medium": "broadcast",
             "mode": "access",
-            "mtu": 1500,
             "nativeVlan": "vlan-1",
+            "userCfgdFlags": "",
             "physExtd-items": {
               "bufferBoost": "enable"
             },
-            "userCfgdFlags": ""
+            "trunkVlans": "1-4094"
           }
         ]
+      },
+      "aggr-items": {
+        "AggrIf-list": []
       }
     },
-    "procsys-items": {
-      "bootTime": "1700000000"
+    "stp-items": {
+      "inst-items": {
+        "if-items": {
+          "If-list": [
+            {
+              "mode": "default",
+              "bpdufilter": "default",
+              "bpduguard": "default",
+              "id": "po1"
+            },
+            {
+              "mode": "default",
+              "bpdufilter": "default",
+              "bpduguard": "default",
+              "id": "eth1/1"
+            }
+          ]
+        }
+      }
+    },
+    "fm-items": {
+      "lacp-items": {
+        "adminSt": "enabled"
+      },
+      "vpc-items": {
+        "adminSt": "enabled"
+      }
+    },
+    "vpc-items": {
+      "inst-items": {}
     }
   }
 }

--- a/test/gnmi/testdata/cisco-nxos-gnmi/vrf.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/vrf.txtar
@@ -20,8 +20,12 @@ spec:
 }
 
 -- state/expect --
+
 {
   "System": {
+    "procsys-items": {
+      "bootTime": "1700000000"
+    },
     "inst-items": {
       "Inst-list": [
         {
@@ -37,18 +41,19 @@ spec:
           }
         }
       ]
-    },
-    "procsys-items": {
-      "bootTime": "1700000000"
     }
   }
 }
 
 -- state/delete --
+
 {
   "System": {
     "procsys-items": {
       "bootTime": "1700000000"
+    },
+    "inst-items": {
+      "Inst-list": []
     }
   }
 }

--- a/test/gnmi/testdata/openconfig/aaa.txtar
+++ b/test/gnmi/testdata/openconfig/aaa.txtar
@@ -19,6 +19,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "aaa": {
@@ -41,4 +42,7 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-system:system": {}
+}

--- a/test/gnmi/testdata/openconfig/acl.txtar
+++ b/test/gnmi/testdata/openconfig/acl.txtar
@@ -27,6 +27,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-acl:acl": {
     "acl-sets": {
@@ -76,7 +77,9 @@ spec:
                 }
               }
             ]
-          }
+          },
+          "name": "MGMT-ACL",
+          "type": "openconfig-acl:ACL_IPV4"
         }
       ]
     }
@@ -84,4 +87,61 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-acl:acl": {
+    "acl-sets": {
+      "acl-set": [
+        {
+          "config": {
+            "name": "MGMT-ACL",
+            "type": "openconfig-acl:ACL_IPV4"
+          },
+          "acl-entries": {
+            "acl-entry": [
+              {
+                "sequence-id": 10,
+                "config": {
+                  "sequence-id": 10,
+                  "description": "Allow management subnet"
+                },
+                "ipv4": {
+                  "config": {
+                    "source-address": "10.0.0.0/24",
+                    "destination-address": "0.0.0.0/0",
+                    "protocol": "6"
+                  }
+                },
+                "actions": {
+                  "config": {
+                    "forwarding-action": "openconfig-acl:ACCEPT"
+                  }
+                }
+              },
+              {
+                "sequence-id": 20,
+                "config": {
+                  "sequence-id": 20,
+                  "description": "Deny all other traffic"
+                },
+                "ipv4": {
+                  "config": {
+                    "source-address": "0.0.0.0/0",
+                    "destination-address": "0.0.0.0/0"
+                  }
+                },
+                "actions": {
+                  "config": {
+                    "forwarding-action": "openconfig-acl:DROP"
+                  }
+                }
+              }
+            ]
+          },
+          "name": "MGMT-ACL",
+          "type": "openconfig-acl:ACL_IPV4"
+        }
+      ]
+    }
+  }
+}

--- a/test/gnmi/testdata/openconfig/banner.txtar
+++ b/test/gnmi/testdata/openconfig/banner.txtar
@@ -22,22 +22,25 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
-    "config": {
-      "login-banner": "Unauthorized access is prohibited."
-    },
     "state": {
       "boot-time": "1784731445707000000"
+    },
+    "config": {
+      "login-banner": "Unauthorized access is prohibited."
     }
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
-    }
+    },
+    "config": {}
   }
 }

--- a/test/gnmi/testdata/openconfig/bgp.txtar
+++ b/test/gnmi/testdata/openconfig/bgp.txtar
@@ -20,10 +20,12 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-network-instance:network-instances": {
     "network-instance": [
       {
+        "name": "default",
         "protocols": {
           "protocol": [
             {
@@ -56,7 +58,9 @@ spec:
                     ]
                   }
                 }
-              }
+              },
+              "identifier": "openconfig-policy-types:BGP",
+              "name": "BGP"
             }
           ]
         }
@@ -66,4 +70,16 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "protocols": {
+          "protocol": []
+        }
+      }
+    ]
+  }
+}

--- a/test/gnmi/testdata/openconfig/bgppeer.txtar
+++ b/test/gnmi/testdata/openconfig/bgppeer.txtar
@@ -35,10 +35,12 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-network-instance:network-instances": {
     "network-instance": [
       {
+        "name": "default",
         "protocols": {
           "protocol": [
             {
@@ -69,7 +71,8 @@ spec:
                     {
                       "config": {
                         "peer-group-name": "NETOP-DEFAULT"
-                      }
+                      },
+                      "peer-group-name": "NETOP-DEFAULT"
                     }
                   ]
                 },
@@ -93,11 +96,14 @@ spec:
                             }
                           }
                         ]
-                      }
+                      },
+                      "neighbor-address": "10.0.0.2"
                     }
                   ]
                 }
-              }
+              },
+              "identifier": "openconfig-policy-types:BGP",
+              "name": "BGP"
             }
           ]
         }
@@ -107,4 +113,16 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "protocols": {
+          "protocol": []
+        }
+      }
+    ]
+  }
+}

--- a/test/gnmi/testdata/openconfig/dns.txtar
+++ b/test/gnmi/testdata/openconfig/dns.txtar
@@ -16,6 +16,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "dns": {
@@ -45,4 +46,7 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-system:system": {}
+}

--- a/test/gnmi/testdata/openconfig/interface.txtar
+++ b/test/gnmi/testdata/openconfig/interface.txtar
@@ -26,6 +26,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -35,31 +36,30 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "lo0",
         "config": {
-          "description": "Router-ID Leaf1",
-          "enabled": true,
           "name": "lo0",
-          "type": "iana-if-type:softwareLoopback"
+          "type": "iana-if-type:softwareLoopback",
+          "description": "Router-ID Leaf1",
+          "enabled": true
         },
         "subinterfaces": {
           "subinterface": [
             {
-              "config": {
-                "enabled": true,
-                "index": 0
-              },
               "index": 0,
+              "config": {
+                "index": 0,
+                "enabled": true
+              },
               "openconfig-if-ip:ipv4": {
                 "addresses": {
                   "address": [
                     {
+                      "ip": "10.0.0.10",
                       "config": {
                         "ip": "10.0.0.10",
                         "prefix-length": 32,
                         "type": "PRIMARY"
-                      },
-                      "ip": "10.0.0.10"
+                      }
                     }
                   ]
                 },
@@ -69,17 +69,22 @@ spec:
               }
             }
           ]
-        }
+        },
+        "name": "lo0"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": []
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_aggregate_l2_trunk.txtar
+++ b/test/gnmi/testdata/openconfig/interface_aggregate_l2_trunk.txtar
@@ -53,6 +53,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -62,29 +63,28 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "eth1/10",
         "config": {
+          "name": "eth1/10",
+          "type": "iana-if-type:ethernetCsmacd",
           "description": "Member of po10",
           "enabled": true,
-          "mtu": 1500,
-          "name": "eth1/10",
-          "type": "iana-if-type:ethernetCsmacd"
+          "mtu": 1500
         },
         "openconfig-if-ethernet:ethernet": {
           "config": {
             "openconfig-if-aggregate:aggregate-id": "po10"
           }
-        }
+        },
+        "name": "eth1/10"
       },
       {
-        "name": "po10",
         "config": {
+          "name": "po10",
+          "type": "iana-if-type:ieee8023adLag",
           "description": "vPC Leaf1 to Host1",
           "enabled": true,
           "mtu": 1500,
-          "name": "po10",
-          "tpid": "TPID_0X8100",
-          "type": "iana-if-type:ieee8023adLag"
+          "tpid": "TPID_0X8100"
         },
         "openconfig-if-aggregate:aggregation": {
           "config": {
@@ -94,20 +94,45 @@ spec:
             "config": {
               "interface-mode": "TRUNK",
               "native-vlan": 1,
-              "trunk-vlans": [10]
+              "trunk-vlans": [
+                10
+              ]
             }
           }
-        }
+        },
+        "name": "po10"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "name": "eth1/10",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": false
+        },
+        "name": "eth1/10",
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "trunk-vlans": [
+                "1..4094"
+              ]
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_aggregate_l3.txtar
+++ b/test/gnmi/testdata/openconfig/interface_aggregate_l3.txtar
@@ -52,6 +52,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -61,52 +62,31 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "eth1/3",
         "config": {
-          "description": "Member of po20",
-          "enabled": true,
-          "mtu": 9216,
-          "name": "eth1/3",
-          "type": "iana-if-type:ethernetCsmacd"
-        },
-        "openconfig-if-ethernet:ethernet": {
-          "config": {
-            "openconfig-if-aggregate:aggregate-id": "po20"
-          }
-        }
-      },
-      {
-        "name": "po20",
-        "config": {
+          "name": "po20",
+          "type": "iana-if-type:ieee8023adLag",
           "description": "L3 Port-Channel",
           "enabled": true,
-          "mtu": 9216,
-          "name": "po20",
-          "type": "iana-if-type:ieee8023adLag"
-        },
-        "openconfig-if-aggregate:aggregation": {
-          "config": {
-            "lag-type": "LACP"
-          }
+          "mtu": 9216
         },
         "subinterfaces": {
           "subinterface": [
             {
-              "config": {
-                "enabled": true,
-                "index": 0
-              },
               "index": 0,
+              "config": {
+                "index": 0,
+                "enabled": true
+              },
               "openconfig-if-ip:ipv4": {
                 "addresses": {
                   "address": [
                     {
+                      "ip": "10.0.100.0",
                       "config": {
                         "ip": "10.0.100.0",
                         "prefix-length": 31,
                         "type": "PRIMARY"
-                      },
-                      "ip": "10.0.100.0"
+                      }
                     }
                   ]
                 },
@@ -116,17 +96,60 @@ spec:
               }
             }
           ]
-        }
+        },
+        "openconfig-if-aggregate:aggregation": {
+          "config": {
+            "lag-type": "LACP"
+          }
+        },
+        "name": "po20"
+      },
+      {
+        "config": {
+          "name": "eth1/3",
+          "type": "iana-if-type:ethernetCsmacd",
+          "description": "Member of po20",
+          "enabled": true,
+          "mtu": 9216
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "config": {
+            "openconfig-if-aggregate:aggregate-id": "po20"
+          }
+        },
+        "name": "eth1/3"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "name": "eth1/3",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": false
+        },
+        "name": "eth1/3",
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "trunk-vlans": [
+                "1..4094"
+              ]
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_loopback_multi_addr.txtar
+++ b/test/gnmi/testdata/openconfig/interface_loopback_multi_addr.txtar
@@ -27,6 +27,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -36,39 +37,38 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "lo1",
         "config": {
-          "description": "NVE/VTEP Leaf1",
-          "enabled": true,
           "name": "lo1",
-          "type": "iana-if-type:softwareLoopback"
+          "type": "iana-if-type:softwareLoopback",
+          "description": "NVE/VTEP Leaf1",
+          "enabled": true
         },
         "subinterfaces": {
           "subinterface": [
             {
-              "config": {
-                "enabled": true,
-                "index": 0
-              },
               "index": 0,
+              "config": {
+                "index": 0,
+                "enabled": true
+              },
               "openconfig-if-ip:ipv4": {
                 "addresses": {
                   "address": [
                     {
+                      "ip": "10.0.1.10",
                       "config": {
                         "ip": "10.0.1.10",
                         "prefix-length": 32,
                         "type": "PRIMARY"
-                      },
-                      "ip": "10.0.1.10"
+                      }
                     },
                     {
+                      "ip": "10.1.0.10",
                       "config": {
                         "ip": "10.1.0.10",
                         "prefix-length": 32,
                         "type": "SECONDARY"
-                      },
-                      "ip": "10.1.0.10"
+                      }
                     }
                   ]
                 },
@@ -78,17 +78,22 @@ spec:
               }
             }
           ]
-        }
+        },
+        "name": "lo1"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": []
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_physical_ipv4.txtar
+++ b/test/gnmi/testdata/openconfig/interface_physical_ipv4.txtar
@@ -27,6 +27,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -36,32 +37,31 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "eth1/1",
         "config": {
+          "name": "eth1/1",
+          "type": "iana-if-type:ethernetCsmacd",
           "description": "Uplink to Spine",
           "enabled": true,
-          "mtu": 9216,
-          "name": "eth1/1",
-          "type": "iana-if-type:ethernetCsmacd"
+          "mtu": 9216
         },
         "subinterfaces": {
           "subinterface": [
             {
-              "config": {
-                "enabled": true,
-                "index": 0
-              },
               "index": 0,
+              "config": {
+                "index": 0,
+                "enabled": true
+              },
               "openconfig-if-ip:ipv4": {
                 "addresses": {
                   "address": [
                     {
+                      "ip": "10.0.100.1",
                       "config": {
                         "ip": "10.0.100.1",
                         "prefix-length": 31,
                         "type": "PRIMARY"
-                      },
-                      "ip": "10.0.100.1"
+                      }
                     }
                   ]
                 },
@@ -71,17 +71,40 @@ spec:
               }
             }
           ]
-        }
+        },
+        "name": "eth1/1"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "name": "eth1/1",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": false
+        },
+        "name": "eth1/1",
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "trunk-vlans": [
+                "1..4094"
+              ]
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_physical_switchport_access.txtar
+++ b/test/gnmi/testdata/openconfig/interface_physical_switchport_access.txtar
@@ -27,6 +27,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -36,33 +37,55 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "eth1/10",
         "config": {
+          "name": "eth1/10",
+          "type": "iana-if-type:ethernetCsmacd",
           "description": "Access port to Host",
           "enabled": true,
           "mtu": 1500,
-          "name": "eth1/10",
-          "tpid": "TPID_0X8100",
-          "type": "iana-if-type:ethernetCsmacd"
+          "tpid": "TPID_0X8100"
         },
         "openconfig-if-ethernet:ethernet": {
           "openconfig-vlan:switched-vlan": {
             "config": {
-              "access-vlan": 10,
-              "interface-mode": "ACCESS"
+              "interface-mode": "ACCESS",
+              "access-vlan": 10
             }
           }
-        }
+        },
+        "name": "eth1/10"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "name": "eth1/10",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": false
+        },
+        "name": "eth1/10",
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "trunk-vlans": [
+                "1..4094"
+              ]
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_physical_switchport_trunk.txtar
+++ b/test/gnmi/testdata/openconfig/interface_physical_switchport_trunk.txtar
@@ -28,6 +28,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -37,34 +38,58 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "eth1/10",
         "config": {
+          "name": "eth1/10",
+          "type": "iana-if-type:ethernetCsmacd",
           "description": "vPC to Host1",
           "enabled": true,
           "mtu": 1500,
-          "name": "eth1/10",
-          "tpid": "TPID_0X8100",
-          "type": "iana-if-type:ethernetCsmacd"
+          "tpid": "TPID_0X8100"
         },
         "openconfig-if-ethernet:ethernet": {
           "openconfig-vlan:switched-vlan": {
             "config": {
               "interface-mode": "TRUNK",
               "native-vlan": 1,
-              "trunk-vlans": [10]
+              "trunk-vlans": [
+                10
+              ]
             }
           }
-        }
+        },
+        "name": "eth1/10"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "name": "eth1/10",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": false
+        },
+        "name": "eth1/10",
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "trunk-vlans": [
+                "1..4094"
+              ]
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/test/gnmi/testdata/openconfig/interface_physical_unnumbered.txtar
+++ b/test/gnmi/testdata/openconfig/interface_physical_unnumbered.txtar
@@ -44,6 +44,7 @@ spec:
 }
 
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "state": {
@@ -53,30 +54,29 @@ spec:
   "openconfig-interfaces:interfaces": {
     "interface": [
       {
-        "name": "lo0",
         "config": {
-          "enabled": true,
           "name": "lo0",
-          "type": "iana-if-type:softwareLoopback"
+          "type": "iana-if-type:softwareLoopback",
+          "enabled": true
         },
         "subinterfaces": {
           "subinterface": [
             {
-              "config": {
-                "enabled": true,
-                "index": 0
-              },
               "index": 0,
+              "config": {
+                "index": 0,
+                "enabled": true
+              },
               "openconfig-if-ip:ipv4": {
                 "addresses": {
                   "address": [
                     {
+                      "ip": "10.0.0.10",
                       "config": {
                         "ip": "10.0.0.10",
                         "prefix-length": 32,
                         "type": "PRIMARY"
-                      },
-                      "ip": "10.0.0.10"
+                      }
                     }
                   ]
                 },
@@ -86,50 +86,73 @@ spec:
               }
             }
           ]
-        }
+        },
+        "name": "lo0"
       },
       {
-        "name": "eth1/1",
         "config": {
+          "name": "eth1/1",
+          "type": "iana-if-type:ethernetCsmacd",
           "description": "Leaf1 to Spine1",
           "enabled": true,
-          "mtu": 9216,
-          "name": "eth1/1",
-          "type": "iana-if-type:ethernetCsmacd"
+          "mtu": 9216
         },
         "subinterfaces": {
           "subinterface": [
             {
-              "config": {
-                "enabled": true,
-                "index": 0
-              },
               "index": 0,
+              "config": {
+                "index": 0,
+                "enabled": true
+              },
               "openconfig-if-ip:ipv4": {
-                "config": {
-                  "enabled": true
-                },
                 "unnumbered": {
                   "interface-ref": {
                     "config": {
                       "interface": "lo0"
                     }
                   }
+                },
+                "config": {
+                  "enabled": true
                 }
               }
             }
           ]
-        }
+        },
+        "name": "eth1/1"
       }
     ]
   }
 }
 
 -- state/delete --
+
 {
   "openconfig-system:system": {
     "state": {
       "boot-time": "1784731445707000000"
     }
+  },
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "name": "eth1/1",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": false
+        },
+        "name": "eth1/1",
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "trunk-vlans": [
+                "1..4094"
+              ]
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/test/gnmi/testdata/openconfig/isis.txtar
+++ b/test/gnmi/testdata/openconfig/isis.txtar
@@ -19,10 +19,12 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-network-instance:network-instances": {
     "network-instance": [
       {
+        "name": "default",
         "protocols": {
           "protocol": [
             {
@@ -53,7 +55,9 @@ spec:
                     ]
                   }
                 }
-              }
+              },
+              "identifier": "openconfig-policy-types:ISIS",
+              "name": "DEFAULT"
             }
           ]
         }
@@ -63,4 +67,16 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "protocols": {
+          "protocol": []
+        }
+      }
+    ]
+  }
+}

--- a/test/gnmi/testdata/openconfig/lldp.txtar
+++ b/test/gnmi/testdata/openconfig/lldp.txtar
@@ -14,6 +14,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-lldp:lldp": {
     "config": {
@@ -23,6 +24,7 @@ spec:
 }
 
 -- state/delete --
+
 {
   "openconfig-lldp:lldp": {
     "config": {

--- a/test/gnmi/testdata/openconfig/managementaccess.txtar
+++ b/test/gnmi/testdata/openconfig/managementaccess.txtar
@@ -17,6 +17,7 @@ spec:
     enabled: true
     timeout: 120s
 -- state/expect --
+
 {
   "openconfig-system:system": {
     "grpc-servers": {
@@ -41,5 +42,18 @@ spec:
     }
   }
 }
+
 -- state/delete --
-{}
+
+{
+  "openconfig-system:system": {
+    "grpc-servers": {
+      "grpc-server": [
+        {
+          "name": "gnmi"
+        }
+      ]
+    },
+    "ssh-server": {}
+  }
+}

--- a/test/gnmi/testdata/openconfig/prefixset.txtar
+++ b/test/gnmi/testdata/openconfig/prefixset.txtar
@@ -19,6 +19,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-routing-policy:routing-policy": {
     "defined-sets": {
@@ -47,7 +48,8 @@ spec:
                   }
                 }
               ]
-            }
+            },
+            "name": "LOOPBACKS"
           }
         ]
       }
@@ -56,4 +58,13 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-routing-policy:routing-policy": {
+    "defined-sets": {
+      "prefix-sets": {
+        "prefix-set": []
+      }
+    }
+  }
+}

--- a/test/gnmi/testdata/openconfig/routingpolicy.txtar
+++ b/test/gnmi/testdata/openconfig/routingpolicy.txtar
@@ -40,6 +40,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-routing-policy:routing-policy": {
     "defined-sets": {
@@ -68,7 +69,8 @@ spec:
                   }
                 }
               ]
-            }
+            },
+            "name": "LOOPBACKS"
           }
         ]
       }
@@ -112,7 +114,8 @@ spec:
                 }
               }
             ]
-          }
+          },
+          "name": "accept-loopbacks"
         }
       ]
     }
@@ -120,4 +123,16 @@ spec:
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-routing-policy:routing-policy": {
+    "defined-sets": {
+      "prefix-sets": {
+        "prefix-set": []
+      }
+    },
+    "policy-definitions": {
+      "policy-definition": []
+    }
+  }
+}

--- a/test/gnmi/testdata/openconfig/vrf.txtar
+++ b/test/gnmi/testdata/openconfig/vrf.txtar
@@ -14,6 +14,7 @@ spec:
 {}
 
 -- state/expect --
+
 {
   "openconfig-network-instance:network-instances": {
     "network-instance": [
@@ -21,11 +22,17 @@ spec:
         "config": {
           "name": "BLUE",
           "type": "openconfig-network-instance-types:L3VRF"
-        }
+        },
+        "name": "BLUE"
       }
     ]
   }
 }
 
 -- state/delete --
-{}
+
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": []
+  }
+}


### PR DESCRIPTION
Use MatchUnorderedJSON instead of ContainUnorderedJSON when comparing test output to expected and post-delete states. Update all tests accordingly.