### PR TITLE
Add PIM logNeighborChanges field

### DIFF
--- a/api/core/v1alpha1/pim_types.go
+++ b/api/core/v1alpha1/pim_types.go
@@ -29,6 +29,10 @@ type PIMSpec struct {
 	// +kubebuilder:default=Up
 	AdminState AdminState `json:"adminState,omitempty"`
 
+	// LogNeighborChanges enables logging when a PIM neighbor is added or removed.
+	// +optional
+	LogNeighborChanges *bool `json:"logNeighborChanges,omitempty"`
+
 	// RendezvousPoints defines the list of rendezvous points for sparse mode multicast.
 	// +optional
 	// +listType=map

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -3535,6 +3535,11 @@ func (in *PIMSpec) DeepCopyInto(out *PIMSpec) {
 		*out = new(TypedLocalObjectReference)
 		**out = **in
 	}
+	if in.LogNeighborChanges != nil {
+		in, out := &in.LogNeighborChanges, &out.LogNeighborChanges
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RendezvousPoints != nil {
 		in, out := &in.RendezvousPoints, &out.RendezvousPoints
 		*out = make([]RendezvousPoint, len(*in))

--- a/charts/network-operator/templates/crd/pim.networking.metal.ironcore.dev.yaml
+++ b/charts/network-operator/templates/crd/pim.networking.metal.ironcore.dev.yaml
@@ -115,6 +115,10 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
+              logNeighborChanges:
+                description: LogNeighborChanges enables logging when a PIM neighbor
+                  is added or removed.
+                type: boolean
               providerConfigRef:
                 description: |-
                   ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.

--- a/config/crd/bases/networking.metal.ironcore.dev_pim.yaml
+++ b/config/crd/bases/networking.metal.ironcore.dev_pim.yaml
@@ -112,6 +112,10 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
+              logNeighborChanges:
+                description: LogNeighborChanges enables logging when a PIM neighbor
+                  is added or removed.
+                type: boolean
               providerConfigRef:
                 description: |-
                   ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -3268,6 +3268,7 @@ _Appears in:_
 | `deviceRef` _[LocalObjectReference](#localobjectreference)_ | DeviceName is the name of the Device this object belongs to. The Device object must exist in the same namespace.<br />Immutable. |  | Required: \{\} <br /> |
 | `providerConfigRef` _[TypedLocalObjectReference](#typedlocalobjectreference)_ | ProviderConfigRef is a reference to a resource holding the provider-specific configuration of this interface.<br />This reference is used to link the PIM to its provider-specific configuration. |  | Optional: \{\} <br /> |
 | `adminState` _[AdminState](#adminstate)_ | AdminState indicates whether the PIM instance is administratively up or down. | Up | Enum: [Up Down] <br />Optional: \{\} <br /> |
+| `logNeighborChanges` _boolean_ | LogNeighborChanges enables logging when a PIM neighbor is added or removed. |  | Optional: \{\} <br /> |
 | `rendezvousPoints` _[RendezvousPoint](#rendezvouspoint) array_ | RendezvousPoints defines the list of rendezvous points for sparse mode multicast. |  | MinItems: 1 <br />Optional: \{\} <br /> |
 | `interfaceRefs` _[PIMInterface](#piminterface) array_ | InterfaceRefs is a list of interfaces that are part of the PIM instance. |  | MinItems: 1 <br />Optional: \{\} <br /> |
 

--- a/internal/provider/cisco/nxos/pim.go
+++ b/internal/provider/cisco/nxos/pim.go
@@ -27,8 +27,9 @@ func (*PIM) XPath() string {
 }
 
 type PIMDom struct {
-	Name    string  `json:"name"`
-	AdminSt AdminSt `json:"adminSt"`
+	Name       string  `json:"name"`
+	AdminSt    AdminSt `json:"adminSt"`
+	LogNbhChng *bool   `json:"logNbhChng,omitempty"`
 }
 
 func (*PIMDom) IsListItem() {}

--- a/internal/provider/cisco/nxos/pim_test.go
+++ b/internal/provider/cisco/nxos/pim_test.go
@@ -15,4 +15,11 @@ func init() {
 	rp := &StaticRP{Addr: "10.0.0.100/32"}
 	rp.RpgrplistItems.RPGrpListList.Set(&StaticRPGrp{GrpListName: "224.0.0.0/4"})
 	Register("pim_rp", rp)
+
+	logEnabled := true
+	Register("pim_dom_log", &PIMDom{
+		Name:       "default",
+		AdminSt:    AdminStEnabled,
+		LogNbhChng: &logEnabled,
+	})
 }

--- a/internal/provider/cisco/nxos/provider.go
+++ b/internal/provider/cisco/nxos/provider.go
@@ -2389,6 +2389,7 @@ func (p *Provider) EnsurePIM(ctx context.Context, req *provider.EnsurePIMRequest
 	if req.PIM.Spec.AdminState == v1alpha1.AdminStateDown {
 		dom.AdminSt = AdminStDisabled
 	}
+	dom.LogNbhChng = req.PIM.Spec.LogNeighborChanges
 	sb.Patch(dom)
 
 	rpItems := new(StaticRPItems)

--- a/internal/provider/cisco/nxos/testdata/pim_dom_log.json
+++ b/internal/provider/cisco/nxos/testdata/pim_dom_log.json
@@ -1,0 +1,15 @@
+{
+  "pim-items": {
+    "inst-items": {
+      "dom-items": {
+        "Dom-list": [
+          {
+            "name": "default",
+            "adminSt": "enabled",
+            "logNbhChng": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/provider/cisco/nxos/testdata/pim_dom_log.json.txt
+++ b/internal/provider/cisco/nxos/testdata/pim_dom_log.json.txt
@@ -1,0 +1,1 @@
+ip pim log-neighbor-changes

--- a/test/gnmi/testdata/cisco-nxos-gnmi/pim.txtar
+++ b/test/gnmi/testdata/cisco-nxos-gnmi/pim.txtar
@@ -24,6 +24,7 @@ spec:
   deviceRef:
     name: device
   adminState: Up
+  logNeighborChanges: true
   interfaceRefs:
     - name: lo-pim
       mode: Sparse
@@ -119,6 +120,7 @@ spec:
             {
               "name": "default",
               "adminSt": "enabled",
+              "logNbhChng": true,
               "if-items": {
                 "If-list": [
                   {


### PR DESCRIPTION
# Add PIM log-neighbor-changes to CRD

## Description

Add PIM logNeighborChanges field

- Added `logNeighborChanges *bool` field to `PIMSpec` in `api/core/v1alpha1/pim_types.go`
- Added `LogNbhChng *bool` (`json:"logNbhChng,omitempty"`) to the NX-OS `PIMDom` struct in `internal/provider/cisco/nxos/pim.go` — field is omitted when nil (user did not configure it), avoiding spurious gNMI Sets
- Wired the field in `EnsurePIM` (`internal/provider/cisco/nxos/provider.go`): `dom.LogNbhChng = req.PIM.Spec.LogNeighborChanges`
- Added `pim_dom_log` test fixture + golden file in `internal/provider/cisco/nxos/pim_test.go` and `testdata/pim_dom_log.json`
- Updated `test/gnmi/testdata/cisco-nxos-gnmi/pim.txtar` with `logNeighborChanges: true` in spec and `"logNbhChng": true` in expected gNMI state

## Test results

### Phase 1 — local checks

| Check | Result |
|---|---|
| Lint | ✓ 0 issues |
| Unit tests | ✓ 21/21 packages passed |
| gNMI integration tests | ✓ 20/20 passed |

### Phase 2 — real device (Cisco NX-OS, `10.1.1.1:57403`)

Applied `PIM` CR with `logNeighborChanges: true` referencing loopback `lo99`.

**Operator reconcile log (first apply):**
```
Updating  path=System/pim-items/inst-items/dom-items/Dom-list[name=default]
          payload={"name":"default","adminSt":"enabled","logNbhChng":true}
```

**gnmic GET response** (`System/pim-items/inst-items/dom-items/Dom-list[name=default]`):
```json
[
  {
    "source": "10.1.1.1:57403",
    "timestamp": 1788878844530406667,
    "time": "2026-09-08T16:47:24.530406667+02:00",
    "updates": [
      {
        "Path": "System/pim-items/inst-items/dom-items/Dom-list[name=default]",
        "values": {
          "System/pim-items/inst-items/dom-items/Dom-list": [
            {
              "adminSt": "enabled",
              "if-items": {
                "If-list": [
                  {
                    "id": "lo99",
                    "ipAddr": "10.99.99.99/32",
                    "pimSparseMode": true
                  }
                ]
              },
              "jpDelay": 100,
              "logNbhChng": true,
              "mtu": 1500,
              "name": "default"
            }
          ]
        }
      }
    ]
  }
]
```

**Idempotency:** On subsequent reconciles (after `logNbhChng` was already set), the operator emitted:
```
Configuration is already up-to-date  path=System/pim-items/inst-items/dom-items/Dom-list[name=default]
```
No gNMI Set was issued — idempotency confirmed.

## Notes

The NX-OS YANG field name is `logNbhChng` (bool), not a string enum. The platform default is `false`.
Since the field is a pointer with `omitempty`, omitting `logNeighborChanges` from the CR spec sends no value to the device, leaving the platform default intact.
